### PR TITLE
DEV-3471 : truncated guid led to portfolio name collision

### DIFF
--- a/examples/use-cases/lusid_sample_data.py
+++ b/examples/use-cases/lusid_sample_data.py
@@ -106,7 +106,7 @@ def create_scope_ids(num_scopes):
     Output
     scopes: List of scope identifiers
     """ 
-    scopes = [str(uuid.uuid4())[:4] for i in range(num_scopes)]
+    scopes = [ str(uuid.uuid4()) for i in range(num_scopes)]
     
     return scopes
 


### PR DESCRIPTION
In internal tests where these are rerun, the truncation of the portfolio name generation (guid truncated to 4 characters) leads to periodic name collision that appears spurious. This should fix that bug. 