### PR TITLE
DEV-6466: Moved created to optional mapping from required

### DIFF
--- a/examples/use-cases/Load Transactions from an External System.ipynb
+++ b/examples/use-cases/Load Transactions from an External System.ipynb
@@ -548,11 +548,11 @@
     "portfolio_mapping_required = {\n",
     "  'code': 'FundCode',\n",
     "  'display_name': 'display_name',\n",
-    "  'created': 'created',\n",
     "  'base_currency': 'base_currency'\n",
     "}\n",
     "\n",
     "portfolio_mapping_optional = {\n",
+    "  'created': 'created',\n",
     "  'description': 'description',\n",
     "  'accounting_method': None\n",
     "}"

--- a/examples/use-cases/Metamorph.ipynb
+++ b/examples/use-cases/Metamorph.ipynb
@@ -373,13 +373,13 @@
     "portfolio_mapping_required = {\n",
     "  'code': 'FundCode',\n",
     "  'display_name': 'display_name',\n",
-    "  'created': 'created',\n",
     "  'base_currency': 'base_currency'\n",
     "}\n",
     "\n",
     "portfolio_mapping_optional = {\n",
     "  'description': 'description',\n",
-    "  'accounting_method': None\n",
+    "  'accounting_method': None,\n",
+    "  'created': 'created'\n",
     "}"
    ]
   },
@@ -2064,7 +2064,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.4"
   },
   "pycharm": {
    "stem_cell": {


### PR DESCRIPTION
Of the notebooks that use lusidtools the following notebooks contained mappings for Load_from_data_frame() and used optional and required mappings for creating portfolios

## Already correctly configured

Accounting demo :check_mark: 
Backtesting with Lusid derived portfolios :check_mark:

## moved created from required to optional

Load Transactions from an External System :check_mark:   
Metamorph :check_mark:    