### PR TITLE
SE-803: Changing get_aggregation to get_valuation in notebook

### DIFF
--- a/examples/use-cases/valuation/Bond Pricing And Accrued Interest Calculation.ipynb
+++ b/examples/use-cases/valuation/Bond Pricing And Accrued Interest Calculation.ipynb
@@ -95,7 +95,7 @@
      "output_type": "stream",
      "text": [
       "LUSID Environment Initialised\n",
-      "LUSID SDK Version:  0.6.6025.0\n"
+      "LUSID SDK Version:  0.6.6350.0\n"
      ]
     }
    ],
@@ -495,7 +495,11 @@
     "        pricing=pricing_context\n",
     "    )\n",
     "\n",
-    "discount_bond_pricing_config_recipe = create_discount_bond_pricing_recipe(scope, market_context, pricing_context)"
+    "discount_bond_pricing_config_recipe = create_discount_bond_pricing_recipe(scope, market_context, pricing_context)\n",
+    "\n",
+    "# Upsert recipe to LUSID\n",
+    "upsert_recipe_request = models.UpsertRecipeRequest(configuration_recipe=discount_bond_pricing_config_recipe)\n",
+    "response = api_factory.build(lusid.api.ConfigurationRecipeApi).upsert_configuration_recipe(upsert_recipe_request)\n"
    ]
   },
   {
@@ -1091,17 +1095,25 @@
    ],
    "source": [
     "def run_bond_pricing_aggregation_on_portfolio(scope, portfolio, recipe, effective_at):\n",
-    "    aggregation_request = models.AggregationRequest(\n",
-    "        effective_at=effective_at.isoformat(),\n",
-    "        inline_recipe=recipe,\n",
-    "        metrics=[\n",
+    "    valuation_request = models.ValuationRequest(\n",
+    "        recipe_id=models.ResourceId(\n",
+    "            scope=recipe.scope,\n",
+    "            code=recipe.code\n",
+    "        ),\n",
+    "          metrics=[\n",
     "            models.AggregateSpec(key='Holding/default/PV', op='Value'),\n",
     "            models.AggregateSpec(key='Holding/default/Accrual', op='Value')\n",
+    "        ],\n",
+    "        valuation_schedule=models.ValuationSchedule(effective_at=effective_at.isoformat()),\n",
+    "        portfolio_entity_ids=[\n",
+    "            models.PortfolioEntityId(\n",
+    "                scope=scope,\n",
+    "                code=portfolio\n",
+    "            )\n",
     "        ]\n",
     "    )\n",
     "\n",
-    "    return api_factory.build(lusid.api.AggregationApi).get_aggregation(scope=scope, code=portfolio,\n",
-    "                                                             aggregation_request=aggregation_request)\n",
+    "    return api_factory.build(lusid.api.AggregationApi).get_valuation(valuation_request=valuation_request)\n",
     "\n",
     "\n",
     "\n",
@@ -1433,7 +1445,11 @@
     "        pricing=pricing_context\n",
     "    )\n",
     "\n",
-    "accrual_override_config_recipe = create_bond_pricing_recipe_with_accrual_override(scope, market_context, accrual_override_pricing_context)"
+    "accrual_override_config_recipe = create_bond_pricing_recipe_with_accrual_override(scope, market_context, accrual_override_pricing_context)\n",
+    "\n",
+    "# Upsert recipe to LUSID\n",
+    "upsert_recipe_request = models.UpsertRecipeRequest(configuration_recipe=accrual_override_config_recipe)\n",
+    "response = api_factory.build(lusid.api.ConfigurationRecipeApi).upsert_configuration_recipe(upsert_recipe_request)"
    ]
   },
   {
@@ -1742,7 +1758,11 @@
     "        pricing=pricing_context\n",
     "    )\n",
     "\n",
-    "static_bond_price_config_recipe = create_static_bond_pricing_recipe(scope, static_bond_pricing_market_context, static_bond_pricing_context)"
+    "static_bond_price_config_recipe = create_static_bond_pricing_recipe(scope, static_bond_pricing_market_context, static_bond_pricing_context)\n",
+    "\n",
+    "# Upsert recipe to LUSID\n",
+    "upsert_recipe_request = models.UpsertRecipeRequest(configuration_recipe=static_bond_price_config_recipe)\n",
+    "response = api_factory.build(lusid.api.ConfigurationRecipeApi).upsert_configuration_recipe(upsert_recipe_request)"
    ]
   },
   {
@@ -2112,7 +2132,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Changing `get_aggregation` methods to `get_valuation`.

Had to upsert the recipes into lusid first with this new approach, as `get_valuation` fetches the recipe by scope and id from LUSID. 

