### PR TITLE
DEV-9679: Changed effetive_at variable to a string type

### DIFF
--- a/examples/use-cases/ibor/IBOR User Journey.ipynb
+++ b/examples/use-cases/ibor/IBOR User Journey.ipynb
@@ -4678,7 +4678,7 @@
     "result_id = StructuredResultDataId(\n",
     "    source = \"client-\" + scope + \"ABORNAV\" + \"-\" + scope,\n",
     "    code = \"default-\" + ibor_portfolio_code,\n",
-    "    effective_at = us_tz.localize(datetime(2020, 4, 29, 8)).astimezone(pytz.utc), \n",
+    "    effective_at = us_tz.localize(datetime(2020, 4, 29, 8)).astimezone(pytz.utc).isoformat(), \n",
     "    result_type = \"UnitResult/Analytic\"\n",
     ")\n",
     "\n",


### PR DESCRIPTION
This merge request transforms an effective_at variable from datetime type to string type so that it supports string-based restrictions such as maximum length and allowed pattern.