### PR TITLE
SE-862: Throw Error when no Access logs are returned

### DIFF
--- a/examples/use-cases/audit-trail/Identifying Downstream Consumers affected by Backdated Corrections on a Locked Reporting Window.ipynb
+++ b/examples/use-cases/audit-trail/Identifying Downstream Consumers affected by Backdated Corrections on a Locked Reporting Window.ipynb
@@ -866,6 +866,10 @@
     "    raise ValueError(f\"Status code is {access_logs.status_code} instead of 200 for request to {access_logs_url}\")\n",
     "\n",
     "access_logs_values = json.loads(access_logs.text)[\"values\"]\n",
+    "\n",
+    "if len(access_logs_values) == 0: \n",
+    "    raise ValueError(f\"No access logs were received from {access_logs_url}\")\n",
+    "    \n",
     "print (f\"Retreived {len(access_logs_values)} access logs\", \"\\n\")\n",
     "print (\"Here are some examples of the access logs\", \"\\n\")\n",
     "pd.DataFrame(access_logs_values).head()"


### PR DESCRIPTION
If the Access logs request does not return any values, throw a sensible error message