### PR TITLE
SE-1405: Entitlements using access metadata

### DIFF
--- a/examples/entitlements/Entitlements using access metadata.ipynb
+++ b/examples/entitlements/Entitlements using access metadata.ipynb
@@ -1,0 +1,784 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b47c2d2b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <form action=\"javascript:code_toggle()\"><input type=\"submit\" id=\"toggleButton\" value=\"Toggle Docstring\"></form>\n",
+       "    \n",
+       "         <script>\n",
+       "         function code_toggle() {\n",
+       "             if ($('div.cell.code_cell.rendered.selected div.input').css('display')!='none'){\n",
+       "                 $('div.cell.code_cell.rendered.selected div.input').hide();\n",
+       "             } else {\n",
+       "                 $('div.cell.code_cell.rendered.selected div.input').show();\n",
+       "             }\n",
+       "         }\n",
+       "         </script>\n",
+       "\n",
+       "     "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from lusidtools.jupyter_tools import toggle_code\n",
+    "\n",
+    "\"\"\"Entitlements based on access metadata\n",
+    "\n",
+    "Demonstrates the use of access metadata to grant access to portfolios in LUSID.\n",
+    "\n",
+    "Attributes\n",
+    "----------\n",
+    "entitlements\n",
+    "portfolios\n",
+    "access metadata\n",
+    "\"\"\"\n",
+    "\n",
+    "toggle_code(\"Toggle Docstring\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ec8e081",
+   "metadata": {},
+   "source": [
+    "# Entitlements using access metadata\n",
+    "\n",
+    "This notebook demonstrates the use of access metadata to grant access to portfolios in LUSID.\n",
+    "\n",
+    "Table of contents:\n",
+    "1. [Setup](#1.-Setup)\n",
+    "2. [Create custom data type](#2.-Create-custom-data-type)\n",
+    "3. [Create custom property definition](#3.-Create-custom-property-definition)\n",
+    "4. [Create portfolio with custom property](#4.-Create-portfolio-with-custom-property)\n",
+    "5. [Set up entitlements policy](#5.-Set-up-entitlements-policy) <br>\n",
+    "    5.1. [Create a policy for the PortfolioStatus property](#4.1.-Create-a-policy-for-the-PortfolioStatus-property) <br>\n",
+    "    5.2. [Create a policy for the PortfolioStatus metadata](#4.2.-Create-a-policy-for-the-PortfolioStatus-metadata) <br>\n",
+    "    5.3. [Add the policies to a role](#4.3.-Add-the-policies-to-a-role) <br>\n",
+    "    5.4. [Assign the role to a user](#5.4.-Assign-the-role-to-a-user)\n",
+    "6. [Try to access portfolio (fail)](#6.-Try-to-access-portfolio-(fail))\n",
+    "7. [Update PortfolioStatus property and metadata](#7.-Update-PortfolioStatus-property-and-metadata)\n",
+    "8. [Try to access portfolio (success)](#8.-Try-to-access-portfolio-(success))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03db55ac",
+   "metadata": {},
+   "source": [
+    "----\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f76f4bab",
+   "metadata": {},
+   "source": [
+    "## 1. Setup\n",
+    "\n",
+    "To start, let's import the libraries and initialise the APIs we'll use in the notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ffda1966",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>.container { width:90% !important; }</style>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>api_version</th>\n",
+       "      <th>build_version</th>\n",
+       "      <th>excel_version</th>\n",
+       "      <th>links</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>v0</td>\n",
+       "      <td>0.6.7270.0</td>\n",
+       "      <td>0.5.2218</td>\n",
+       "      <td>{'relation': 'RequestLogs', 'href': 'http://de...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  api_version build_version excel_version  \\\n",
+       "0          v0    0.6.7270.0      0.5.2218   \n",
+       "\n",
+       "                                               links  \n",
+       "0  {'relation': 'RequestLogs', 'href': 'http://de...  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Import Libraries\n",
+    "import os\n",
+    "import json\n",
+    "import pytz\n",
+    "import pandas as pd\n",
+    "from datetime import datetime, timedelta\n",
+    "from IPython.core.display import HTML\n",
+    "\n",
+    "import lusid\n",
+    "from lusid import models as models\n",
+    "import finbourne_access\n",
+    "from finbourne_access import models as access_models\n",
+    "import finbourne_identity\n",
+    "from finbourne_identity import models as identity_models\n",
+    "from lusidjam import RefreshingToken\n",
+    "\n",
+    "# Set DataFrame display formats\n",
+    "pd.set_option(\"display.max_columns\", None)\n",
+    "pd.set_option(\"display.max_rows\", None)\n",
+    "pd.options.display.float_format = \"{:,.2f}\".format\n",
+    "display(HTML(\"<style>.container { width:90% !important; }</style>\"))\n",
+    "\n",
+    "# Authenticate our user and create our API client\n",
+    "secrets_path = os.getenv(\"FBN_SECRETS_PATH\")\n",
+    "\n",
+    "lusid_api_factory = lusid.utilities.ApiClientFactory(\n",
+    "    token=RefreshingToken(),\n",
+    "    api_secrets_filename=secrets_path,\n",
+    "    app_name=\"LusidJupyterNotebook\",\n",
+    ")\n",
+    "\n",
+    "api_client = lusid_api_factory.api_client\n",
+    "\n",
+    "lusid_api_url = api_client.configuration.host\n",
+    "access_api_url = lusid_api_url[: lusid_api_url.rfind(\"/\") + 1] + \"access\"\n",
+    "identity_api_url = lusid_api_url[: lusid_api_url.rfind(\"/\") + 1] + \"identity\"\n",
+    "\n",
+    "access_api_factory = finbourne_access.utilities.ApiClientFactory(\n",
+    "    token=api_client.configuration.access_token,\n",
+    "    access_url=access_api_url,\n",
+    "    app_name=\"LusidJupyterNotebook\",\n",
+    ")\n",
+    "\n",
+    "identity_api_factory = finbourne_identity.utilities.ApiClientFactory(\n",
+    "    token=api_client.configuration.access_token,\n",
+    "    api_url=identity_api_url,\n",
+    "    app_name=\"LusidJupyterNotebook\",\n",
+    ")\n",
+    "\n",
+    "api_status = pd.DataFrame(\n",
+    "    lusid_api_factory.build(lusid.api.ApplicationMetadataApi)\n",
+    "    .get_lusid_versions()\n",
+    "    .to_dict()\n",
+    ")\n",
+    "\n",
+    "display(api_status)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8777ab7a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialise all APIs used in the notebook\n",
+    "data_types_api = lusid_api_factory.build(lusid.DataTypesApi)\n",
+    "properties_api = lusid_api_factory.build(lusid.PropertyDefinitionsApi)\n",
+    "transaction_portfolios_api = lusid_api_factory.build(lusid.TransactionPortfoliosApi)\n",
+    "portfolios_api = lusid_api_factory.build(lusid.PortfoliosApi)\n",
+    "policies_api = access_api_factory.build(finbourne_access.PoliciesApi)\n",
+    "access_roles_api = access_api_factory.build(finbourne_access.RolesApi)\n",
+    "identity_roles_api = identity_api_factory.build(finbourne_identity.RolesApi)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "d5506b57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set key variables for the notebook\n",
+    "scope = \"AccessMetadataEntitlements\"\n",
+    "portfolio_code = \"EntitledPortfolio\"\n",
+    "portfolio_name = \"Entitled Portfolio\"\n",
+    "portfolio_status_data_type_code = \"PortfolioStatusCodes\"\n",
+    "portfolio_status_data_type_values = [\n",
+    "    \"Approved\",\n",
+    "    \"Pending\"\n",
+    "]\n",
+    "portfolio_status_property_code = \"PortfolioStatus\"\n",
+    "effective_date = \"2021-01-01\"\n",
+    "approved_portfolio_policy_code = \"approved-portfolios-only\"\n",
+    "property_policy_code = \"allow-portfolio-status-property\"\n",
+    "standard_lusid_access_policy_code = \"allow-standard-lusid-features-access\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "368b29b9",
+   "metadata": {},
+   "source": [
+    "## 2. Create custom data type\n",
+    "We want to define a strict custom data type for use in this notebook, i.e. one that can only be `Approved` or `Pending`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cf49b66a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'List of allowable values for PortfolioStatusCodes'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['Pending', 'Approved']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    create_request = models.CreateDataTypeRequest(\n",
+    "        scope=scope,\n",
+    "        code=portfolio_status_data_type_code,\n",
+    "        type_value_range=\"Closed\",\n",
+    "        display_name=f\"Available {portfolio_status_data_type_code}\",\n",
+    "        description=f\"List of allowable values for {portfolio_status_data_type_code}\",\n",
+    "        value_type=\"String\",\n",
+    "        acceptable_values=portfolio_status_data_type_values\n",
+    "    )\n",
+    "\n",
+    "    response = data_types_api.create_data_type(\n",
+    "        create_data_type_request=create_request\n",
+    "    )\n",
+    "\n",
+    "    display(f\"Data Type of {portfolio_status_data_type_code} has been created.\")\n",
+    "    display(f\"The acceptable values for this data type are: {str(portfolio_status_data_type_values)}\")\n",
+    "\n",
+    "except:\n",
+    "    response = data_types_api.get_data_type(\n",
+    "        scope=scope,\n",
+    "        code=portfolio_status_data_type_code\n",
+    "    )\n",
+    "\n",
+    "    display(response.description)\n",
+    "    display(response.acceptable_values)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5cb52601",
+   "metadata": {},
+   "source": [
+    "## 3. Create custom property definition\n",
+    "We need to create a custom property which we will use to display the status of the portfolio. It will be defined using\n",
+    "the custom data type created in step #2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ae28e8b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    properties_api.create_property_definition(\n",
+    "        create_property_definition_request=models.CreatePropertyDefinitionRequest(\n",
+    "            domain=\"Portfolio\",\n",
+    "            scope=scope,\n",
+    "            code=portfolio_status_property_code,\n",
+    "            display_name=portfolio_status_property_code,\n",
+    "            data_type_id=models.ResourceId(\n",
+    "                code=portfolio_status_data_type_code,\n",
+    "                scope=scope\n",
+    "            )\n",
+    "        )\n",
+    "    )\n",
+    "\n",
+    "except lusid.ApiException as e:\n",
+    "    display(json.loads(e.body)[\"title\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82605919",
+   "metadata": {},
+   "source": [
+    "## 4. Create portfolio with custom property\n",
+    "\n",
+    "Create a new transaction portfolio with the property `PortfolioStatus` and value `Pending`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "dd7d4dd3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    request = transaction_portfolios_api.create_portfolio(\n",
+    "        scope=scope,\n",
+    "        create_transaction_portfolio_request=models.CreateTransactionPortfolioRequest(\n",
+    "            display_name=portfolio_name,\n",
+    "            code=portfolio_code,\n",
+    "            base_currency=\"GBP\",\n",
+    "            created=effective_date,\n",
+    "            sub_holding_keys=[],\n",
+    "            properties={\n",
+    "                f\"Portfolio/{scope}/{portfolio_status_property_code}\": models.ModelProperty(\n",
+    "                    key=f\"Portfolio/{scope}/{portfolio_status_property_code}\",\n",
+    "                    value=models.PropertyValue(\n",
+    "                        label_value=\"Pending\"\n",
+    "                    )\n",
+    "                )\n",
+    "            }\n",
+    "        )\n",
+    "    )\n",
+    "\n",
+    "except lusid.ApiException as e:\n",
+    "    display(json.loads(e.body)[\"title\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9659b32f",
+   "metadata": {},
+   "source": [
+    "## 5. Set up entitlements policies\n",
+    "\n",
+    "We want to create an entitlement policy that grants access to portfolios, only if they are marked with a metadata key\n",
+    "`PortfolioStatus` of `Approved`.\n",
+    "\n",
+    "We also want to create an entitlement policy that grants the user access to the portfolio property that manually\n",
+    "shadows the metadata key value of `Pending` or `Approved`.\n",
+    "\n",
+    "We will need to add these policies to a role that can be assigned to a user.\n",
+    "\n",
+    "To do this we will have to: <br>\n",
+    "5.1. [Create a policy for the PortfolioStatus property](#5.1.-Create-a-policy-for-the-PortfolioStatus-property)<br>\n",
+    "5.2. [Create a policy for the PortfolioStatus metadata](#5.2.-Create-a-policy-for-the-PortfolioStatus-metadata)<br>\n",
+    "5.3. [Add the policies to a role](#5.3.-Add-the-policies-to-a-role) <br>\n",
+    "5.4. [Assign the role to a user](#5.4.-Assign-the-role-to-a-user)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "86d05e6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# WhenSpec objects specify the \"lifetime\" of a modification:\n",
+    "# when it is activated and when it is deactivated.\n",
+    "when_spec = access_models.WhenSpec(\n",
+    "    activate=datetime.now(tz=pytz.utc) - timedelta(days=2),\n",
+    "    deactivate=datetime(9999, 12, 31, tzinfo=pytz.utc),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53b37f0c",
+   "metadata": {},
+   "source": [
+    "### 5.1 Create a policy for the PortfolioStatus property\n",
+    "\n",
+    "This policy should allow `Read` access to the `PropertyValue` and `PropertyDefinition` for property\n",
+    "`Portfolio/AccessMetadataEntitlements/PortfolioStatus`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c8b9c793",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create the property policy using the policies api\n",
+    "try:\n",
+    "    policies_api.create_policy(\n",
+    "        access_models.PolicyCreationRequest(\n",
+    "            code=property_policy_code,\n",
+    "            applications=[\"LUSID\"],\n",
+    "            grant=access_models.Grant.ALLOW,\n",
+    "            selectors=[access_models.SelectorDefinition(\n",
+    "                id_selector_definition=access_models.IdSelectorDefinition(\n",
+    "                    identifier={\n",
+    "                        \"scope\": scope,\n",
+    "                        \"code\": portfolio_status_property_code,\n",
+    "                        \"domain\": \"Portfolio\"\n",
+    "                    },\n",
+    "                    actions=[\n",
+    "                        access_models.ActionId(\n",
+    "                            scope=\"default\",\n",
+    "                            activity=\"Read\",\n",
+    "                            entity=\"PropertyValue\"\n",
+    "                        ),\n",
+    "                        access_models.ActionId(\n",
+    "                            scope=\"default\",\n",
+    "                            activity=\"Read\",\n",
+    "                            entity=\"PropertyDefinition\"\n",
+    "                        )\n",
+    "                    ]\n",
+    "                )\n",
+    "            )],\n",
+    "            when=when_spec\n",
+    "        )\n",
+    "    )\n",
+    "except finbourne_access.ApiException as e:\n",
+    "    detail = json.loads(e.body)\n",
+    "    if detail[\"code\"] != 613: # PolicyWithCodeAlreadyExists\n",
+    "        raise e"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "616c753f",
+   "metadata": {},
+   "source": [
+    "### 5.2 Create a policy for the PortfolioStatus metadata\n",
+    "\n",
+    "This policy should allow `Read` and `List` access to any portfolio where the metadata key `PortfolioStatus` == `Approved`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "58921786",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create the metadata policy using the policies api\n",
+    "try:\n",
+    "    policies_api.create_policy(\n",
+    "        access_models.PolicyCreationRequest(\n",
+    "            code=approved_portfolio_policy_code,\n",
+    "            applications=[\"LUSID\"],\n",
+    "            grant=access_models.Grant.ALLOW,\n",
+    "            selectors=[access_models.SelectorDefinition(\n",
+    "                metadata_selector_definition=access_models.MetadataSelectorDefinition(\n",
+    "                    expressions=[\n",
+    "                        access_models.MetadataExpression(\n",
+    "                            metadata_key=portfolio_status_property_code,\n",
+    "                            operator=access_models.Operator.EQUALS,\n",
+    "                            text_value=\"Approved\"\n",
+    "                        )\n",
+    "                    ],\n",
+    "                    actions=[\n",
+    "                        access_models.ActionId(\n",
+    "                            scope=\"default\",\n",
+    "                            activity=\"Read\",\n",
+    "                            entity=\"Portfolio\"\n",
+    "                        ),\n",
+    "                        access_models.ActionId(\n",
+    "                            scope=\"default\",\n",
+    "                            activity=\"List\",\n",
+    "                            entity=\"Portfolio\"\n",
+    "                        )\n",
+    "                    ]\n",
+    "                )\n",
+    "            )],\n",
+    "            when=when_spec\n",
+    "        )\n",
+    "    )\n",
+    "except finbourne_access.ApiException as e:\n",
+    "    detail = json.loads(e.body)\n",
+    "    if detail[\"code\"] != 613: # PolicyWithCodeAlreadyExists\n",
+    "        raise e"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67859f67",
+   "metadata": {},
+   "source": [
+    "### 5.3 Add the policies to a role\n",
+    "\n",
+    "One implementation detail for LUSID roles is that we'll have to create the same role twice: once using the identity API\n",
+    "and once using the access API. This is such that the access module, which handles applying policies to a role,\n",
+    "can communicate with the identity module, which handles applying roles to users."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "b460c300",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create the role using the access API\n",
+    "try:\n",
+    "    access_roles_api.create_role(\n",
+    "        role_creation_request=access_models.RoleCreationRequest(\n",
+    "            code=approved_portfolio_policy_code,\n",
+    "            description=approved_portfolio_policy_code,\n",
+    "            resource=access_models.RoleResourceRequest(\n",
+    "                policy_id_role_resource=access_models.PolicyIdRoleResource(\n",
+    "                    # Here we apply the policy we defined earlier as well as a default policy to provide basic access\n",
+    "                    policies=[\n",
+    "                        access_models.PolicyId(\n",
+    "                            scope=\"default\",\n",
+    "                            code=standard_lusid_access_policy_code\n",
+    "                        ),\n",
+    "                        access_models.PolicyId(\n",
+    "                            scope=\"default\",\n",
+    "                            code=approved_portfolio_policy_code\n",
+    "                        ),\n",
+    "                        access_models.PolicyId(\n",
+    "                            scope=\"default\",\n",
+    "                            code=property_policy_code\n",
+    "                        )\n",
+    "                    ]\n",
+    "                )\n",
+    "            ),\n",
+    "            when=when_spec\n",
+    "        )\n",
+    "    )\n",
+    "\n",
+    "except finbourne_access.ApiException as e:\n",
+    "    detail = json.loads(e.body)\n",
+    "    if detail[\"code\"] != 613: # Role with code already exists\n",
+    "        raise e\n",
+    "\n",
+    "\n",
+    "# Create the same role using the identity API\n",
+    "try:\n",
+    "    identity_roles_api.create_role(\n",
+    "        create_role_request=identity_models.CreateRoleRequest(\n",
+    "            name=approved_portfolio_policy_code\n",
+    "        )\n",
+    "    )\n",
+    "\n",
+    "except finbourne_identity.ApiException as e:\n",
+    "    detail = json.loads(e.body)\n",
+    "    if detail[\"code\"] != 157: # Role with code already exists\n",
+    "        raise e"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2429e6fb",
+   "metadata": {},
+   "source": [
+    "### 5.4. Assign the role to a user\n",
+    "\n",
+    "Whilst logged into the LUSID UI as a user with entitlements to assign roles to other users,\n",
+    "assign this role to a user with no other roles or policy entitlements."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "decfab1f",
+   "metadata": {},
+   "source": [
+    "----"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c86eefc",
+   "metadata": {},
+   "source": [
+    "## 6. Try to access portfolio (fail)\n",
+    "\n",
+    "In the LUSID UI whilst logged in as the new user, assigned only with the newly created role, try to load or view the\n",
+    "details for the portfolio created in this notebook.\n",
+    "\n",
+    "This should fail as the user should not have access to the portfolio due to there being no `PortfolioStatus` metadata\n",
+    "key with a value of `Approved`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "201802f3",
+   "metadata": {},
+   "source": [
+    "----"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64e1c56a",
+   "metadata": {},
+   "source": [
+    "## 7. Update PortfolioStatus property and metadata\n",
+    "\n",
+    "Now update the `PortfolioStatus` property and metadata to `Approved`, signifying that the administrator has approved\n",
+    "the portfolio for read access for users assigned to the new custom role.\n",
+    "\n",
+    "These two updates can be wrapped in one function so we can easily pass in `Approved` or `Pending` to switch between the two statuses."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "c46e2e3b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def update_portfolio_status(status):\n",
+    "    if status not in portfolio_status_data_type_values:\n",
+    "        return print(f\"'{status}' is not one of the approved values: {portfolio_status_data_type_values}\")\n",
+    "    \n",
+    "    # Update property\n",
+    "    portfolios_api.upsert_portfolio_properties(\n",
+    "        scope=scope,\n",
+    "        code=portfolio_code,\n",
+    "        request_body={\n",
+    "            f\"Portfolio/{scope}/{portfolio_status_property_code}\": models.ModelProperty(\n",
+    "                key=f\"Portfolio/{scope}/{portfolio_status_property_code}\",\n",
+    "                value=models.PropertyValue(\n",
+    "                    label_value=status\n",
+    "                )\n",
+    "            )\n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "    # Access metadata\n",
+    "    portfolios_api.upsert_portfolio_access_metadata(\n",
+    "        scope=scope,\n",
+    "        code=portfolio_code,\n",
+    "        metadata_key=portfolio_status_property_code,\n",
+    "        upsert_portfolio_access_metadata_request=models.UpsertPortfolioAccessMetadataRequest(\n",
+    "            metadata=[\n",
+    "                models.AccessMetadataValue(\n",
+    "                    value=status\n",
+    "                )\n",
+    "            ]\n",
+    "        )\n",
+    "    )\n",
+    "    \n",
+    "    print(f\"PortfolioStatus updated to '{status}'\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "fbfcb82c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PortfolioStatus updated to 'Approved'\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Update the status\n",
+    "update_portfolio_status(\"Approved\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "048773cb",
+   "metadata": {},
+   "source": [
+    "----"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c92051e5",
+   "metadata": {},
+   "source": [
+    "## 8. Try to access portfolio (success)\n",
+    "\n",
+    "In the LUSID UI whilst logged in as the new user, assigned only with the newly created role, try to load or view the\n",
+    "details for the portfolio created in this notebook.\n",
+    "\n",
+    "This should now pass as the user should have access to the portfolio due to the `PortfolioStatus` metadata\n",
+    "key now having a value of `Approved`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e3152bd",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ lusidtools
 lusid-jam
 docstring-parser
 chevron
+finbourne-access-sdk
+finbourne-identity-sdk


### PR DESCRIPTION
This notebook is based on the ticket [SE-1405](https://finbourne.atlassian.net/browse/SE-1405).

# Entitlements using access metadata
This notebook demonstrates the use of access metadata to grant access to portfolios in LUSID.

## Table of contents:

- Setup
- Create custom data type
- Create custom property definition
- Create portfolio with custom property
- Set up entitlements policy
  - Create a policy for the PortfolioStatus property
  - Create a policy for the PortfolioStatus metadata
  - Add the policies to a role
  - Assign the role to a user  **(TODO: Empty cell currently, guides user to UI)**
- Try to access portfolio (fail) **(TODO: Empty cell currently, guides user to UI)**
- Update PortfolioStatus property and metadata
- Try to access portfolio (success) **(TODO: Empty cell currently, guides user to UI)**

## To be discussed:
- [ ] How to handle the new user with restricted entitlements whilst the notebook has the user logged in (presumably) with higher level privileges