### PR TITLE
update build badge and add a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains Jupyter notebooks showcasing how to use the LUSID SDK. 
 | branch | status |
 | --- | --- |
 | `master`  | ![Daily build](https://github.com/finbourne/sample-notebooks/workflows/Daily%20build/badge.svg) ![Build and test](https://github.com/finbourne/sample-notebooks/workflows/Build%20and%20test/badge.svg) |
-| `develop` | ![run-sample-notebooks-tests](https://github.com/finbourne/sample-notebooks/workflows/run-sample-notebooks-tests/badge.svg?branch=develop) |
+| `develop` | ![Build and test](https://github.com/finbourne/sample-notebooks/workflows/Build%20and%20test/badge.svg?branch=develop) [view builds](https://github.com/finbourne/sample-notebooks/actions/workflows/main.yml?query=branch%3Adevelop) |
 
 
 


### PR DESCRIPTION
I noticed the build badge is incorrect for `build and test` on the develop branch. This fixes up the badge and adds a useful link to take you to the recent builds.