### PR TITLE
DEV-11902: Delete the creation of the relationship definition used in composited (this is now created as default)

### DIFF
--- a/examples/use-cases/risk-and-performance/Returns on composite portfolios.ipynb
+++ b/examples/use-cases/risk-and-performance/Returns on composite portfolios.ipynb
@@ -209,9 +209,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3.2 Create a relationship definition\n",
-    "\n",
-    "Create a relationship to represent the composite"
+    "## 3.2 Create relationship between composite and two investment portfolios effective from 31 Dec 2013"
    ]
   },
   {
@@ -220,40 +218,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Scope and Code for the Relationship used for Composite Returns\n",
     "relationship_scope = \"default\"\n",
     "relationship_code = \"CompositeMembership\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "try:\n",
-    "\n",
-    "    relationship_definition_api.create_relationship_definition(\n",
-    "        create_relationship_definition_request=models.CreateRelationshipDefinitionRequest(\n",
-    "            scope=relationship_scope,\n",
-    "            code=relationship_code,\n",
-    "            source_entity_type=\"Portfolio\",\n",
-    "            target_entity_type=\"Portfolio\",\n",
-    "            display_name=\"Relationship for Composite Returns\",\n",
-    "            outward_description=\"Relationship for Composite Returns\",\n",
-    "            inward_description=\"Relationship for Composite Returns\",\n",
-    "            life_time=\"TimeVariant\",\n",
-    "        )\n",
-    "    )\n",
-    "\n",
-    "except lusid.ApiException as e:\n",
-    "    print(json.loads(e.body)[\"title\"])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 3.3 Create relationship between composite and two investment portfolios effective from 31 Dec 2013"
    ]
   },
   {
@@ -280,7 +247,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3.4 Delete relationship between composite and FI portfolios effective from 1 Jan 2016"
+    "## 3.3 Delete relationship between composite and FI portfolios effective from 1 Jan 2016"
    ]
   },
   {
@@ -306,7 +273,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3.5 Add another child portfolio to composite effective from 1 Jan 2017"
+    "## 3.4 Add another child portfolio to composite effective from 1 Jan 2017"
    ]
   },
   {
@@ -332,7 +299,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3.6 Delete relationship between composite and MA portfolios effective from 29 Feb 2020"
+    "## 3.5 Delete relationship between composite and MA portfolios effective from 29 Feb 2020"
    ]
   },
   {


### PR DESCRIPTION
Delete the block of code which is creating the default relationship definition used for the composite portfolios in the return calculation. This definition is in default scope and is used only for the returns calculation purpose.
Reason why we are deleting this is because this relationship definition is now created in the bootstrapper (the env will come with this relationship definition as default same way how the default properties are working).

This should not affect the run of the notebook.