### PR TITLE
Feature/ANA259

### DIFF
--- a/examples/use-cases/valuation/Valuations with Inferred FX Rates.ipynb
+++ b/examples/use-cases/valuation/Valuations with Inferred FX Rates.ipynb
@@ -496,7 +496,7 @@
     "            models.AggregateSpec(\"Valuation/PvInPortfolioCcy/Ccy\", \"Value\"),\n",
     "            models.AggregateSpec(\"Holding/default/PV\", \"Proportion\"),\n",
     "            models.AggregateSpec(\"Holding/default/Units\", \"Sum\"),\n",
-    "            models.AggregateSpec(\"Holding/default/Error\", \"Value\"),\n",
+    "            models.AggregateSpec(\"Aggregation/Errors\", \"Value\"),\n",
     "        ],\n",
     "        group_by=[\"Instrument/default/Name\"],\n",
     "        report_currency = report_currency,\n",
@@ -826,7 +826,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -840,9 +840,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.8.11"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/use-cases/valuation/Valuations with recipes.ipynb
+++ b/examples/use-cases/valuation/Valuations with recipes.ipynb
@@ -1165,7 +1165,7 @@
     "            models.AggregateSpec(\"Holding/default/PV\", \"Proportion\"),\n",
     "            models.AggregateSpec(\"Holding/default/PV\", \"Sum\"),\n",
     "            models.AggregateSpec(\"Holding/default/Units\", \"Sum\"),\n",
-    "            models.AggregateSpec(\"Holding/default/Error\", \"Value\"),\n",
+    "            models.AggregateSpec(\"Aggregation/Errors\", \"Value\"),\n",
     "        ],\n",
     "        group_by=[\"Instrument/default/Name\"],\n",
     "        # choose the valuation time for the request\n",
@@ -1596,9 +1596,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.8.11"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Have removed data error legacy keys from lusid, these were being called in two notebook tests. The new key to use is 'Aggregation/Errors' which returns a list of all the errors. 