### PR TITLE
PLAT-51: Get commands before deletion as at time

### DIFF
--- a/examples/use-cases/ibor/Portfolio types and portfolio groups in LUSID.ipynb
+++ b/examples/use-cases/ibor/Portfolio types and portfolio groups in LUSID.ipynb
@@ -1266,7 +1266,7 @@
    "outputs": [],
    "source": [
     "# 3. Delete group\n",
-    "group_deletion = api_factory.build(lusid.api.PortfolioGroupsApi).delete_portfolio_group(\n",
+    "group_deletion = api_factory.build(lusid.api.PortfolioGroupsApi).delete_portfolio_group_with_http_info(\n",
     "    scope=portfolio_group2.id.scope,\n",
     "    code=portfolio_group2.id.code)"
    ]
@@ -1276,7 +1276,7 @@
    "metadata": {},
    "source": [
     "## 12. Get Group Commands\n",
-    "We can now check what operations have been applied to each of our groups, including an already deleted group, by using the `get portfolio group commands` method, as below.\n",
+    "We can now check what operations have been applied to each of our groups, by using the `get portfolio group commands` method, as below.\n",
     "\n",
     "*Run the cell below to get all commands from groups 1 and 2*"
    ]
@@ -1347,9 +1347,11 @@
     "    scope=portfolio_group1.id.scope,\n",
     "    code=portfolio_group1.id.code)\n",
     "\n",
+    "# Get commands for portfolio group 2 before the group's deletion as at\n",
     "group2_commands = api_factory.build(lusid.api.PortfolioGroupsApi).get_portfolio_group_commands(\n",
     "    scope=portfolio_group2.id.scope,\n",
-    "    code=portfolio_group2.id.code)\n",
+    "    code=portfolio_group2.id.code,\n",
+    "    to_as_at=group_deletion[0].as_at - timedelta(microseconds=1))\n",
     "\n",
     "prettyprint.group_commands(group1_commands, portfolio_group1.display_name)\n",
     "\n",


### PR DESCRIPTION
# Pull Request Checklist

- [x] Changes follow the [style guide](https://github.com/finbourne/sample-notebooks/blob/master/docs/FINBOURNE%20notebook%20style%20guide.ipynb)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Get commands before the group deletion asAt to deal with an api breaking change.
Note to reviewer: I have not run the cells locally to generate new outputs but have tested them through the online jupyter runner in CI

Describe the code changes for the reviewers, explain the solution you have provided and how it fixes the issue
