### PR TITLE
ANA-1550 : correct bond and fx-forward for addition of instrument ide…

### DIFF
--- a/examples/use-cases/instruments/Bond.ipynb
+++ b/examples/use-cases/instruments/Bond.ipynb
@@ -1685,7 +1685,7 @@
     "cash_flow_table = lusid_response_to_data_frame(upsertable_cash_flows)\n",
     "cash_flow_table.drop(\n",
     "    [\n",
-    "        \"instrument_identifiers\",\n",
+    "        \"instrument_identifiers.Instrument/default/LusidInstrumentId\",\n",
     "        \"instrument_uid\",\n",
     "        \"properties\",\n",
     "        \"source\",\n",

--- a/examples/use-cases/instruments/FX Forward.ipynb
+++ b/examples/use-cases/instruments/FX Forward.ipynb
@@ -1937,7 +1937,7 @@
     "\n",
     "# we create a dataframe out of the cash flows table and drop some columns to improve readability\n",
     "cash_flow_table = lusid_response_to_data_frame(upsertable_cash_flows)\n",
-    "cash_flow_table.drop(['instrument_identifiers', 'instrument_uid', 'properties', 'source', 'entry_date_time', 'transaction_currency', 'units', 'transaction_price.price', 'transaction_price.type', 'exchange_rate'], axis=1)\n",
+    "cash_flow_table.drop(['instrument_identifiers.Instrument/default/LusidInstrumentId', 'instrument_uid', 'properties', 'source', 'entry_date_time', 'transaction_currency', 'units', 'transaction_price.price', 'transaction_price.type', 'exchange_rate'], axis=1)\n",
     "cash_flow_table"
    ]
   },

--- a/examples/use-cases/instruments/FX Forward.ipynb
+++ b/examples/use-cases/instruments/FX Forward.ipynb
@@ -2139,7 +2139,7 @@
     "\n",
     "# we create a dataframe out of the cash flows table and drop some columns to improve readability\n",
     "cash_flow_table = lusid_response_to_data_frame(upsertable_cash_flows)\n",
-    "cash_flow_table.drop(['instrument_identifiers', 'instrument_uid', 'properties', 'source', 'entry_date_time', 'transaction_currency', 'units', 'transaction_price.price', 'transaction_price.type', 'exchange_rate'], axis=1)\n",
+    "cash_flow_table.drop(['instrument_identifiers.Instrument/default/LusidInstrumentId', 'instrument_uid', 'properties', 'source', 'entry_date_time', 'transaction_currency', 'units', 'transaction_price.price', 'transaction_price.type', 'exchange_rate'], axis=1)\n",
     "cash_flow_table"
    ]
   },


### PR DESCRIPTION
ANA-1550 : addition of instrument identifiers to the returned transactions means the flatten code no longer returns the same response and so the drop call needs a different filter. 

# Pull Request Checklist

- [ ] Changes follow the [style guide](https://github.com/finbourne/sample-notebooks/blob/master/docs/FINBOURNE%20notebook%20style%20guide.ipynb)
- [ ] Tests pass
- [ ] Raised the PR against the `develop` branch

# Description of the PR

Describe the code changes for the reviewers, explain the solution you have provided and how it fixes the issue
