### PR TITLE
CTECH-1344: Fixes version of Luminesce SDK.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ docstring-parser
 chevron
 finbourne-access-sdk
 finbourne-identity-sdk
-dve-lumipy-preview
+luminesce-sdk-preview
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] Changes follow the [style guide](https://github.com/finbourne/sample-notebooks/blob/master/docs/FINBOURNE%20notebook%20style%20guide.ipynb)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Fixes version of Luminesce SDK.
Lumipy isn't actually used, but the SDK is.  This removes lumipy from the requirements.txt and adds the luminesce-sdk in it's place.