### PR TITLE
CTECH-1903: Pins version of sdks < 2.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,9 @@ pandas
 pytz
 requests
 
-finbourne-access-sdk >= 0.0.2272, <= 1.0
-finbourne-identity-sdk >= 0.0.1845, <= 1.0
-luminesce-sdk-preview >= 1.11.140, <= 2.0
+finbourne-access-sdk >= 0.0.2272, < 2
+finbourne-identity-sdk >= 0.0.1845, < 2
+luminesce-sdk-preview >= 1.11.140, < 3
 lusid-jam
-lusid-sdk-preview >= 0.11.4713, <= 1.0
+lusid-sdk-preview >= 0.11.4713, < 2
 lusidtools >= 1.0.0


### PR DESCRIPTION
Signed-off-by: Paul Saunders <paul.saunders@finbourne.com>

# Pull Request Checklist

- [x] Changes follow the [style guide](https://github.com/finbourne/sample-notebooks/blob/master/docs/FINBOURNE%20notebook%20style%20guide.ipynb)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Upcoming changes to the the generator for the sdk's might break compatibility. This pins the version of the finbourne sdks so that this package will not break in such an event.

The premise previously had been that pinning to <= 1.0 would still allow us to update patch versions 1.0.x however that is not true, so now pinning < 2