### PR TITLE
Adding retry logic to the request-response body request for Insights log details notebook

### DIFF
--- a/examples/use-cases/audit-trail/Requesting log details using the Insights API.ipynb
+++ b/examples/use-cases/audit-trail/Requesting log details using the Insights API.ipynb
@@ -2,10 +2,36 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "f991e27e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <form action=\"javascript:code_toggle()\"><input type=\"submit\" id=\"toggleButton\" value=\"Toggle Docstring\"></form>\n",
+       "    \n",
+       "         <script>\n",
+       "         function code_toggle() {\n",
+       "             if ($('div.cell.code_cell.rendered.selected div.input').css('display')!='none'){\n",
+       "                 $('div.cell.code_cell.rendered.selected div.input').hide();\n",
+       "             } else {\n",
+       "                 $('div.cell.code_cell.rendered.selected div.input').show();\n",
+       "             }\n",
+       "         }\n",
+       "         </script>\n",
+       "\n",
+       "     "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "from lusidtools.jupyter_tools import toggle_code\n",
     "\n",
@@ -50,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "610ed425",
    "metadata": {
     "code_folding": []
@@ -129,17 +155,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d0283da6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "lusid_api_url = l_api_factory.api_client.configuration.host\n",
-    "insights_api_url = lusid_api_url[: lusid_api_url.rfind(\"/\") + 1] + \"insights\""
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "aade11d4",
    "metadata": {},
@@ -165,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "4599a7ac",
    "metadata": {},
    "outputs": [],
@@ -212,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "0e48fe19",
    "metadata": {},
    "outputs": [],
@@ -262,7 +277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "d2ee4951",
    "metadata": {},
    "outputs": [],
@@ -303,7 +318,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "095a9e4e",
    "metadata": {},
    "outputs": [],
@@ -380,7 +395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "05d76256",
    "metadata": {},
    "outputs": [],
@@ -428,10 +443,117 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "7a370790",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Valuation/PvInReportCcy/Ccy</th>\n",
+       "      <th>Valuation/PvInReportCcy</th>\n",
+       "      <th>Analytic/default/InstrumentTag</th>\n",
+       "      <th>Quotes/FxRate/DomReport</th>\n",
+       "      <th>Quotes/Price</th>\n",
+       "      <th>Quotes/Price/Ccy</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>JPY</td>\n",
+       "      <td>3,022.06</td>\n",
+       "      <td>client_internal_1</td>\n",
+       "      <td>151.10</td>\n",
+       "      <td>20.00</td>\n",
+       "      <td>GBP</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>JPY</td>\n",
+       "      <td>7,555.15</td>\n",
+       "      <td>client_internal_2</td>\n",
+       "      <td>151.10</td>\n",
+       "      <td>50.00</td>\n",
+       "      <td>GBP</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>JPY</td>\n",
+       "      <td>15,110.31</td>\n",
+       "      <td>client_internal_3</td>\n",
+       "      <td>151.10</td>\n",
+       "      <td>100.00</td>\n",
+       "      <td>GBP</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>JPY</td>\n",
+       "      <td>11,332.73</td>\n",
+       "      <td>client_internal_4</td>\n",
+       "      <td>151.10</td>\n",
+       "      <td>75.00</td>\n",
+       "      <td>GBP</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>JPY</td>\n",
+       "      <td>9,066.18</td>\n",
+       "      <td>client_internal_5</td>\n",
+       "      <td>151.10</td>\n",
+       "      <td>60.00</td>\n",
+       "      <td>GBP</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  Valuation/PvInReportCcy/Ccy  Valuation/PvInReportCcy  \\\n",
+       "0                         JPY                 3,022.06   \n",
+       "1                         JPY                 7,555.15   \n",
+       "2                         JPY                15,110.31   \n",
+       "3                         JPY                11,332.73   \n",
+       "4                         JPY                 9,066.18   \n",
+       "\n",
+       "  Analytic/default/InstrumentTag  Quotes/FxRate/DomReport  Quotes/Price  \\\n",
+       "0              client_internal_1                   151.10         20.00   \n",
+       "1              client_internal_2                   151.10         50.00   \n",
+       "2              client_internal_3                   151.10        100.00   \n",
+       "3              client_internal_4                   151.10         75.00   \n",
+       "4              client_internal_5                   151.10         60.00   \n",
+       "\n",
+       "  Quotes/Price/Ccy  \n",
+       "0              GBP  \n",
+       "1              GBP  \n",
+       "2              GBP  \n",
+       "3              GBP  \n",
+       "4              GBP  "
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Run inline valuation in JPY\n",
     "aggregation = aggregation_api.get_valuation_of_weighted_instruments(\n",
@@ -462,10 +584,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "a5ac921b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ERROR : One or more of the bits of input data provided were not valid\n"
+     ]
+    }
+   ],
    "source": [
     "# Run inline Valuation for AUD with an empty list of instruments\n",
     "try :\n",
@@ -504,7 +634,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "a3268f11",
    "metadata": {
     "scrolled": true
@@ -512,7 +642,7 @@
    "outputs": [],
    "source": [
     "# Logs are written asynchronously and there may be a lag for them to be queryable after writing. \n",
-    "# This function will keep polling until it finds both logs for the 2 valuations from the previous steps\n",
+    "# This function will keep polling until it finds both logs for the 2 valuations from the previous steps.\n",
     "\n",
     "@backoff.on_predicate(backoff.expo, lambda x: len(x.values) < 2, max_tries=5)\n",
     "def insights_log_requests(operation, timestamp_diff_lower, timestamp_diff_upper):\n",
@@ -546,23 +676,112 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "25145612",
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>timestamp</th>\n",
+       "      <th>outcome</th>\n",
+       "      <th>error</th>\n",
+       "      <th>error_details</th>\n",
+       "      <th>request_body</th>\n",
+       "      <th>response_body</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0HMOJ4B155QAP:00000005</td>\n",
+       "      <td>2023-02-20 11:48:59.961000+00:00</td>\n",
+       "      <td>Failed</td>\n",
+       "      <td>InvalidParameterValue</td>\n",
+       "      <td>[{'id': 'Instruments', 'detail': 'The specific...</td>\n",
+       "      <td>{'recipeId': {'scope': 'Insights_Inline_valuat...</td>\n",
+       "      <td>{'name': 'InvalidParameterValue', 'errorDetail...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0HMOJ4B2EEKBB:00000007</td>\n",
+       "      <td>2023-02-20 11:48:59.895000+00:00</td>\n",
+       "      <td>Completed</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>{'recipeId': {'scope': 'Insights_Inline_valuat...</td>\n",
+       "      <td>{'aggregationEffectiveAt': '2023-01-26T00:00:0...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                       id                        timestamp    outcome  \\\n",
+       "0  0HMOJ4B155QAP:00000005 2023-02-20 11:48:59.961000+00:00     Failed   \n",
+       "1  0HMOJ4B2EEKBB:00000007 2023-02-20 11:48:59.895000+00:00  Completed   \n",
+       "\n",
+       "                   error                                      error_details  \\\n",
+       "0  InvalidParameterValue  [{'id': 'Instruments', 'detail': 'The specific...   \n",
+       "1                   None                                               None   \n",
+       "\n",
+       "                                        request_body  \\\n",
+       "0  {'recipeId': {'scope': 'Insights_Inline_valuat...   \n",
+       "1  {'recipeId': {'scope': 'Insights_Inline_valuat...   \n",
+       "\n",
+       "                                       response_body  \n",
+       "0  {'name': 'InvalidParameterValue', 'errorDetail...  \n",
+       "1  {'aggregationEffectiveAt': '2023-01-26T00:00:0...  "
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "# Function to retreive request and response bodies given a set of request logs\n",
+    "# The request and response bodies are written asynchronously and seperate to the request logs, so they may be a further\n",
+    "# delay after the initial logs are retrieved.\n",
+    "# This function will keep trying to request the request and response bodies until neither request returns an exception.\n",
+    "@backoff.on_exception(backoff.expo, finbourne_insights.ApiException, max_tries=5 )\n",
+    "def request_response_reqs(id):\n",
+    "    request = i_requests_api.get_request(id)\n",
+    "    response = i_requests_api.get_response(id)\n",
+    "\n",
+    "    \n",
+    "    return (request,response)\n",
+    "\n",
+    "\n",
+    "# Function to construct a data frame out of the request and response bodies.\n",
     "def request_response_bodies(req_logs):\n",
     "\n",
     "    rr_bodies = []\n",
     "\n",
     "    for row in req_logs.values:\n",
-    "        request = i_requests_api.get_request(row.id)\n",
-    "        response = i_requests_api.get_response(row.id)\n",
-    "        request_body = json.loads(request.body)\n",
-    "        response_body = json.loads(response.body)\n",
+    "        req_resp = request_response_reqs(row.id)\n",
+    "        request_body = json.loads(req_resp[0].body)\n",
+    "        response_body = json.loads(req_resp[1].body)\n",
     "        error = None\n",
     "        error_details = None\n",
     "        if row.http_status_code == 400 : \n",
@@ -591,12 +810,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "1f493f3d",
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "For message ID 0HMOJ4B155QAP:00000005, error type InvalidParameterValue was returned for the Instruments parameter. The error message was 'The specification of at least one item is required'\n"
+     ]
+    }
+   ],
    "source": [
     "for index, row in request_bodies_df.iterrows() :\n",
     "    if row['error'] : \n",


### PR DESCRIPTION
# Pull Request Checklist

- [x] Changes follow the [style guide](https://github.com/finbourne/sample-notebooks/blob/master/docs/FINBOURNE%20notebook%20style%20guide.ipynb)
- [ ] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

The "Requesting log details using the Insights API" example notebook has been failing intermittently in prod. The IAM team have suggested it could be because the notebook is requesting the request bodies before they are available. This change will add retry logic to the request/response body requests, similar to how the prior insights log request is being retried.
