### PR TITLE
Adding retry logic to the request-response body request for Insights API notebook

### DIFF
--- a/examples/use-cases/audit-trail/Requesting log details using the Insights API.ipynb
+++ b/examples/use-cases/audit-trail/Requesting log details using the Insights API.ipynb
@@ -129,17 +129,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d0283da6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "lusid_api_url = l_api_factory.api_client.configuration.host\n",
-    "insights_api_url = lusid_api_url[: lusid_api_url.rfind(\"/\") + 1] + \"insights\""
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "aade11d4",
    "metadata": {},
@@ -512,7 +501,7 @@
    "outputs": [],
    "source": [
     "# Logs are written asynchronously and there may be a lag for them to be queryable after writing. \n",
-    "# This function will keep polling until it finds both logs for the 2 valuations from the previous steps\n",
+    "# This function will keep polling until it finds both logs for the 2 valuations from the previous steps.\n",
     "\n",
     "@backoff.on_predicate(backoff.expo, lambda x: len(x.values) < 2, max_tries=5)\n",
     "def insights_log_requests(operation, timestamp_diff_lower, timestamp_diff_upper):\n",
@@ -553,16 +542,25 @@
    },
    "outputs": [],
    "source": [
-    "# Function to retreive request and response bodies given a set of request logs\n",
+    "# The request and response bodies are written asynchronously and seperate to the request logs, so they may be a further\n",
+    "# delay after the initial logs are retrieved.\n",
+    "# This function will keep trying to request the request and response bodies until neither request returns an exception.\n",
+    "@backoff.on_exception(backoff.expo, finbourne_insights.ApiException, max_tries=5 )\n",
+    "def request_response_reqs(id):\n",
+    "    request = i_requests_api.get_request(id)\n",
+    "    response = i_requests_api.get_response(id)\n",
+    "    \n",
+    "    return (request,response)\n",
+    "\n",
+    "# Function to construct a data frame out of the request and response bodies.\n",
     "def request_response_bodies(req_logs):\n",
     "\n",
     "    rr_bodies = []\n",
     "\n",
     "    for row in req_logs.values:\n",
-    "        request = i_requests_api.get_request(row.id)\n",
-    "        response = i_requests_api.get_response(row.id)\n",
-    "        request_body = json.loads(request.body)\n",
-    "        response_body = json.loads(response.body)\n",
+    "        req_resp = request_response_reqs(row.id)\n",
+    "        request_body = json.loads(req_resp[0].body)\n",
+    "        response_body = json.loads(req_resp[1].body)\n",
     "        error = None\n",
     "        error_details = None\n",
     "        if row.http_status_code == 400 : \n",


### PR DESCRIPTION
# Pull Request Checklist

- [x] Changes follow the [style guide](https://github.com/finbourne/sample-notebooks/blob/master/docs/FINBOURNE%20notebook%20style%20guide.ipynb)
- [ ] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

The "Requesting log details using the Insights API" example notebook has been failing intermittently in prod. The IAM team have suggested it could be because the notebook is requesting the request bodies before they are available. This change will add retry logic to the request/response body requests, similar to how the prior insights log request is being retried.
