### PR TITLE
Changing request bodies backoff loop to last 30 seconds instead of 5 tries

### DIFF
--- a/examples/use-cases/audit-trail/Requesting log details using the Insights API.ipynb
+++ b/examples/use-cases/audit-trail/Requesting log details using the Insights API.ipynb
@@ -545,7 +545,7 @@
     "# The request and response bodies are written asynchronously and seperate to the request logs, so they may be a further\n",
     "# delay after the initial logs are retrieved.\n",
     "# This function will keep trying to request the request and response bodies until neither request returns an exception.\n",
-    "@backoff.on_exception(backoff.expo, finbourne_insights.ApiException, max_tries=5 )\n",
+    "@backoff.on_exception(backoff.expo, finbourne_insights.ApiException, max_time=30 )\n",
     "def request_response_reqs(id):\n",
     "    request = i_requests_api.get_request(id)\n",
     "    response = i_requests_api.get_response(id)\n",


### PR DESCRIPTION
# Pull Request Checklist

- [x] Changes follow the [style guide](https://github.com/finbourne/sample-notebooks/blob/master/docs/FINBOURNE%20notebook%20style%20guide.ipynb)
- [ ] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Previous change to add a backoff loop to the request bodies function was still causing notebook failures on concourse as the request would still fail after 5 tries. Changing the max retry argument to a max time of 30 seconds.
