### PR TITLE
Feature/CTECH-2183-add-retry-flag-for-notebook-runner

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -31,7 +31,7 @@ jobs:
           FBN_INSIGHTS_API_URL: ${{ secrets.MASTER_FBN_INSIGHTS_API_URL }}
           FBN_CONFIGURATION_API_URL: ${{ secrets.MASTER_FBN_CONFIGURATION_API_URL }}
         with:
-          args: -n ./examples -c
+          args: -n ./examples -c -r 2
 
       - name: Slack notification
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
           FBN_CONFIGURATION_API_URL: ${{ secrets.DEVELOP_FBN_CONFIGURATION_API_URL }}
 
         with:
-          args: -n ./examples -v latest -u ${{ secrets.DEVELOP_NEXUS_USERNAME }} -p ${{ secrets.DEVELOP_NEXUS_PASSWORD }} -c
+          args: -n ./examples -v latest -u ${{ secrets.DEVELOP_NEXUS_USERNAME }} -p ${{ secrets.DEVELOP_NEXUS_PASSWORD }} -c -r 2
 
       - name: Run tests on MASTER branch
         uses: docker://finbourne/notebook-runner2:latest
@@ -64,7 +64,7 @@ jobs:
           FBN_CONFIGURATION_API_URL: ${{ secrets.MASTER_FBN_CONFIGURATION_API_URL }}
 
         with:
-          args: -n ./examples -v latest -u ${{ secrets.MASTER_NEXUS_USERNAME }} -p ${{ secrets.MASTER_NEXUS_PASSWORD }} -c
+          args: -n ./examples -v latest -u ${{ secrets.MASTER_NEXUS_USERNAME }} -p ${{ secrets.MASTER_NEXUS_PASSWORD }} -c -r 2
 
       - name: Slack notification
         uses: 8398a7/action-slack@v3


### PR DESCRIPTION
# Pull Request Checklist

- [x] Changes follow the [style guide](https://github.com/finbourne/sample-notebooks/blob/master/docs/FINBOURNE%20notebook%20style%20guide.ipynb)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Add retry flag so builds of master and develop branch retry notebooks twice on failure.
