### PR TITLE
ANA-2812: Use InArrears reset convention

### DIFF
--- a/examples/use-cases/valuation/FundingLeg Valuation with compounding interests.ipynb
+++ b/examples/use-cases/valuation/FundingLeg Valuation with compounding interests.ipynb
@@ -259,6 +259,7 @@
     "    notional_exchange_type = \"None\",\n",
     "    pay_receive = \"Pay\",\n",
     "    rate_or_spread = spread,\n",
+    "    reset_convention = \"InArrears\",\n",
     "    stub_type = \"Back\",\n",
     "    compounding = compounding_1d\n",
     ")\n",


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Changes follow the [style guide](https://github.com/finbourne/sample-notebooks/blob/master/docs/FINBOURNE%20notebook%20style%20guide.ipynb)
- [ ] Tests pass
- [ ] Raised the PR against the `develop` branch
- [ ] Notebook outputs do not contain any priviledged data

# Description of the PR

Changes the reset convention for the daily compounding leg to `InArrears`, which will revert to using the resets the notebook expects to be used.
