### PR TITLE
ANA-3427: Added notebook showing how Recipe Composer can be used, allowing user to use configuration recipe more extensively.

### DIFF
--- a/examples/use-cases/valuation/Configuration Recipe Composability Using Recipe Composer.ipynb
+++ b/examples/use-cases/valuation/Configuration Recipe Composability Using Recipe Composer.ipynb
@@ -1,0 +1,1242 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "<IPython.core.display.HTML object>",
+      "text/html": "\n    <form action=\"javascript:code_toggle()\"><input type=\"submit\" id=\"toggleButton\" value=\"Toggle Docstring\"></form>\n    \n         <script>\n         function code_toggle() {\n             if ($('div.cell.code_cell.rendered.selected div.input').css('display')!='none'){\n                 $('div.cell.code_cell.rendered.selected div.input').hide();\n             } else {\n                 $('div.cell.code_cell.rendered.selected div.input').show();\n             }\n         }\n         </script>\n\n     "
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from lusidtools.jupyter_tools import toggle_code\n",
+    "\n",
+    "\"\"\"Recipe Composer Workflow\n",
+    "\n",
+    "Attributes\n",
+    "----------\n",
+    "recipe composers\n",
+    "recipes\n",
+    "valuations\n",
+    "\"\"\"\n",
+    "\n",
+    "toggle_code(\"Toggle Docstring\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-06T13:58:08.243650Z",
+     "start_time": "2024-03-06T13:58:08.194030Z"
+    }
+   },
+   "id": "f56cb38dd65d6388"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Composing Configuration Recipes\n",
+    "Configuration Recipes are used for valuation, look-through and more. Its purpose is to allow user to be able to specify what market data to use, how to do lookthrough, what model to select and so on. Due to how much it is covering it can get quiet big and bespoke and is reasonable for a team or an individual to have their own. Problem arises when a user wants a recipe that is just like an already upserted recipe except with some small changes. Perhaps a user wants to combine market data rules from two recipes, prioritising ones over the other. In addition, the user will likely want their recipe to change should the recipe they depend on change also.\n",
+    "\n",
+    "This is where Recipe Composer comes in. It is made of scope-code (identification) and a list of operations. Operations are allowing you the user to state how you want the Configuration Recipe to be composed. You could say \"I want to start of with recipe A\", that is one operation, then perhaps \"I want to add market rules from recipe B\", that is another operation and so on. Recipe Composer supports CRUD operations just like Configuration Recipes, moreover you can use Recipe Composers wherever Configuration Recipe is used and it will create the desired recipe and use that without you having to do anything differently.\n",
+    "\n",
+    "In this notebook, we first present some Recipe Composers, showing some examples, we then demonstrate how a user can get a Configuration Recipe out of a Recipe Composer that is either upserted or inline. Following that we show how one can use a Recipe Composer in Valuation."
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "125a05df192a58c1"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 82,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LUSID Environment Initialised\n",
+      "LUSID SDK Version:  0.6.12698.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Import LUSID libraries\n",
+    "import lusid as lu\n",
+    "import lusid.models as lm\n",
+    "from lusidjam.refreshing_token import RefreshingToken\n",
+    "from datetime import datetime, timedelta\n",
+    "import pytz\n",
+    "import pandas as pd\n",
+    "import os\n",
+    "import json\n",
+    "from typing import Any\n",
+    "# Settings and utility functions to display objects and responses more clearly.\n",
+    "pd.set_option('float_format', '{:,.4f}'.format)\n",
+    "\n",
+    "# Set the secrets path\n",
+    "secrets_path = os.getenv(\"FBN_SECRETS_PATH\")\n",
+    "\n",
+    "if secrets_path is None:\n",
+    "    secrets_path = os.path.join(os.path.dirname(os.getcwd()), \"secrets.json\")\n",
+    "\n",
+    "api_factory = lu.utilities.ApiClientFactory(\n",
+    "    token=RefreshingToken(),\n",
+    "    api_secrets_filename = secrets_path,\n",
+    "    app_name=\"LusidJupyterNotebook\")\n",
+    "\n",
+    "print ('LUSID Environment Initialised')\n",
+    "print ('LUSID SDK Version: ', api_factory.build(lu.api.ApplicationMetadataApi).get_lusid_versions().build_version)"
+   ],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-06T13:58:09.498613Z",
+     "start_time": "2024-03-06T13:58:08.246875Z"
+    }
+   },
+   "id": "b85bd9b6-e539-4f89-b3f2-9eba88aff729"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 83,
+   "id": "4a1cbc56-3234-4d6c-9b8b-1c98dceedd92",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-03-06T13:58:09.510471Z",
+     "start_time": "2024-03-06T13:58:09.502384Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Initiate the LUSID APIs required for the notebook\n",
+    "configuration_recipe_api = api_factory.build(lu.api.ConfigurationRecipeApi)\n",
+    "instruments_api = api_factory.build(lu.api.InstrumentsApi)\n",
+    "transaction_portfolios_api = api_factory.build(lu.api.TransactionPortfoliosApi)\n",
+    "quotes_api = api_factory.build(lu.api.QuotesApi)\n",
+    "aggregation_api = api_factory.build(lu.api.AggregationApi)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "outputs": [],
+   "source": [
+    "# Helper functions \n",
+    "def get_recipe_scope(recipe_name: str) -> str:\n",
+    "    return f\"{recipe_name}-recipe-composer-scope-n\"\n",
+    "def get_recipe_code(recipe_name: str) -> str:\n",
+    "    return f\"{recipe_name}-recipe-composer-code-n\"\n",
+    "def upsert_recipe(recipe: lu.ConfigurationRecipe) -> None:\n",
+    "    # Upsert configuration recipe\n",
+    "    response = configuration_recipe_api.upsert_configuration_recipe(\n",
+    "        upsert_recipe_request=lm.UpsertRecipeRequest(configuration_recipe=recipe)\n",
+    "    )\n",
+    "    print(response)\n",
+    "    #print_json(str(response))\n",
+    "def resolve_recipe_composer(recipe_composer: lu.RecipeComposer) -> lu.ConfigurationRecipe:\n",
+    "    response: lu.GetRecipeResponse = configuration_recipe_api.get_recipe_composer_resolved_inline(\n",
+    "        upsert_recipe_composer_request = lm.UpsertRecipeComposerRequest(\n",
+    "            recipe_composer = recipe_composer\n",
+    "        )\n",
+    "    )\n",
+    "    return response.value\n",
+    "def pprint(openapi_obj: Any) -> None:\n",
+    "    resp = openapi_obj.to_dict()\n",
+    "    print(json.dumps(resp, indent=4))\n",
+    "def create_fx_option(strike, dom_ccy, fgn_ccy, start_date, maturity_date, settlement_date, is_call, is_fx_delivery = True, is_payoff_digital = False, exercise_type = \"European\"):\n",
+    "\n",
+    "    return lm.FxOption(\n",
+    "        strike = strike,\n",
+    "        dom_ccy = dom_ccy,\n",
+    "        fgn_ccy = fgn_ccy,\n",
+    "        start_date = start_date,\n",
+    "        option_maturity_date = maturity_date,\n",
+    "        option_settlement_date = settlement_date,\n",
+    "        is_call_not_put = is_call,\n",
+    "        is_delivery_not_cash = is_fx_delivery,\n",
+    "        is_payoff_digital = is_payoff_digital,\n",
+    "        instrument_type = \"FxOption\",\n",
+    "        dom_amount = 1,\n",
+    "        exercise_type = exercise_type\n",
+    "    )\n",
+    "market_supplier = \"Lusid\"\n",
+    "\n",
+    "# Will use this scope and code for last recipe composer and then in valuation\n",
+    "recipe_composer_scope = \"aVivaldiScope\"\n",
+    "recipe_composer_code = \"aVivaldiCode\""
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-06T13:58:09.519301Z",
+     "start_time": "2024-03-06T13:58:09.508462Z"
+    }
+   },
+   "id": "b2fb63e351f7be56"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Creating Configuration Recipes\n",
+    "In order to demonstrate how Recipe Composer can be used to build a new Recipe lets first create some Recipes in a typical way and then use them to create new Recipes using Recipe Composers. "
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "315dba89e3353ac"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'href': None,\n",
+      " 'links': [{'description': 'A link to the LUSID Insights website showing all '\n",
+      "                           'logs related to this request',\n",
+      "            'href': 'https://fbn-ci.lusid.com/app/insights/logs/0HN1TROVBS4AC:000000A6',\n",
+      "            'method': 'GET',\n",
+      "            'relation': 'RequestLogs'}],\n",
+      " 'value': datetime.datetime(2024, 3, 6, 13, 57, 46, 695099, tzinfo=tzutc())}\n"
+     ]
+    }
+   ],
+   "source": [
+    "recipe1 = lm.ConfigurationRecipe(\n",
+    "    scope = get_recipe_scope(\"recipe1\"),\n",
+    "    code = get_recipe_code(\"recipe1\"),\n",
+    "    market=lm.MarketContext(\n",
+    "        market_rules=[\n",
+    "            lm.MarketDataKeyRule(\n",
+    "                key=\"FX.CurrencyPair.*\",\n",
+    "                supplier=market_supplier,\n",
+    "                data_scope=recipe_composer_scope,\n",
+    "                quote_type=\"Rate\",\n",
+    "                field=\"mid\",\n",
+    "                quote_interval=\"100D\"\n",
+    "            ),\n",
+    "            lm.MarketDataKeyRule(\n",
+    "                key=\"FXVol.*.*.*\",\n",
+    "                supplier=market_supplier,\n",
+    "                data_scope=recipe_composer_scope,\n",
+    "                price_source=market_supplier,\n",
+    "                quote_type=\"Price\",\n",
+    "                field=\"mid\",\n",
+    "                quote_interval=\"100D\",\n",
+    "            ),\n",
+    "            lm.MarketDataKeyRule(\n",
+    "                key=\"Rates.*.*\",\n",
+    "                supplier=market_supplier,\n",
+    "                data_scope=recipe_composer_scope,\n",
+    "                price_source=market_supplier,\n",
+    "                quote_type=\"Price\",\n",
+    "                field=\"mid\",\n",
+    "                quote_interval=\"100D\",\n",
+    "            ),\n",
+    "        ],\n",
+    "        options=lm.MarketOptions(\n",
+    "            default_scope = recipe_composer_scope,\n",
+    "            attempt_to_infer_missing_fx=True\n",
+    "        ),\n",
+    "    ),\n",
+    "    pricing = lm.PricingContext(\n",
+    "        model_rules = [\n",
+    "            lm.VendorModelRule(\n",
+    "                supplier = \"Lusid\",\n",
+    "                model_name = \"Discounting\",\n",
+    "                instrument_type = \"InflationSwap\",\n",
+    "            ),\n",
+    "            lm.VendorModelRule(\n",
+    "                supplier = \"Lusid\",\n",
+    "                model_name = \"BlackScholes\",\n",
+    "                instrument_type = \"FxOption\",\n",
+    "            ),\n",
+    "            lm.VendorModelRule(\n",
+    "                supplier = \"Lusid\",\n",
+    "                model_name = \"SimpleStatic\",\n",
+    "                instrument_type = \"FixedLeg\",\n",
+    "            )\n",
+    "        ],\n",
+    "    ),\n",
+    ")\n",
+    "upsert_recipe(recipe1)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-06T13:58:09.824083Z",
+     "start_time": "2024-03-06T13:58:09.518519Z"
+    }
+   },
+   "id": "dcb6ad9728ea38f"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'href': None,\n",
+      " 'links': [{'description': 'A link to the LUSID Insights website showing all '\n",
+      "                           'logs related to this request',\n",
+      "            'href': 'https://fbn-ci.lusid.com/app/insights/logs/0HN1TROVBS4B9:0000005C',\n",
+      "            'method': 'GET',\n",
+      "            'relation': 'RequestLogs'}],\n",
+      " 'value': datetime.datetime(2024, 3, 6, 13, 57, 47, 13312, tzinfo=tzutc())}\n"
+     ]
+    }
+   ],
+   "source": [
+    "recipe2 = lm.ConfigurationRecipe(\n",
+    "    scope = get_recipe_scope(\"recipe2\"),\n",
+    "    code = get_recipe_code(\"recipe2\"),\n",
+    "    market= lm.MarketContext(\n",
+    "        market_rules=[\n",
+    "            lm.MarketDataKeyRule(\n",
+    "                key=\"Quote.RIC.AMZN\",\n",
+    "                supplier=\"Client\",\n",
+    "                data_scope=\"NotUsed\",\n",
+    "                quote_type=\"Price\",\n",
+    "                source_system=\"SimulatedData/Constant/136.01\"\n",
+    "            ),\n",
+    "        ]\n",
+    "    ),\n",
+    "    pricing = lm.PricingContext(\n",
+    "        model_rules = [\n",
+    "            lm.VendorModelRule(\n",
+    "                supplier = \"Lusid\",\n",
+    "                model_name = \"BlackScholes\",\n",
+    "                instrument_type = \"FxOption\",\n",
+    "                address_key_filters = [\n",
+    "                    lm.AddressKeyFilter(left=\"Instrument/Features/ExerciseType\", operator=\"eq\", right=lm.ResultValueString(value=\"European\", result_value_type=\"ResultValueString\"))\n",
+    "                ] \n",
+    "            ),\n",
+    "            lm.VendorModelRule(\n",
+    "                supplier = \"Lusid\",\n",
+    "                model_name = \"ConstantTimeValueOfMoney\",\n",
+    "                instrument_type = \"ComplexBond\",\n",
+    "            )\n",
+    "        ],\n",
+    "    ),\n",
+    ")\n",
+    "upsert_recipe(recipe2)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-06T13:58:10.226690Z",
+     "start_time": "2024-03-06T13:58:09.822218Z"
+    }
+   },
+   "id": "a1e4c56f34f364a0"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Recipe Composing\n",
+    "Recipe Composer is very flexible, user has a lot of freedom to set up their Recipes the way that fits their use-case, it can however be challenging to get it right on the first attempt. Because of this we have made a GetRecipeComposerResolvedInline endpoint (`configuration_recipe_api.get_recipe_composer_resolved_inline` in the SDK which here is called via `resolve_recipe_composer`), it allows a user to see what the Recipe Composer would provide without actually upserting it, allowing user to do fast prototyping and getting the outcome they want fast."
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "1a530500241c95b5"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    \"scope\": \"vivaldiScope1\",\n",
+      "    \"code\": \"vivaldiCode1\",\n",
+      "    \"market\": {\n",
+      "        \"market_rules\": [\n",
+      "            {\n",
+      "                \"key\": \"FX.CurrencyPair.*\",\n",
+      "                \"supplier\": \"Lusid\",\n",
+      "                \"data_scope\": \"aVivaldiScope\",\n",
+      "                \"quote_type\": \"Rate\",\n",
+      "                \"field\": \"mid\",\n",
+      "                \"quote_interval\": \"100D\",\n",
+      "                \"as_at\": null,\n",
+      "                \"price_source\": \"\",\n",
+      "                \"mask\": null,\n",
+      "                \"source_system\": \"Lusid\"\n",
+      "            },\n",
+      "            {\n",
+      "                \"key\": \"FXVol.*.*.*\",\n",
+      "                \"supplier\": \"Lusid\",\n",
+      "                \"data_scope\": \"aVivaldiScope\",\n",
+      "                \"quote_type\": \"Price\",\n",
+      "                \"field\": \"mid\",\n",
+      "                \"quote_interval\": \"100D\",\n",
+      "                \"as_at\": null,\n",
+      "                \"price_source\": \"Lusid\",\n",
+      "                \"mask\": null,\n",
+      "                \"source_system\": \"Lusid\"\n",
+      "            },\n",
+      "            {\n",
+      "                \"key\": \"Rates.*.*\",\n",
+      "                \"supplier\": \"Lusid\",\n",
+      "                \"data_scope\": \"aVivaldiScope\",\n",
+      "                \"quote_type\": \"Price\",\n",
+      "                \"field\": \"mid\",\n",
+      "                \"quote_interval\": \"100D\",\n",
+      "                \"as_at\": null,\n",
+      "                \"price_source\": \"Lusid\",\n",
+      "                \"mask\": null,\n",
+      "                \"source_system\": \"Lusid\"\n",
+      "            }\n",
+      "        ],\n",
+      "        \"suppliers\": {\n",
+      "            \"commodity\": null,\n",
+      "            \"credit\": null,\n",
+      "            \"equity\": null,\n",
+      "            \"fx\": null,\n",
+      "            \"rates\": null\n",
+      "        },\n",
+      "        \"options\": {\n",
+      "            \"default_supplier\": \"Lusid\",\n",
+      "            \"default_instrument_code_type\": \"LusidInstrumentId\",\n",
+      "            \"default_scope\": \"aVivaldiScope\",\n",
+      "            \"attempt_to_infer_missing_fx\": true,\n",
+      "            \"calendar_scope\": \"CoppClarkHolidayCalendars\",\n",
+      "            \"convention_scope\": \"Conventions\"\n",
+      "        },\n",
+      "        \"specific_rules\": [],\n",
+      "        \"grouped_market_rules\": []\n",
+      "    },\n",
+      "    \"pricing\": {\n",
+      "        \"model_rules\": [\n",
+      "            {\n",
+      "                \"supplier\": \"Lusid\",\n",
+      "                \"model_name\": \"BlackScholes\",\n",
+      "                \"instrument_type\": \"FxOption\",\n",
+      "                \"parameters\": \"\",\n",
+      "                \"model_options\": {\n",
+      "                    \"model_options_type\": \"EmptyModelOptions\"\n",
+      "                },\n",
+      "                \"instrument_id\": \"\",\n",
+      "                \"address_key_filters\": [\n",
+      "                    {\n",
+      "                        \"left\": \"Instrument/Features/ExerciseType\",\n",
+      "                        \"operator\": \"eq\",\n",
+      "                        \"right\": {\n",
+      "                            \"value\": \"European\",\n",
+      "                            \"result_value_type\": \"ResultValueString\"\n",
+      "                        }\n",
+      "                    }\n",
+      "                ]\n",
+      "            },\n",
+      "            {\n",
+      "                \"supplier\": \"Lusid\",\n",
+      "                \"model_name\": \"ConstantTimeValueOfMoney\",\n",
+      "                \"instrument_type\": \"ComplexBond\",\n",
+      "                \"parameters\": \"\",\n",
+      "                \"model_options\": {\n",
+      "                    \"model_options_type\": \"EmptyModelOptions\"\n",
+      "                },\n",
+      "                \"instrument_id\": \"\",\n",
+      "                \"address_key_filters\": []\n",
+      "            },\n",
+      "            {\n",
+      "                \"supplier\": \"Lusid\",\n",
+      "                \"model_name\": \"Discounting\",\n",
+      "                \"instrument_type\": \"InflationSwap\",\n",
+      "                \"parameters\": \"\",\n",
+      "                \"model_options\": {\n",
+      "                    \"model_options_type\": \"EmptyModelOptions\"\n",
+      "                },\n",
+      "                \"instrument_id\": \"\",\n",
+      "                \"address_key_filters\": []\n",
+      "            },\n",
+      "            {\n",
+      "                \"supplier\": \"Lusid\",\n",
+      "                \"model_name\": \"BlackScholes\",\n",
+      "                \"instrument_type\": \"FxOption\",\n",
+      "                \"parameters\": \"\",\n",
+      "                \"model_options\": {\n",
+      "                    \"model_options_type\": \"EmptyModelOptions\"\n",
+      "                },\n",
+      "                \"instrument_id\": \"\",\n",
+      "                \"address_key_filters\": []\n",
+      "            },\n",
+      "            {\n",
+      "                \"supplier\": \"Lusid\",\n",
+      "                \"model_name\": \"SimpleStatic\",\n",
+      "                \"instrument_type\": \"FixedLeg\",\n",
+      "                \"parameters\": \"\",\n",
+      "                \"model_options\": {\n",
+      "                    \"model_options_type\": \"EmptyModelOptions\"\n",
+      "                },\n",
+      "                \"instrument_id\": \"\",\n",
+      "                \"address_key_filters\": []\n",
+      "            }\n",
+      "        ],\n",
+      "        \"model_choice\": {},\n",
+      "        \"options\": {\n",
+      "            \"model_selection\": {\n",
+      "                \"library\": \"Lusid\",\n",
+      "                \"model\": \"SimpleStatic\"\n",
+      "            },\n",
+      "            \"use_instrument_type_to_determine_pricer\": false,\n",
+      "            \"allow_any_instruments_with_sec_uid_to_price_off_lookup\": false,\n",
+      "            \"allow_partially_successful_evaluation\": false,\n",
+      "            \"produce_separate_result_for_linear_otc_legs\": false,\n",
+      "            \"enable_use_of_cached_unit_results\": false,\n",
+      "            \"window_valuation_on_instrument_start_end\": false,\n",
+      "            \"remove_contingent_cashflows_in_payment_diary\": false,\n",
+      "            \"use_child_sub_holding_keys_for_portfolio_expansion\": false,\n",
+      "            \"validate_domestic_and_quote_currencies_are_consistent\": false,\n",
+      "            \"conserved_quantity_for_lookthrough_expansion\": \"PV\"\n",
+      "        },\n",
+      "        \"result_data_rules\": []\n",
+      "    },\n",
+      "    \"aggregation\": {\n",
+      "        \"options\": {\n",
+      "            \"use_ansi_like_syntax\": false,\n",
+      "            \"allow_partial_entitlement_success\": false,\n",
+      "            \"apply_iso4217_rounding\": false\n",
+      "        }\n",
+      "    },\n",
+      "    \"description\": null,\n",
+      "    \"holding\": {\n",
+      "        \"tax_lot_level_holdings\": true\n",
+      "    },\n",
+      "    \"translation\": null\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "recipe_composer1 = lm.RecipeComposer(\n",
+    "    code = \"vivaldiCode1\",\n",
+    "    scope = \"vivaldiScope1\",\n",
+    "    operations = [\n",
+    "        lm.RecipeBlock(\n",
+    "            op = \"Insert\",\n",
+    "            path = \"$\",\n",
+    "            value = lm.RecipeValue(from_recipe=lm.FromRecipe(scope=get_recipe_scope(\"recipe1\"), code=get_recipe_code(\"recipe1\")))\n",
+    "        ),\n",
+    "        lm.RecipeBlock(\n",
+    "            op = \"Prepend\",\n",
+    "            path = \"Pricing.ModelRules\",\n",
+    "            value = lm.RecipeValue(from_recipe=lm.FromRecipe(scope=get_recipe_scope(\"recipe2\"), code=get_recipe_code(\"recipe2\")))\n",
+    "        )\n",
+    "    ]\n",
+    ")\n",
+    "resolved_recipe1 = resolve_recipe_composer(recipe_composer1)\n",
+    "\n",
+    "pprint(resolved_recipe1)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-06T13:58:10.378635Z",
+     "start_time": "2024-03-06T13:58:10.217680Z"
+    }
+   },
+   "id": "71561aae66e42b57"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Its nice to get data from other recipe, it is also possible to provide the desired part of recipe inline. Above we saw operations like \"Insert\" and \"Prepend\", there are 5 operations in total, namely\n",
+    "\"Insert\", \"Update\", \"Remove\", \"Prepend\", \"Append\". Do note Insert can only be done on parts which don't already exist, meanwhile Update and Remove can only be ran on parts that already exist. Prepend and Append can only be used on arrays."
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "763260e4f231dfeb"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{'address_key_filters': [{'left': 'Instrument/Features/ExerciseType',\n",
+      "                          'operator': 'eq',\n",
+      "                          'right': {'result_value_type': 'ResultValueString',\n",
+      "                                    'value': 'European'}}],\n",
+      " 'instrument_id': '',\n",
+      " 'instrument_type': 'FxOption',\n",
+      " 'model_name': 'BlackScholes',\n",
+      " 'model_options': {'model_options_type': 'EmptyModelOptions'},\n",
+      " 'parameters': '',\n",
+      " 'supplier': 'Lusid'}, {'address_key_filters': [],\n",
+      " 'instrument_id': '',\n",
+      " 'instrument_type': 'ComplexBond',\n",
+      " 'model_name': 'ConstantTimeValueOfMoney',\n",
+      " 'model_options': {'model_options_type': 'EmptyModelOptions'},\n",
+      " 'parameters': '',\n",
+      " 'supplier': 'Lusid'}, {'address_key_filters': [],\n",
+      " 'instrument_id': '',\n",
+      " 'instrument_type': 'InflationSwap',\n",
+      " 'model_name': 'Discounting',\n",
+      " 'model_options': {'model_options_type': 'EmptyModelOptions'},\n",
+      " 'parameters': '',\n",
+      " 'supplier': 'Lusid'}, {'address_key_filters': [],\n",
+      " 'instrument_id': '',\n",
+      " 'instrument_type': 'FxOption',\n",
+      " 'model_name': 'BlackScholes',\n",
+      " 'model_options': {'model_options_type': 'EmptyModelOptions'},\n",
+      " 'parameters': '',\n",
+      " 'supplier': 'Lusid'}, {'address_key_filters': [],\n",
+      " 'instrument_id': '',\n",
+      " 'instrument_type': 'FixedLeg',\n",
+      " 'model_name': 'SimpleStatic',\n",
+      " 'model_options': {'model_options_type': 'EmptyModelOptions'},\n",
+      " 'parameters': '',\n",
+      " 'supplier': 'Lusid'}, {'address_key_filters': [],\n",
+      " 'instrument_id': '',\n",
+      " 'instrument_type': 'TotalReturnSwap',\n",
+      " 'model_name': 'SimpleStatic',\n",
+      " 'model_options': {'model_options_type': 'EmptyModelOptions'},\n",
+      " 'parameters': None,\n",
+      " 'supplier': 'Lusid'}]\n"
+     ]
+    }
+   ],
+   "source": [
+    "recipe_composer2 = lm.RecipeComposer(\n",
+    "    code = \"vivaldiCode2\",\n",
+    "    scope = \"vivaldiScope2\",\n",
+    "    operations = [\n",
+    "        lm.RecipeBlock(\n",
+    "            op = \"Insert\",\n",
+    "            path = \"$\",\n",
+    "            value = lm.RecipeValue(from_recipe=lm.FromRecipe(scope=get_recipe_scope(\"recipe1\"), code=get_recipe_code(\"recipe1\")))\n",
+    "        ),\n",
+    "        lm.RecipeBlock(\n",
+    "            op = \"Append\",\n",
+    "            path = \"Pricing.ModelRules\",\n",
+    "            value = lm.RecipeValue(as_json=\"[{\\\"Supplier\\\":\\\"Lusid\\\",\\\"ModelName\\\":\\\"SimpleStatic\\\",\\\"InstrumentType\\\":\\\"TotalReturnSwap\\\",\\\"Parameters\\\":null,\\\"ModelOptions\\\":{\\\"ModelOptionsType\\\":2},\\\"InstrumentId\\\":\\\"\\\",\\\"AddressKeyFilters\\\":[]}]\")\n",
+    "        ),\n",
+    "        lm.RecipeBlock(\n",
+    "            op = \"Prepend\",\n",
+    "            path = \"Pricing.ModelRules\",\n",
+    "            value = lm.RecipeValue(from_recipe=lm.FromRecipe(scope=get_recipe_scope(\"recipe2\"), code=get_recipe_code(\"recipe2\")))\n",
+    "        )\n",
+    "    ]\n",
+    ")\n",
+    "resolved_recipe2 = resolve_recipe_composer(recipe_composer2)\n",
+    "\n",
+    "# To reduce confusion, only looking at model rules \n",
+    "print(resolved_recipe2.pricing.model_rules)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-06T13:58:10.471667Z",
+     "start_time": "2024-03-06T13:58:10.382290Z"
+    }
+   },
+   "id": "8dbbfd04be97759c"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "We can modify the rules should we wish using Update operation. Furthermore the path attribute on each operation accepts star notation on arrays so `Pricing.ModelRules.[*]` would refer to each element in the array of ModelRules."
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "e1c018aa70e12a9c"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{'address_key_filters': [{'left': 'Instrument/Features/ExerciseType',\n",
+      "                          'operator': 'eq',\n",
+      "                          'right': {'result_value_type': 'ResultValueString',\n",
+      "                                    'value': 'European'}}],\n",
+      " 'instrument_id': '',\n",
+      " 'instrument_type': 'FxOption',\n",
+      " 'model_name': 'ConstantTimeValueOfMoney',\n",
+      " 'model_options': {'model_options_type': 'EmptyModelOptions'},\n",
+      " 'parameters': '',\n",
+      " 'supplier': 'Lusid'}, {'address_key_filters': [],\n",
+      " 'instrument_id': '',\n",
+      " 'instrument_type': 'ComplexBond',\n",
+      " 'model_name': 'ConstantTimeValueOfMoney',\n",
+      " 'model_options': {'model_options_type': 'EmptyModelOptions'},\n",
+      " 'parameters': '',\n",
+      " 'supplier': 'Lusid'}, {'address_key_filters': [],\n",
+      " 'instrument_id': '',\n",
+      " 'instrument_type': 'InflationSwap',\n",
+      " 'model_name': 'ConstantTimeValueOfMoney',\n",
+      " 'model_options': {'model_options_type': 'EmptyModelOptions'},\n",
+      " 'parameters': '',\n",
+      " 'supplier': 'Lusid'}, {'address_key_filters': [],\n",
+      " 'instrument_id': '',\n",
+      " 'instrument_type': 'FxOption',\n",
+      " 'model_name': 'ConstantTimeValueOfMoney',\n",
+      " 'model_options': {'model_options_type': 'EmptyModelOptions'},\n",
+      " 'parameters': '',\n",
+      " 'supplier': 'Lusid'}, {'address_key_filters': [],\n",
+      " 'instrument_id': '',\n",
+      " 'instrument_type': 'FixedLeg',\n",
+      " 'model_name': 'ConstantTimeValueOfMoney',\n",
+      " 'model_options': {'model_options_type': 'EmptyModelOptions'},\n",
+      " 'parameters': '',\n",
+      " 'supplier': 'Lusid'}, {'address_key_filters': [],\n",
+      " 'instrument_id': '',\n",
+      " 'instrument_type': 'TotalReturnSwap',\n",
+      " 'model_name': 'ConstantTimeValueOfMoney',\n",
+      " 'model_options': {'model_options_type': 'EmptyModelOptions'},\n",
+      " 'parameters': None,\n",
+      " 'supplier': 'Lusid'}]\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "recipe_composer3 = lm.RecipeComposer(\n",
+    "    code = recipe_composer_code,\n",
+    "    scope = recipe_composer_scope,\n",
+    "    operations = [\n",
+    "        # Use recipe1 as my starting point\n",
+    "        lm.Operation(\n",
+    "            op = \"Insert\",\n",
+    "            path = \"$\",\n",
+    "            value = lm.RecipeValue(from_recipe=lm.FromRecipe(scope=get_recipe_scope(\"recipe1\"), code=get_recipe_code(\"recipe1\")))\n",
+    "        ),\n",
+    "        # Append (low priority) my specific model rule\n",
+    "        lm.RecipeBlock(\n",
+    "            op = \"Append\",\n",
+    "            path = \"Pricing.ModelRules\",\n",
+    "            value = lm.RecipeValue(as_json=\"[{\\\"Supplier\\\":\\\"Lusid\\\",\\\"ModelName\\\":\\\"SimpleStatic\\\",\\\"InstrumentType\\\":\\\"TotalReturnSwap\\\",\\\"Parameters\\\":null,\\\"ModelOptions\\\":{\\\"ModelOptionsType\\\":2},\\\"InstrumentId\\\":\\\"\\\",\\\"AddressKeyFilters\\\":[]}]\")\n",
+    "        ),\n",
+    "        # Prepend (prioritise) model rules form recipe 2\n",
+    "        lm.RecipeBlock(\n",
+    "            op = \"Prepend\",\n",
+    "            path = \"Pricing.ModelRules\",\n",
+    "            value = lm.RecipeValue(from_recipe=lm.FromRecipe(scope=get_recipe_scope(\"recipe2\"), code=get_recipe_code(\"recipe2\")))\n",
+    "        ),\n",
+    "        # Update all model rules I have to use ConstantTimeValueOfMoney\n",
+    "        lm.RecipeBlock(\n",
+    "            op = \"Update\",\n",
+    "            path = \"Pricing.ModelRules.[*].ModelName\",\n",
+    "            value = lm.RecipeValue(as_string=\"ConstantTimeValueOfMoney\")\n",
+    "        ),\n",
+    "    ]\n",
+    ")\n",
+    "resolved_recipe3 = resolve_recipe_composer(recipe_composer3)\n",
+    "\n",
+    "# To reduce confusion, only looking at model rules \n",
+    "print(resolved_recipe3.pricing.model_rules)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-06T13:58:10.653318Z",
+     "start_time": "2024-03-06T13:58:10.470488Z"
+    }
+   },
+   "id": "dedb9dca12ad747b"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Do note the Update operation at the very end will replace all of the model rules in the recipe at the time of that operation, so all the model rules that came from the 3 operations above will have their `ModelName` changed to `ConstantTimeValueOfMoney`."
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "e6822e96e470cd1"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Having figured out what Recipe Composer we want, we can now upsert it. Just as Recipes it supports the standard CRUD operations. After upserting we can always get it back using the GetRecipeComposer, in addition to that we can get it in the resolved Recipe form using GetDerivedRecipe endpoint. GetDerivedRecipe extends the functionality of GetConfigurationRecipe endpoint, returning a Recipe if scope and code for a Recipe is given, and if scope and code is given for RecipeComposer it resolves it to a Recipe and returns that."
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "19d749c6df46ce32"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 90,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'href': None,\n",
+      " 'links': [{'description': 'A link to the LUSID Insights website showing all '\n",
+      "                           'logs related to this request',\n",
+      "            'href': 'https://fbn-ci.lusid.com/app/insights/logs/0HN1TRO0VIQAD:00000067',\n",
+      "            'method': 'GET',\n",
+      "            'relation': 'RequestLogs'}],\n",
+      " 'value': {'code': 'aVivaldiCode',\n",
+      "           'operations': [{'op': 'Insert',\n",
+      "                           'path': '$',\n",
+      "                           'value': {'as_json': None,\n",
+      "                                     'as_string': None,\n",
+      "                                     'from_recipe': {'code': 'recipe1-recipe-composer-code-n',\n",
+      "                                                     'scope': 'recipe1-recipe-composer-scope-n'}}},\n",
+      "                          {'op': 'Append',\n",
+      "                           'path': 'Pricing.ModelRules',\n",
+      "                           'value': {'as_json': '[{\"Supplier\":\"Lusid\",\"ModelName\":\"SimpleStatic\",\"InstrumentType\":\"TotalReturnSwap\",\"Parameters\":null,\"ModelOptions\":{\"ModelOptionsType\":2},\"InstrumentId\":\"\",\"AddressKeyFilters\":[]}]',\n",
+      "                                     'as_string': None,\n",
+      "                                     'from_recipe': {'code': None,\n",
+      "                                                     'scope': None}}},\n",
+      "                          {'op': 'Prepend',\n",
+      "                           'path': 'Pricing.ModelRules',\n",
+      "                           'value': {'as_json': None,\n",
+      "                                     'as_string': None,\n",
+      "                                     'from_recipe': {'code': 'recipe2-recipe-composer-code-n',\n",
+      "                                                     'scope': 'recipe2-recipe-composer-scope-n'}}},\n",
+      "                          {'op': 'Update',\n",
+      "                           'path': 'Pricing.ModelRules.[*].ModelName',\n",
+      "                           'value': {'as_json': None,\n",
+      "                                     'as_string': 'ConstantTimeValueOfMoney',\n",
+      "                                     'from_recipe': {'code': None,\n",
+      "                                                     'scope': None}}}],\n",
+      "           'scope': 'aVivaldiScope'}}\n",
+      "{'href': None,\n",
+      " 'links': [{'description': 'A link to the LUSID Insights website showing all '\n",
+      "                           'logs related to this request',\n",
+      "            'href': 'https://fbn-ci.lusid.com/app/insights/logs/0HN1TRO0VIQAD:00000068',\n",
+      "            'method': 'GET',\n",
+      "            'relation': 'RequestLogs'}],\n",
+      " 'value': {'aggregation': {'options': {'allow_partial_entitlement_success': False,\n",
+      "                                       'apply_iso4217_rounding': False,\n",
+      "                                       'use_ansi_like_syntax': False}},\n",
+      "           'code': 'aVivaldiCode',\n",
+      "           'description': None,\n",
+      "           'holding': {'tax_lot_level_holdings': True},\n",
+      "           'market': {'grouped_market_rules': [],\n",
+      "                      'market_rules': [{'as_at': None,\n",
+      "                                        'data_scope': 'aVivaldiScope',\n",
+      "                                        'field': 'mid',\n",
+      "                                        'key': 'FX.CurrencyPair.*',\n",
+      "                                        'mask': None,\n",
+      "                                        'price_source': '',\n",
+      "                                        'quote_interval': '100D',\n",
+      "                                        'quote_type': 'Rate',\n",
+      "                                        'source_system': 'Lusid',\n",
+      "                                        'supplier': 'Lusid'},\n",
+      "                                       {'as_at': None,\n",
+      "                                        'data_scope': 'aVivaldiScope',\n",
+      "                                        'field': 'mid',\n",
+      "                                        'key': 'FXVol.*.*.*',\n",
+      "                                        'mask': None,\n",
+      "                                        'price_source': 'Lusid',\n",
+      "                                        'quote_interval': '100D',\n",
+      "                                        'quote_type': 'Price',\n",
+      "                                        'source_system': 'Lusid',\n",
+      "                                        'supplier': 'Lusid'},\n",
+      "                                       {'as_at': None,\n",
+      "                                        'data_scope': 'aVivaldiScope',\n",
+      "                                        'field': 'mid',\n",
+      "                                        'key': 'Rates.*.*',\n",
+      "                                        'mask': None,\n",
+      "                                        'price_source': 'Lusid',\n",
+      "                                        'quote_interval': '100D',\n",
+      "                                        'quote_type': 'Price',\n",
+      "                                        'source_system': 'Lusid',\n",
+      "                                        'supplier': 'Lusid'}],\n",
+      "                      'options': {'attempt_to_infer_missing_fx': True,\n",
+      "                                  'calendar_scope': 'CoppClarkHolidayCalendars',\n",
+      "                                  'convention_scope': 'Conventions',\n",
+      "                                  'default_instrument_code_type': 'LusidInstrumentId',\n",
+      "                                  'default_scope': 'aVivaldiScope',\n",
+      "                                  'default_supplier': 'Lusid'},\n",
+      "                      'specific_rules': [],\n",
+      "                      'suppliers': {'commodity': None,\n",
+      "                                    'credit': None,\n",
+      "                                    'equity': None,\n",
+      "                                    'fx': None,\n",
+      "                                    'rates': None}},\n",
+      "           'pricing': {'model_choice': {},\n",
+      "                       'model_rules': [{'address_key_filters': [{'left': 'Instrument/Features/ExerciseType',\n",
+      "                                                                 'operator': 'eq',\n",
+      "                                                                 'right': {'result_value_type': 'ResultValueString',\n",
+      "                                                                           'value': 'European'}}],\n",
+      "                                        'instrument_id': '',\n",
+      "                                        'instrument_type': 'FxOption',\n",
+      "                                        'model_name': 'ConstantTimeValueOfMoney',\n",
+      "                                        'model_options': {'model_options_type': 'EmptyModelOptions'},\n",
+      "                                        'parameters': '',\n",
+      "                                        'supplier': 'Lusid'},\n",
+      "                                       {'address_key_filters': [],\n",
+      "                                        'instrument_id': '',\n",
+      "                                        'instrument_type': 'ComplexBond',\n",
+      "                                        'model_name': 'ConstantTimeValueOfMoney',\n",
+      "                                        'model_options': {'model_options_type': 'EmptyModelOptions'},\n",
+      "                                        'parameters': '',\n",
+      "                                        'supplier': 'Lusid'},\n",
+      "                                       {'address_key_filters': [],\n",
+      "                                        'instrument_id': '',\n",
+      "                                        'instrument_type': 'InflationSwap',\n",
+      "                                        'model_name': 'ConstantTimeValueOfMoney',\n",
+      "                                        'model_options': {'model_options_type': 'EmptyModelOptions'},\n",
+      "                                        'parameters': '',\n",
+      "                                        'supplier': 'Lusid'},\n",
+      "                                       {'address_key_filters': [],\n",
+      "                                        'instrument_id': '',\n",
+      "                                        'instrument_type': 'FxOption',\n",
+      "                                        'model_name': 'ConstantTimeValueOfMoney',\n",
+      "                                        'model_options': {'model_options_type': 'EmptyModelOptions'},\n",
+      "                                        'parameters': '',\n",
+      "                                        'supplier': 'Lusid'},\n",
+      "                                       {'address_key_filters': [],\n",
+      "                                        'instrument_id': '',\n",
+      "                                        'instrument_type': 'FixedLeg',\n",
+      "                                        'model_name': 'ConstantTimeValueOfMoney',\n",
+      "                                        'model_options': {'model_options_type': 'EmptyModelOptions'},\n",
+      "                                        'parameters': '',\n",
+      "                                        'supplier': 'Lusid'},\n",
+      "                                       {'address_key_filters': [],\n",
+      "                                        'instrument_id': '',\n",
+      "                                        'instrument_type': 'TotalReturnSwap',\n",
+      "                                        'model_name': 'ConstantTimeValueOfMoney',\n",
+      "                                        'model_options': {'model_options_type': 'EmptyModelOptions'},\n",
+      "                                        'parameters': '',\n",
+      "                                        'supplier': 'Lusid'}],\n",
+      "                       'options': {'allow_any_instruments_with_sec_uid_to_price_off_lookup': False,\n",
+      "                                   'allow_partially_successful_evaluation': False,\n",
+      "                                   'conserved_quantity_for_lookthrough_expansion': 'PV',\n",
+      "                                   'enable_use_of_cached_unit_results': False,\n",
+      "                                   'model_selection': {'library': 'Lusid',\n",
+      "                                                       'model': 'SimpleStatic'},\n",
+      "                                   'produce_separate_result_for_linear_otc_legs': False,\n",
+      "                                   'remove_contingent_cashflows_in_payment_diary': False,\n",
+      "                                   'use_child_sub_holding_keys_for_portfolio_expansion': False,\n",
+      "                                   'use_instrument_type_to_determine_pricer': False,\n",
+      "                                   'validate_domestic_and_quote_currencies_are_consistent': False,\n",
+      "                                   'window_valuation_on_instrument_start_end': False},\n",
+      "                       'result_data_rules': []},\n",
+      "           'scope': 'aVivaldiScope',\n",
+      "           'translation': None}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "upsert = configuration_recipe_api.upsert_recipe_composer(upsert_recipe_composer_request= lu.UpsertRecipeComposerRequest(recipe_composer=recipe_composer3))\n",
+    "\n",
+    "# Get back Recipe Composer\n",
+    "recipe_composer_back = configuration_recipe_api.get_recipe_composer(scope=recipe_composer_scope, code=recipe_composer_code)\n",
+    "print(recipe_composer_back)\n",
+    "\n",
+    "# Get Back Recipe that is resolved from our Recipe Composer\n",
+    "recipe_back = configuration_recipe_api.get_derived_recipe(scope=recipe_composer_scope, code=recipe_composer_code)\n",
+    "print(recipe_back)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-06T13:58:11.147454Z",
+     "start_time": "2024-03-06T13:58:10.655454Z"
+    }
+   },
+   "id": "ff846f75f3934c5"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Recipe Composer Used In Valuation\n",
+    "As already mentioned, Recipe Composer seamlessly integrates wherever Configuration Recipe does, making a very easy experience."
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "35991798ccd3e456"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 91,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Transaction successfully updated at time: 2024-03-06 13:57:49.710366+00:00\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create portfolio\n",
+    "portfolio_code = \"recipe-composer-pf\"\n",
+    "scope = \"someScope-recipe-composer\"\n",
+    "try:\n",
+    "    transaction_portfolios_api.create_portfolio(\n",
+    "        scope=scope,\n",
+    "        create_transaction_portfolio_request=lm.CreateTransactionPortfolioRequest(\n",
+    "            display_name=portfolio_code,\n",
+    "            code=portfolio_code,\n",
+    "            base_currency=\"EUR\",\n",
+    "            created=\"2010-01-01\",\n",
+    "            instrument_scopes=[scope]\n",
+    "        ),\n",
+    "    )\n",
+    "\n",
+    "except lu.ApiException as e:\n",
+    "    print(e.body)\n",
+    "\n",
+    "# Create instrument definition\n",
+    "trade_date = datetime(2021, 1, 5, tzinfo=pytz.utc)\n",
+    "start_date = trade_date\n",
+    "maturity_date = trade_date + timedelta(days = 400)\n",
+    "settlement_date = maturity_date + timedelta(days = 2)\n",
+    "strike = 1.19\n",
+    "name = \"EUR/USD FX Option \" + maturity_date.strftime(\"%m/%d/%Y\")  + \" \" + str(strike)\n",
+    "identifier = \"EURUSDOptionDemo\"\n",
+    "dom_ccy = \"EUR\"\n",
+    "fgn_ccy = \"USD\"\n",
+    "\n",
+    "# Create Instrument\n",
+    "instrument_definition = create_fx_option(\n",
+    "    strike = strike,\n",
+    "    dom_ccy = dom_ccy,\n",
+    "    fgn_ccy = fgn_ccy,\n",
+    "    start_date = start_date,\n",
+    "    maturity_date = maturity_date,\n",
+    "    settlement_date = settlement_date,\n",
+    "    is_call = True,\n",
+    "    is_fx_delivery = True,\n",
+    "    is_payoff_digital = False,\n",
+    "    exercise_type = \"European\"\n",
+    ")\n",
+    "\n",
+    "# Upsert instrument\n",
+    "instruments_api.upsert_instruments(\n",
+    "    request_body={\n",
+    "        identifier: lm.InstrumentDefinition(\n",
+    "            name=\"myInstrument\",\n",
+    "            identifiers={\n",
+    "                \"ClientInternal\": lm.InstrumentIdValue(value=identifier)\n",
+    "            },\n",
+    "            definition=instrument_definition,\n",
+    "        )\n",
+    "    },\n",
+    "    scope = scope\n",
+    ")\n",
+    "\n",
+    "# Create and Upsert Transaction\n",
+    "premium = 0.03\n",
+    "option_version = 1\n",
+    "deal_2_id = \"TXN001\"\n",
+    "settle_days = 2\n",
+    "units = 50\n",
+    "\n",
+    "opt_txn = lm.TransactionRequest(\n",
+    "    transaction_id= deal_2_id,\n",
+    "    type=\"Sell\",\n",
+    "    instrument_identifiers={\"Instrument/default/ClientInternal\": identifier},\n",
+    "    transaction_date=trade_date.isoformat(),\n",
+    "    settlement_date=(trade_date + timedelta(days = settle_days)).isoformat(),\n",
+    "    units=units,\n",
+    "    transaction_price=lm.TransactionPrice(price=premium,type=\"Price\"),\n",
+    "    total_consideration=lm.CurrencyAndAmount(amount=premium*units,currency=dom_ccy),\n",
+    "    exchange_rate=1,\n",
+    "    transaction_currency=dom_ccy,\n",
+    ")\n",
+    "\n",
+    "response = transaction_portfolios_api.upsert_transactions(scope=scope,\n",
+    "                                                          code=portfolio_code,\n",
+    "                                                          transaction_request=[opt_txn])\n",
+    "\n",
+    "print(f\"Transaction successfully updated at time: {response.version.as_at_date}\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-06T13:58:12.815782Z",
+     "start_time": "2024-03-06T13:58:11.156780Z"
+    }
+   },
+   "id": "7e0d19d3e0a1eccf"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 92,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "                       Date   Rate     Pair\n0 2021-01-01 00:00:00+00:00 1.2215  EUR/USD\n1 2021-01-04 00:00:00+00:00 1.2248  EUR/USD\n2 2021-01-05 00:00:00+00:00 1.2298  EUR/USD\n3 2021-01-06 00:00:00+00:00 1.2327  EUR/USD\n4 2021-01-07 00:00:00+00:00 1.2272  EUR/USD",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>Date</th>\n      <th>Rate</th>\n      <th>Pair</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>2021-01-01 00:00:00+00:00</td>\n      <td>1.2215</td>\n      <td>EUR/USD</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>2021-01-04 00:00:00+00:00</td>\n      <td>1.2248</td>\n      <td>EUR/USD</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2021-01-05 00:00:00+00:00</td>\n      <td>1.2298</td>\n      <td>EUR/USD</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>2021-01-06 00:00:00+00:00</td>\n      <td>1.2327</td>\n      <td>EUR/USD</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>2021-01-07 00:00:00+00:00</td>\n      <td>1.2272</td>\n      <td>EUR/USD</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "execution_count": 92,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Read fx spot rates and make datetimes timezone aware\n",
+    "quotes_df = pd.read_csv(\"data/eurusd_spot.csv\")\n",
+    "quotes_df[\"Date\"] = pd.to_datetime(quotes_df[\"Date\"], dayfirst=True)\n",
+    "quotes_df[\"Date\"] = quotes_df[\"Date\"].apply(lambda x: x.replace(tzinfo=pytz.utc))\n",
+    "quotes_df.head()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-06T13:58:12.856791Z",
+     "start_time": "2024-03-06T13:58:12.814267Z"
+    }
+   },
+   "id": "14c74d923b642281"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Quotes successfully loaded into LUSID. 223 quotes loaded.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create quotes request\n",
+    "instrument_quotes = {\n",
+    "    index: lm.UpsertQuoteRequest(\n",
+    "        quote_id=lm.QuoteId(\n",
+    "            quote_series_id=lm.QuoteSeriesId(\n",
+    "                provider=market_supplier,\n",
+    "                instrument_id=row[\"Pair\"],\n",
+    "                instrument_id_type=\"CurrencyPair\",\n",
+    "                quote_type=\"Rate\",\n",
+    "                field=\"mid\",\n",
+    "            ),\n",
+    "            effective_at=row[\"Date\"].isoformat(),\n",
+    "        ),\n",
+    "        metric_value=lm.MetricValue(value=row[\"Rate\"], unit=row[\"Pair\"]),\n",
+    "    )\n",
+    "    for index, row in quotes_df.iterrows()\n",
+    "}\n",
+    "\n",
+    "# Upsert quotes into LUSID\n",
+    "response = quotes_api.upsert_quotes(\n",
+    "    scope=recipe_composer_scope, request_body=instrument_quotes\n",
+    ")\n",
+    "\n",
+    "if response.failed == {}:\n",
+    "    print(f\"Quotes successfully loaded into LUSID. {len(response.values)} quotes loaded.\")\n",
+    "else:\n",
+    "    print(f\"Some failures occurred during quotes upsertion, {len(response.failed)} did not get loaded into LUSID.\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-06T13:58:13.173230Z",
+     "start_time": "2024-03-06T13:58:12.867605Z"
+    }
+   },
+   "id": "f68857647a12417b"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "  InstrumentName    ClientInternal                 ModelName   Value\n0   myInstrument  EURUSDOptionDemo  ConstantTimeValueOfMoney -1.6181\n1            EUR              None  ConstantTimeValueOfMoney  1.5000",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>InstrumentName</th>\n      <th>ClientInternal</th>\n      <th>ModelName</th>\n      <th>Value</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>myInstrument</td>\n      <td>EURUSDOptionDemo</td>\n      <td>ConstantTimeValueOfMoney</td>\n      <td>-1.6181</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>EUR</td>\n      <td>None</td>\n      <td>ConstantTimeValueOfMoney</td>\n      <td>1.5000</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "metrics = [\n",
+    "    lm.AggregateSpec(\"Instrument/default/Name\", \"Value\"),\n",
+    "    lm.AggregateSpec(\"Instrument/default/ClientInternal\", \"Value\"),\n",
+    "    lm.AggregateSpec(\"Valuation/Model/Name\", \"Value\"),\n",
+    "    lm.AggregateSpec(\"Valuation/PV\", \"Value\"),\n",
+    "]\n",
+    "\n",
+    "valuation_request = lm.ValuationRequest(\n",
+    "    recipe_id=lm.ResourceId(scope=recipe_composer_scope, code=recipe_composer_code),\n",
+    "    metrics=metrics,\n",
+    "    group_by=[],\n",
+    "    portfolio_entity_ids=[\n",
+    "        lm.PortfolioEntityId(scope=scope, code=portfolio_code)\n",
+    "    ],\n",
+    "    valuation_schedule=lm.ValuationSchedule(\n",
+    "        effective_at = trade_date.isoformat(),\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "val_data = aggregation_api.get_valuation(valuation_request=valuation_request).data\n",
+    "\n",
+    "vals_df = pd.DataFrame(val_data)\n",
+    "\n",
+    "vals_df.rename(\n",
+    "    columns={\n",
+    "        \"Instrument/default/Name\" : \"InstrumentName\",\n",
+    "        \"Instrument/default/ClientInternal\" : \"ClientInternal\",\n",
+    "        \"Valuation/Model/Name\" : \"ModelName\",\n",
+    "        \"Valuation/PV\": \"Value\",\n",
+    "    },\n",
+    "    inplace=True,\n",
+    ")\n",
+    "\n",
+    "display(vals_df)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-06T13:58:16.871629Z",
+     "start_time": "2024-03-06T13:58:13.172232Z"
+    }
+   },
+   "id": "39ce823cb5103de9"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "As we can see above, using Recipe Composer in a Valuation can be done in the exactly same way as the Configuration Recipe is used. This is not just for Valuation, wherever a Configuration Recipe can be used so can a Recipe Composer."
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "864abdb3d15b97fc"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
# Pull Request Checklist

- [x] Changes follow the [style guide](https://github.com/finbourne/sample-notebooks/blob/master/docs/FINBOURNE%20notebook%20style%20guide.ipynb)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch
- [x] Notebook outputs do not contain any priviledged data

# Description of the PR
Demonstrating functionality of Recipe Composer and showing how it can be used in Valuation.
