### PR TITLE
ANA-3352: Updated the MBS Notebook to use BondLookupPricer

### DIFF
--- a/examples/use-cases/instruments/Mortgage Backed Securities.ipynb
+++ b/examples/use-cases/instruments/Mortgage Backed Securities.ipynb
@@ -103,7 +103,7 @@
      "output_type": "stream",
      "text": [
       "LUSID Environment Initialised\n",
-      "LUSID API Version : 0.6.11989.0\n"
+      "LUSID API Version : 0.6.12722.0\n"
      ]
     }
    ],
@@ -250,8 +250,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Portfolio \"TESTMBS/portfolio_2783\" created\n",
-      "Portfolio \"TESTMBS/portfolio_9400\" created\n"
+      "Portfolio \"TESTMBS/portfolio_52\" created\n",
+      "Portfolio \"TESTMBS/portfolio_8252\" created\n"
      ]
     },
     {
@@ -1304,7 +1304,7 @@
    "source": [
     "# 7. Valuations\n",
     "\n",
-    "In addition from querying future cashflows, we may want to value our portfolio on a daily basis using market quotes and obtain a daily P&L. To do that, we now move from the \"Constant Time Value of Money\" model into the \"Simple Static\" model.\n",
+    "In addition from querying future cashflows, we may want to value our portfolio on a daily basis using market quotes and obtain a daily P&L. To do that, we now move from the \"Constant Time Value of Money\" model into the \"Bond Lookup Pricer\" model.\n",
     "\n",
     "The first step is to define appropriate recipes and quote upserting functions."
    ]
@@ -1322,15 +1322,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "A important point to note is that Simple Static only accepts one quote (the price) for valuation. To represent correctly the latest MBS price, we need to include the latest known pool factor value as the scaling factor of the quote, as in the recipe below. This \"latest known pool factor\" doesn't need to be the accounting pool factor using at month end, it can be for example a market projection used during trading. \n",
-    "\n",
-    "In our example, we are setting a different number than any of the accounting factors used for the cashflow estimates, just for illustration purposes."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 24,
    "metadata": {},
@@ -1344,9 +1335,6 @@
     }
    ],
    "source": [
-    "# Use a market estimate of the pool factor as at the valuation date\n",
-    "latest_pool_factor = 0.094892\n",
-    "\n",
     "# Create quotes request\n",
     "instrument_quotes = {\n",
     "    index: lm.UpsertQuoteRequest(\n",
@@ -1361,7 +1349,7 @@
     "            effective_at=datetime.strptime(row[\"Date\"],\"%Y-%m-%d\").isoformat()+'Z',\n",
     "        ),\n",
     "        metric_value=lm.MetricValue(value=row[\"Price\"], unit=row[\"Currency\"]),\n",
-    "        scale_factor=100/(original_notional*latest_pool_factor),\n",
+    "        scale_factor=100,\n",
     "    )\n",
     "    for index, row in bond_quotes.iterrows()\n",
     "}\n",
@@ -1387,7 +1375,7 @@
    "outputs": [],
    "source": [
     "# Create a recipe to perform a valuation\n",
-    "recipe_code_for_simple_static = \"MBS_SIMPLE_STATIC\"\n",
+    "recipe_code_for_lookup_pricing = \"MBS_LOOKUP_PRICER\"\n",
     "\n",
     "quoted_price_key_rule = lm.MarketDataKeyRule(\n",
     "                key=\"Credit.ClientInternal.*\",\n",
@@ -1400,7 +1388,7 @@
     "\n",
     "configuration_recipe = lm.ConfigurationRecipe(\n",
     "    scope=scope,\n",
-    "    code=recipe_code_for_simple_static,\n",
+    "    code=recipe_code_for_lookup_pricing,\n",
     "    market=lm.MarketContext(\n",
     "        market_rules=[\n",
     "            pool_factor_data_rule,\n",
@@ -1416,7 +1404,7 @@
     "        model_rules=[\n",
     "            lm.VendorModelRule(\n",
     "                supplier=\"Lusid\",\n",
-    "                model_name=\"SimpleStatic\",\n",
+    "                model_name=\"BondLookupPricer\",\n",
     "                instrument_type=\"ComplexBond\",\n",
     "                parameters=\"{}\",\n",
     "            )\n",
@@ -1442,7 +1430,7 @@
     "def get_val(date, portfolio_code):\n",
     "\n",
     "    valuation_request = lm.ValuationRequest(\n",
-    "        recipe_id=lm.ResourceId(scope=scope, code=recipe_code_for_simple_static),\n",
+    "        recipe_id=lm.ResourceId(scope=scope, code=recipe_code_for_lookup_pricing),\n",
     "        metrics=[\n",
     "            lm.AggregateSpec(\"Instrument/default/Name\", \"Value\"),\n",
     "            lm.AggregateSpec(\"Instrument/default/ClientInternal\", \"Value\"),\n",
@@ -1522,13 +1510,13 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>380,079.59</td>\n",
+       "      <td>380,736.25</td>\n",
        "      <td>FED NATIONAL MTGE ASSOC 2014-33</td>\n",
        "      <td>US3136AKAD59</td>\n",
        "      <td>100.10</td>\n",
        "      <td>4.00</td>\n",
        "      <td>132.02</td>\n",
-       "      <td>405.97</td>\n",
+       "      <td>406.63</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -1546,11 +1534,11 @@
       ],
       "text/plain": [
        "   Present Value                   InstrumentName          ISIN  Quotes/Price  \\\n",
-       "0     380,079.59  FED NATIONAL MTGE ASSOC 2014-33  US3136AKAD59        100.10   \n",
+       "0     380,736.25  FED NATIONAL MTGE ASSOC 2014-33  US3136AKAD59        100.10   \n",
        "1    -400,000.00                              USD          None           NaN   \n",
        "\n",
        "   Holding/default/Units  Accrued Interest  PnL (1-day)  \n",
-       "0                   4.00            132.02       405.97  \n",
+       "0                   4.00            132.02       406.63  \n",
        "1            -400,000.00              0.00         0.00  "
       ]
      },
@@ -1571,8 +1559,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Portfolio \"TESTMBS/portfolio_2783\" deleted\n",
-      "Portfolio \"TESTMBS/portfolio_9400\" deleted\n"
+      "Portfolio \"TESTMBS/portfolio_52\" deleted\n",
+      "Portfolio \"TESTMBS/portfolio_8252\" deleted\n"
      ]
     },
     {


### PR DESCRIPTION
# Pull Request Checklist

- [x] Changes follow the [style guide](https://github.com/finbourne/sample-notebooks/blob/master/docs/FINBOURNE%20notebook%20style%20guide.ipynb)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch
- [x] Notebook outputs do not contain any priviledged data

# Description of the PR

The strategic pricer for bonds in LUSID going forward is the `BondLookupPricer`. This PR updates the MBS example notebook to use the strategic pricer.