### PR TITLE
ANA-3429: Added Total Return Swap pricing with reference instrument notebook

### DIFF
--- a/examples/use-cases/valuation/Total Return Swap Pricing With Reference Instrument.ipynb
+++ b/examples/use-cases/valuation/Total Return Swap Pricing With Reference Instrument.ipynb
@@ -32,8 +32,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-03-12T14:27:26.483406Z",
-     "start_time": "2024-03-12T14:27:19.614467Z"
+     "end_time": "2024-03-13T15:26:25.694975Z",
+     "start_time": "2024-03-13T15:26:20.701665Z"
     }
    },
    "id": "707e7707c87a6ea2"
@@ -57,7 +57,7 @@
      "output_type": "stream",
      "text": [
       "LUSID Environment Initialised\n",
-      "LUSID SDK Version:  0.6.12724.0\n"
+      "LUSID SDK Version:  0.6.12731.0\n"
      ]
     }
    ],
@@ -74,7 +74,7 @@
     "\n",
     "\n",
     "# Authenticate our user and create our API client\n",
-    "secrets_path = os.getenv(\"FBN_SECRETS_PATH\")\n",
+    "secrets_path =  os.getenv(\"FBN_SECRETS_PATH\")\n",
     "\n",
     "# Initiate an API Factory which is the client side object for interacting with LUSID APIs\n",
     "api_factory = lusid.utilities.ApiClientFactory(\n",
@@ -97,8 +97,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-03-12T14:27:27.798802Z",
-     "start_time": "2024-03-12T14:27:26.481696Z"
+     "end_time": "2024-03-13T15:26:27.205403Z",
+     "start_time": "2024-03-13T15:26:25.694127Z"
     }
    },
    "id": "381e2ac63f3b696a"
@@ -124,8 +124,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-03-12T14:27:27.799210Z",
-     "start_time": "2024-03-12T14:27:27.795959Z"
+     "end_time": "2024-03-13T15:26:27.206029Z",
+     "start_time": "2024-03-13T15:26:27.202954Z"
     }
    },
    "id": "384429388f3ae588"
@@ -175,8 +175,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-03-12T14:27:28.135132Z",
-     "start_time": "2024-03-12T14:27:27.799476Z"
+     "end_time": "2024-03-13T15:26:27.497883Z",
+     "start_time": "2024-03-13T15:26:27.207170Z"
     }
    },
    "id": "d56123295914f9d7"
@@ -241,8 +241,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-03-12T14:27:28.318381Z",
-     "start_time": "2024-03-12T14:27:28.137356Z"
+     "end_time": "2024-03-13T15:26:27.665489Z",
+     "start_time": "2024-03-13T15:26:27.499457Z"
     }
    },
    "id": "344eaa14e341de72"
@@ -283,8 +283,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-03-12T14:27:28.331613Z",
-     "start_time": "2024-03-12T14:27:28.321337Z"
+     "end_time": "2024-03-13T15:26:27.670934Z",
+     "start_time": "2024-03-13T15:26:27.666646Z"
     }
    },
    "id": "15d1c970dde50a88"
@@ -319,8 +319,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-03-12T14:27:28.511322Z",
-     "start_time": "2024-03-12T14:27:28.325938Z"
+     "end_time": "2024-03-13T15:26:27.877812Z",
+     "start_time": "2024-03-13T15:26:27.669363Z"
     }
    },
    "id": "bc38309c483738fc"
@@ -354,8 +354,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-03-12T14:27:28.665787Z",
-     "start_time": "2024-03-12T14:27:28.515432Z"
+     "end_time": "2024-03-13T15:26:27.961818Z",
+     "start_time": "2024-03-13T15:26:27.877873Z"
     }
    },
    "id": "c7c9a8bdf59cb130"
@@ -378,7 +378,7 @@
     "\n",
     "txn_ref = lusid.TransactionRequest(\n",
     "    transaction_id= trs_ref_id,\n",
-    "    type=\"Buy\",\n",
+    "    type=\"StockIn\",\n",
     "    instrument_identifiers={\"Instrument/default/ClientInternal\": trs_ref_id},\n",
     "    transaction_date=trade_date.isoformat(),\n",
     "    settlement_date=(trade_date + timedelta(days = 2)).isoformat(),\n",
@@ -390,7 +390,7 @@
     ")\n",
     "txn_bond = lusid.TransactionRequest(\n",
     "    transaction_id= trs_bond_id,\n",
-    "    type=\"Buy\",\n",
+    "    type=\"StockIn\",\n",
     "    instrument_identifiers={\"Instrument/default/ClientInternal\": trs_bond_id},\n",
     "    transaction_date=trade_date.isoformat(),\n",
     "    settlement_date=(trade_date + timedelta(days = 2)).isoformat(),\n",
@@ -407,8 +407,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-03-12T14:27:29.328953Z",
-     "start_time": "2024-03-12T14:27:28.673144Z"
+     "end_time": "2024-03-13T15:26:30.635981Z",
+     "start_time": "2024-03-13T15:26:27.963551Z"
     }
    },
    "id": "4c47363f43ae4ce6"
@@ -429,56 +429,57 @@
    "outputs": [],
    "source": [
     "market_supplier = \"Lusid\"\n",
-    "recipe = models.ConfigurationRecipe(\n",
-    "    scope=scope,\n",
-    "    code=code,\n",
-    "    description=\"Price bond using discounting model\",\n",
-    "    market=lusid.MarketContext(\n",
-    "        market_rules=[\n",
-    "            lusid.MarketDataKeyRule(\n",
-    "                key=\"Rates.*.*\",\n",
-    "                supplier=market_supplier,\n",
-    "                data_scope=\"default\",\n",
-    "                price_source=market_supplier,\n",
-    "                quote_type=\"Price\",\n",
-    "                field=\"mid\",\n",
-    "                quote_interval=\"100D\",\n",
+    "def create_recipe(recipe_code, produce_separate_result_for_linear_otc_legs):\n",
+    "    recipe =  models.ConfigurationRecipe(\n",
+    "        scope=scope,\n",
+    "        code=recipe_code,\n",
+    "        description=\"Price bond using discounting model\",\n",
+    "        market=lusid.MarketContext(\n",
+    "            market_rules=[\n",
+    "                lusid.MarketDataKeyRule(\n",
+    "                    key=\"Rates.*.*\",\n",
+    "                    supplier=market_supplier,\n",
+    "                    data_scope=\"default\",\n",
+    "                    price_source=market_supplier,\n",
+    "                    quote_type=\"Price\",\n",
+    "                    field=\"mid\",\n",
+    "                    quote_interval=\"100D\",\n",
+    "                ),\n",
+    "            ],\n",
+    "            options=lusid.MarketOptions(\n",
+    "                default_scope = scope,\n",
+    "                attempt_to_infer_missing_fx=True\n",
     "            ),\n",
-    "        ],\n",
-    "        options=lusid.MarketOptions(\n",
-    "            default_scope = scope,\n",
-    "            attempt_to_infer_missing_fx=True\n",
     "        ),\n",
-    "    ),\n",
-    "    pricing=models.PricingContext(\n",
-    "        # select the \"Discounting\" model for bond pricing\n",
-    "        model_rules=[\n",
-    "            models.VendorModelRule(\n",
-    "                supplier=\"Lusid\",\n",
-    "                model_name=\"ConstantTimeValueOfMoney\",\n",
-    "                instrument_type=\"Bond\",\n",
-    "                parameters=\"{}\"\n",
-    "            ),\n",
-    "            models.VendorModelRule(\n",
-    "                supplier=\"Lusid\",\n",
-    "                model_name=\"ConstantTimeValueOfMoney\",\n",
-    "                instrument_type=\"FixedLeg\",\n",
-    "                parameters=\"{}\"\n",
-    "            ),\n",
-    "        ],\n",
-    "        options=models.PricingOptions(model_selection=models.ModelSelection(library=\"Lusid\", model=\"ConstantTimeValueOfMoney\"))\n",
+    "        pricing=models.PricingContext(\n",
+    "            # select the \"Discounting\" model for bond pricing\n",
+    "            model_rules=[\n",
+    "                models.VendorModelRule(\n",
+    "                    supplier=\"Lusid\",\n",
+    "                    model_name=\"ConstantTimeValueOfMoney\",\n",
+    "                    instrument_type=\"Bond\",\n",
+    "                    parameters=\"{}\"\n",
+    "                ),\n",
+    "                models.VendorModelRule(\n",
+    "                    supplier=\"Lusid\",\n",
+    "                    model_name=\"ConstantTimeValueOfMoney\",\n",
+    "                    instrument_type=\"FixedLeg\",\n",
+    "                    parameters=\"{}\"\n",
+    "                ),\n",
+    "            ],\n",
+    "            options=models.PricingOptions(produce_separate_result_for_linear_otc_legs= produce_separate_result_for_linear_otc_legs, model_selection=models.ModelSelection(library=\"Lusid\", model=\"ConstantTimeValueOfMoney\"))\n",
+    "        )\n",
     "    )\n",
-    ")\n",
-    "\n",
-    "# Upsert recipe to LUSID\n",
-    "upsert_recipe_request = models.UpsertRecipeRequest(configuration_recipe=recipe)\n",
-    "response = api_factory.build(lusid.api.ConfigurationRecipeApi).upsert_configuration_recipe(upsert_recipe_request)"
+    "    \n",
+    "    # Upsert recipe to LUSID\n",
+    "    upsert_recipe_request = models.UpsertRecipeRequest(configuration_recipe=recipe)\n",
+    "    return api_factory.build(lusid.api.ConfigurationRecipeApi).upsert_configuration_recipe(upsert_recipe_request)\n"
    ],
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-03-12T14:27:29.540515Z",
-     "start_time": "2024-03-12T14:27:29.339569Z"
+     "end_time": "2024-03-13T15:26:30.643230Z",
+     "start_time": "2024-03-13T15:26:30.633048Z"
     }
    },
    "id": "ff73181e6cbd5b1e"
@@ -497,28 +498,23 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "outputs": [
-    {
-     "data": {
-      "text/plain": "   Valuation/PV/Amount Instrument/default/Name  Valuation/InstrumentAccrued\n0           -865.19863       MyTRSWithRefInstr                     2.054795\n1           -865.19863     MyTRSWithBondInline                     2.054795",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>Valuation/PV/Amount</th>\n      <th>Instrument/default/Name</th>\n      <th>Valuation/InstrumentAccrued</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>-865.19863</td>\n      <td>MyTRSWithRefInstr</td>\n      <td>2.054795</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>-865.19863</td>\n      <td>MyTRSWithBondInline</td>\n      <td>2.054795</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "def run_valuation(date):\n",
+    "def run_valuation(date, recipe_code, show_leg_ids):\n",
     "    metrics = [\n",
+    "        lusid.AggregateSpec(\"Instrument/default/LusidInstrumentId\", \"Value\"),\n",
     "        lusid.AggregateSpec(\"Instrument/default/Name\", \"Value\"),\n",
     "        lusid.AggregateSpec(\"Valuation/PV/Amount\", \"Value\"),\n",
-    "        lusid.AggregateSpec(\"Valuation/InstrumentAccrued\", \"Value\")\n",
+    "        lusid.AggregateSpec(\"Instrument/InstrumentType\", \"Value\")\n",
     "    ]\n",
+    "    \n",
+    "    if show_leg_ids:\n",
+    "        metrics.append(lusid.AggregateSpec(\"Valuation/LegIdentifier\", \"Value\"))\n",
     "\n",
     "    group_by = []\n",
     "\n",
     "    valuation_request = lusid.ValuationRequest(\n",
-    "        recipe_id=lusid.ResourceId(scope=scope, code=code),\n",
+    "        recipe_id=lusid.ResourceId(scope=scope, code=recipe_code),\n",
     "        metrics=metrics,\n",
     "        group_by=group_by,\n",
     "        portfolio_entity_ids=[\n",
@@ -534,19 +530,75 @@
     "    vals_df.fillna(\"\", inplace=True)\n",
     "\n",
     "    return vals_df\n",
-    "\n",
     "pricing_date = trade_date + timedelta(weeks=52)\n",
-    "valuation = run_valuation(pricing_date.isoformat())\n",
-    "display(valuation.head(2))"
+    "pricing_date_string = pricing_date.isoformat()"
    ],
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-03-12T14:27:31.219154Z",
-     "start_time": "2024-03-12T14:27:29.549851Z"
+     "end_time": "2024-03-13T15:26:30.651340Z",
+     "start_time": "2024-03-13T15:26:30.644114Z"
     }
    },
    "id": "3edf9d400685591f"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "   Valuation/PV/Amount Instrument/default/LusidInstrumentId  \\\n0           530.246575                        LUID_000A8TCY   \n1         -1397.500000                        LUID_000A8TCY   \n2           530.246575                        LUID_000A8TCZ   \n3         -1397.500000                        LUID_000A8TCZ   \n\n  Instrument/default/Name Instrument/InstrumentType Valuation/LegIdentifier  \n0       MyTRSWithRefInstr           TotalReturnSwap                AssetLeg  \n1       MyTRSWithRefInstr           TotalReturnSwap              FundingLeg  \n2     MyTRSWithBondInline           TotalReturnSwap                AssetLeg  \n3     MyTRSWithBondInline           TotalReturnSwap              FundingLeg  ",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>Valuation/PV/Amount</th>\n      <th>Instrument/default/LusidInstrumentId</th>\n      <th>Instrument/default/Name</th>\n      <th>Instrument/InstrumentType</th>\n      <th>Valuation/LegIdentifier</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>530.246575</td>\n      <td>LUID_000A8TCY</td>\n      <td>MyTRSWithRefInstr</td>\n      <td>TotalReturnSwap</td>\n      <td>AssetLeg</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>-1397.500000</td>\n      <td>LUID_000A8TCY</td>\n      <td>MyTRSWithRefInstr</td>\n      <td>TotalReturnSwap</td>\n      <td>FundingLeg</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>530.246575</td>\n      <td>LUID_000A8TCZ</td>\n      <td>MyTRSWithBondInline</td>\n      <td>TotalReturnSwap</td>\n      <td>AssetLeg</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>-1397.500000</td>\n      <td>LUID_000A8TCZ</td>\n      <td>MyTRSWithBondInline</td>\n      <td>TotalReturnSwap</td>\n      <td>FundingLeg</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Valuation with produce_separate_result_for_linear_otc_legs = True\n",
+    "recipe_code_legs = \"recipe_with_produce_separate_result\"\n",
+    "create_recipe(recipe_code_legs, True)\n",
+    "valuation_with_legs = run_valuation(pricing_date_string, recipe_code_legs, True)\n",
+    "display(valuation_with_legs)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-13T15:26:34.568554Z",
+     "start_time": "2024-03-13T15:26:30.648481Z"
+    }
+   },
+   "id": "f331d83c5059e515"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "   Valuation/PV/Amount Instrument/default/LusidInstrumentId  \\\n0           -865.19863                        LUID_000A8TCY   \n1           -865.19863                        LUID_000A8TCZ   \n\n  Instrument/default/Name Instrument/InstrumentType  \n0       MyTRSWithRefInstr           TotalReturnSwap  \n1     MyTRSWithBondInline           TotalReturnSwap  ",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>Valuation/PV/Amount</th>\n      <th>Instrument/default/LusidInstrumentId</th>\n      <th>Instrument/default/Name</th>\n      <th>Instrument/InstrumentType</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>-865.19863</td>\n      <td>LUID_000A8TCY</td>\n      <td>MyTRSWithRefInstr</td>\n      <td>TotalReturnSwap</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>-865.19863</td>\n      <td>LUID_000A8TCZ</td>\n      <td>MyTRSWithBondInline</td>\n      <td>TotalReturnSwap</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Valuation without produce_separate_result_for_linear_otc_legs = True\n",
+    "recipe_code_no_legs = \"recipe_without_produce_separate_result\"\n",
+    "create_recipe(recipe_code_no_legs, False)\n",
+    "valuation_without_legs = run_valuation(pricing_date_string, recipe_code_no_legs, False)\n",
+    "display(valuation_without_legs)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-13T15:26:36.424612Z",
+     "start_time": "2024-03-13T15:26:34.566021Z"
+    }
+   },
+   "id": "783a0c6924f077df"
   }
  ],
  "metadata": {

--- a/examples/use-cases/valuation/Total Return Swap Pricing With Reference Instrument.ipynb
+++ b/examples/use-cases/valuation/Total Return Swap Pricing With Reference Instrument.ipynb
@@ -1,0 +1,527 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 117,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "<IPython.core.display.HTML object>",
+      "text/html": "\n    <form action=\"javascript:code_toggle()\"><input type=\"submit\" id=\"toggleButton\" value=\"Hide docstring\"></form>\n    \n         <script>\n         function code_toggle() {\n             if ($('div.cell.code_cell.rendered.selected div.input').css('display')!='none'){\n                 $('div.cell.code_cell.rendered.selected div.input').hide();\n             } else {\n                 $('div.cell.code_cell.rendered.selected div.input').show();\n             }\n         }\n         </script>\n\n     "
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from lusidtools.jupyter_tools import toggle_code\n",
+    "\n",
+    "\"\"\"Total Return Swap Pricing With Reference Instrument\n",
+    "\n",
+    "Demonstrates pricing of an Total Return Swap with AssetLeg having the ReferenceInstrument as underlying.\n",
+    "\n",
+    "Attributes\n",
+    "----------\n",
+    "instruments\n",
+    "valuation\n",
+    "reference-instrument\n",
+    "\"\"\"\n",
+    "\n",
+    "toggle_code(\"Hide docstring\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-12T11:38:14.093360Z",
+     "start_time": "2024-03-12T11:38:14.048293Z"
+    }
+   },
+   "id": "707e7707c87a6ea2"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Setup LUSID and LUSID API objects."
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "cc1054789e670651"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 118,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LUSID Environment Initialised\n",
+      "LUSID SDK Version:  0.6.12724.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "from datetime import datetime, timedelta\n",
+    "import lusid\n",
+    "import json\n",
+    "import pandas as pd\n",
+    "import pytz\n",
+    "from lusid import models\n",
+    "from lusid.utilities import ApiClientFactory\n",
+    "from lusidjam import RefreshingToken\n",
+    "\n",
+    "\n",
+    "# Authenticate our user and create our API client\n",
+    "secrets_path = os.getenv(\"FBN_SECRETS_PATH\")\n",
+    "\n",
+    "# Initiate an API Factory which is the client side object for interacting with LUSID APIs\n",
+    "api_factory = lusid.utilities.ApiClientFactory(\n",
+    "    token=RefreshingToken(),\n",
+    "    api_secrets_filename=secrets_path,\n",
+    "    app_name=\"LusidJupyterNotebook\",\n",
+    ")\n",
+    "\n",
+    "print ('LUSID Environment Initialised')\n",
+    "print ('LUSID SDK Version: ', api_factory.build(lusid.api.ApplicationMetadataApi).get_lusid_versions().build_version)\n",
+    "\n",
+    "# Setup the apis we'll use in this notebook:\n",
+    "instruments_api = api_factory.build(lusid.api.InstrumentsApi)\n",
+    "complex_market_data_api = api_factory.build(lusid.api.ComplexMarketDataApi)\n",
+    "structured_result_data_api = api_factory.build(lusid.api.StructuredResultDataApi)\n",
+    "transaction_portfolios_api = api_factory.build(lusid.api.TransactionPortfoliosApi)\n",
+    "aggregation_api = api_factory.build(lusid.api.AggregationApi)\n",
+    "\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-12T11:38:15.441453Z",
+     "start_time": "2024-03-12T11:38:14.093059Z"
+    }
+   },
+   "id": "381e2ac63f3b696a"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 119,
+   "outputs": [],
+   "source": [
+    "# Setup the scope we'll use in this notebook:\n",
+    "scope = \"trs-pricing-scope\"\n",
+    "code = \"trs-pricing-code\"\n",
+    "\n",
+    "coupon_rate = 0.015\n",
+    "start_date = datetime(2016, 9, 21, tzinfo=pytz.utc)\n",
+    "maturity_date = datetime(2047, 7, 22, tzinfo=pytz.utc)\n",
+    "dom_ccy = \"GBP\"\n",
+    "face_value = 1000\n",
+    "\n",
+    "trade_date = datetime(2020, 6, 22, tzinfo=pytz.utc)\n",
+    "effective_at = datetime(2020, 6, 23, tzinfo=pytz.utc)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-12T11:38:15.442040Z",
+     "start_time": "2024-03-12T11:38:15.437390Z"
+    }
+   },
+   "id": "384429388f3ae588"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Creating portfolio\n",
+    "We start by creating a portfolio which will consist of TotalReturnSwap only."
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "31bbaab26df540e3"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 120,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Portfolio with this id already exists.\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    transaction_portfolios_api.create_portfolio(\n",
+    "        scope=scope,\n",
+    "        create_transaction_portfolio_request=lusid.CreateTransactionPortfolioRequest(\n",
+    "            display_name=code,\n",
+    "            code=code,\n",
+    "            base_currency=dom_ccy,\n",
+    "            created=start_date,\n",
+    "            instrument_scopes=[scope]\n",
+    "        ),\n",
+    "    )\n",
+    "\n",
+    "except lusid.ApiException as e:\n",
+    "    if json.loads(e.body)['name'] == \"PortfolioWithIdAlreadyExists\":\n",
+    "        print(\"Portfolio with this id already exists.\")\n",
+    "    else:\n",
+    "        raise e"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-12T11:38:16.959285Z",
+     "start_time": "2024-03-12T11:38:15.440255Z"
+    }
+   },
+   "id": "d56123295914f9d7"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Creating Instruments\n",
+    "A TotalReturnSwap is mainly composed of 2 parts, the AssetLeg and the FundingLeg. The AssetLeg is composed of direction (Pay/Receive) and the underlying instrument, that instrument could be inline definition of a Bond or ComplexBond or a ReferenceInstrument referencing already upserted Bond or ComplexBond. The second part is the FundingLeg which has to be either FixedLeg instrument or FloatLeg instrument inline.\n",
+    "\n",
+    "One can insert a definition of a Bond or ComplexBond into TotalReturnSwap's AssetLeg directly without upserting it first, this is fairly common across Lusid. Upserting a ReferenceInstrument instead that references already existing instrument is new however and this is what will be focused on here. To do this, we will first upsert a Bond and then create a ReferenceInstrument that will point to it."
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "c034f69ca946a00"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 121,
+   "outputs": [],
+   "source": [
+    "# Create and upsert a bond\n",
+    "bond_definition = models.Bond(\n",
+    "    start_date=start_date.isoformat(),\n",
+    "    maturity_date=maturity_date.isoformat(),\n",
+    "    dom_ccy=dom_ccy,\n",
+    "    coupon_rate=coupon_rate,\n",
+    "    principal=face_value,\n",
+    "    flow_conventions=models.FlowConventions(\n",
+    "        # coupon payment currency\n",
+    "        currency=\"GBP\",\n",
+    "        # semi-annual coupon payments\n",
+    "        payment_frequency= \"6M\",\n",
+    "        # using an Actual/365 day count convention (other options : Act360, ActAct, ...\n",
+    "        day_count_convention=\"Act365\",\n",
+    "        # modified following rolling convention (other options : ModifiedPrevious, NoAdjustment, EndOfMonth,...)\n",
+    "        roll_convention=\"ModifiedFollowing\",\n",
+    "        # no holiday calendar supplied\n",
+    "        payment_calendars=[],\n",
+    "        reset_calendars=[],\n",
+    "        settle_days=2,\n",
+    "        reset_days=2,\n",
+    "    ),\n",
+    "    identifiers={},\n",
+    "    instrument_type=\"Bond\"\n",
+    ")\n",
+    "bond_id = \"gilt2047s\"\n",
+    "bond_upsert = instruments_api.upsert_instruments(request_body={bond_id: models.InstrumentDefinition(\n",
+    "    # instrument display name\n",
+    "    name=\"gilt 1.5% 47s\",\n",
+    "    # unique instrument identifier\n",
+    "    identifiers={\"ClientInternal\": models.InstrumentIdValue(bond_id)},\n",
+    "    # our gilt instrument definition\n",
+    "    definition=bond_definition\n",
+    ")})\n",
+    "bond_luid = bond_upsert.values[bond_id].lusid_instrument_id\n",
+    "\n",
+    "# Create ReferenceInstrument that points to the already upserted Bond.\n",
+    "reference_instrument = lusid.ReferenceInstrument(instrument_id=bond_id, scope=\"default\", instrument_id_type=\"ClientInternal\", instrument_type=\"ReferenceInstrument\")\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-12T11:38:17.347977Z",
+     "start_time": "2024-03-12T11:38:16.957888Z"
+    }
+   },
+   "id": "344eaa14e341de72"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 122,
+   "outputs": [],
+   "source": [
+    "# Create a FixedLeg for the TotalReturnSwap\n",
+    "flow_conv = lusid.FlowConventions(\n",
+    "    currency=dom_ccy,\n",
+    "    payment_frequency=\"6M\",\n",
+    "    day_count_convention=\"Act365\",\n",
+    "    roll_convention=\"ModifiedFollowing\",\n",
+    "    payment_calendars=[],\n",
+    "    reset_calendars=[],\n",
+    "    settle_days=0,\n",
+    "    reset_days=0\n",
+    ")\n",
+    "\n",
+    "fixed_leg_definition = lusid.LegDefinition(\n",
+    "    rate_or_spread=0.02,\n",
+    "    pay_receive=\"Receive\",\n",
+    "    conventions=flow_conv,\n",
+    "    stub_type=\"ShortFront\",\n",
+    "    notional_exchange_type=\"None\"\n",
+    ")\n",
+    "\n",
+    "fixed_leg = lusid.FixedLeg(\n",
+    "    start_date=start_date,\n",
+    "    maturity_date=maturity_date,\n",
+    "    notional=2*face_value,\n",
+    "    leg_definition=fixed_leg_definition,\n",
+    "    instrument_type=\"FixedLeg\"\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-12T11:38:17.353994Z",
+     "start_time": "2024-03-12T11:38:17.349357Z"
+    }
+   },
+   "id": "15d1c970dde50a88"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 123,
+   "outputs": [],
+   "source": [
+    "# Create and upsert TRS\n",
+    "trs_definition = lusid.TotalReturnSwap(\n",
+    "    start_date=start_date,\n",
+    "    maturity_date=maturity_date,\n",
+    "    asset_leg=lusid.AssetLeg(pay_receive=\"Pay\", asset=reference_instrument),\n",
+    "    instrument_type=\"TotalReturnSwap\",\n",
+    "    funding_leg=fixed_leg\n",
+    ")\n",
+    "trs_id = \"gilt2047sTrs\"\n",
+    "trs_upsert = instruments_api.upsert_instruments(\n",
+    "    {\n",
+    "        trs_id: models.InstrumentDefinition(\n",
+    "        # instrument display name\n",
+    "        name=\"MyTRS\",\n",
+    "        # unique instrument identifier\n",
+    "        identifiers={\"ClientInternal\": models.InstrumentIdValue(trs_id)},\n",
+    "        # our gilt instrument definition\n",
+    "        definition=trs_definition\n",
+    "    )})\n",
+    "\n",
+    "    "
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-12T11:38:17.449506Z",
+     "start_time": "2024-03-12T11:38:17.352636Z"
+    }
+   },
+   "id": "bc38309c483738fc"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Creating Transaction"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "bd5224fd2adb2586"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 124,
+   "outputs": [],
+   "source": [
+    "\n",
+    "txn = lusid.TransactionRequest(\n",
+    "    transaction_id= trs_id,\n",
+    "    type=\"Buy\",\n",
+    "    instrument_identifiers={\"Instrument/default/ClientInternal\": trs_id},\n",
+    "    transaction_date=trade_date.isoformat(),\n",
+    "    settlement_date=(trade_date + timedelta(days = 2)).isoformat(),\n",
+    "    units=1,\n",
+    "    transaction_price=lusid.TransactionPrice(price=1,type=\"Price\"),\n",
+    "    total_consideration=lusid.CurrencyAndAmount(amount=1,currency=dom_ccy),\n",
+    "    exchange_rate=1,\n",
+    "    transaction_currency=dom_ccy\n",
+    ")\n",
+    "\n",
+    "upsert_txn = transaction_portfolios_api.upsert_transactions(scope=scope,\n",
+    "                                                          code=code,\n",
+    "                                                          transaction_request=[txn])"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-12T11:38:19.921189Z",
+     "start_time": "2024-03-12T11:38:17.451505Z"
+    }
+   },
+   "id": "4c47363f43ae4ce6"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Creating ConfigurationRecipe"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "5341463e6737cb07"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 125,
+   "outputs": [],
+   "source": [
+    "market_supplier = \"Lusid\"\n",
+    "recipe = models.ConfigurationRecipe(\n",
+    "    scope=scope,\n",
+    "    code=code,\n",
+    "    description=\"Price bond using discounting model\",\n",
+    "    market=lusid.MarketContext(\n",
+    "        market_rules=[\n",
+    "            lusid.MarketDataKeyRule(\n",
+    "                key=\"Rates.*.*\",\n",
+    "                supplier=market_supplier,\n",
+    "                data_scope=\"default\",\n",
+    "                price_source=market_supplier,\n",
+    "                quote_type=\"Price\",\n",
+    "                field=\"mid\",\n",
+    "                quote_interval=\"100D\",\n",
+    "            ),\n",
+    "        ],\n",
+    "        options=lusid.MarketOptions(\n",
+    "            default_scope = scope,\n",
+    "            attempt_to_infer_missing_fx=True\n",
+    "        ),\n",
+    "    ),\n",
+    "    pricing=models.PricingContext(\n",
+    "        # select the \"Discounting\" model for bond pricing\n",
+    "        model_rules=[\n",
+    "            models.VendorModelRule(\n",
+    "                supplier=\"Lusid\",\n",
+    "                model_name=\"ConstantTimeValueOfMoney\",\n",
+    "                instrument_type=\"Bond\",\n",
+    "                parameters=\"{}\"\n",
+    "            ),\n",
+    "            models.VendorModelRule(\n",
+    "                supplier=\"Lusid\",\n",
+    "                model_name=\"ConstantTimeValueOfMoney\",\n",
+    "                instrument_type=\"FixedLeg\",\n",
+    "                parameters=\"{}\"\n",
+    "            ),\n",
+    "        ],\n",
+    "        options=models.PricingOptions(model_selection=models.ModelSelection(library=\"Lusid\", model=\"ConstantTimeValueOfMoney\"))\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "# Upsert recipe to LUSID\n",
+    "upsert_recipe_request = models.UpsertRecipeRequest(configuration_recipe=recipe)\n",
+    "response = api_factory.build(lusid.api.ConfigurationRecipeApi).upsert_configuration_recipe(upsert_recipe_request)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-12T11:38:20.131152Z",
+     "start_time": "2024-03-12T11:38:19.924349Z"
+    }
+   },
+   "id": "ff73181e6cbd5b1e"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Performing valuation\n",
+    "Now that we have a portfolio with valid TotalReturnSwap we can perform a valuation on it. The ReferenceInstrument will be resolved automatically."
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "42f1de350ea5cc8b"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 126,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "   Valuation/PV/Amount Instrument/default/Name  Valuation/InstrumentAccrued\n0           -865.19863                   MyTRS                     2.054795",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>Valuation/PV/Amount</th>\n      <th>Instrument/default/Name</th>\n      <th>Valuation/InstrumentAccrued</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>-865.19863</td>\n      <td>MyTRS</td>\n      <td>2.054795</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def run_valuation(date):\n",
+    "    metrics = [\n",
+    "        lusid.AggregateSpec(\"Instrument/default/Name\", \"Value\"),\n",
+    "        lusid.AggregateSpec(\"Valuation/PV/Amount\", \"Value\"),\n",
+    "        lusid.AggregateSpec(\"Valuation/InstrumentAccrued\", \"Value\")\n",
+    "    ]\n",
+    "\n",
+    "    group_by = []\n",
+    "\n",
+    "    valuation_request = lusid.ValuationRequest(\n",
+    "        recipe_id=lusid.ResourceId(scope=scope, code=code),\n",
+    "        metrics=metrics,\n",
+    "        group_by=group_by,\n",
+    "        portfolio_entity_ids=[\n",
+    "            lusid.PortfolioEntityId(scope=scope, code=code)\n",
+    "        ],\n",
+    "        valuation_schedule=lusid.ValuationSchedule(effective_at=date),\n",
+    "    )\n",
+    "\n",
+    "    val_data = aggregation_api.get_valuation(valuation_request=valuation_request).data\n",
+    " \n",
+    "    vals_df = pd.DataFrame(val_data)\n",
+    "\n",
+    "    vals_df.fillna(\"\", inplace=True)\n",
+    "\n",
+    "    return vals_df\n",
+    "\n",
+    "pricing_date = trade_date + timedelta(weeks=52)\n",
+    "valuation = run_valuation(pricing_date.isoformat())\n",
+    "display(valuation.head(1))"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-12T11:38:24.242072Z",
+     "start_time": "2024-03-12T11:38:20.133369Z"
+    }
+   },
+   "id": "3edf9d400685591f"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/use-cases/valuation/Total Return Swap Pricing With Reference Instrument.ipynb
+++ b/examples/use-cases/valuation/Total Return Swap Pricing With Reference Instrument.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 117,
+   "execution_count": 1,
    "outputs": [
     {
      "data": {
@@ -32,8 +32,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-03-12T11:38:14.093360Z",
-     "start_time": "2024-03-12T11:38:14.048293Z"
+     "end_time": "2024-03-12T14:27:26.483406Z",
+     "start_time": "2024-03-12T14:27:19.614467Z"
     }
    },
    "id": "707e7707c87a6ea2"
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": 2,
    "outputs": [
     {
      "name": "stdout",
@@ -97,20 +97,20 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-03-12T11:38:15.441453Z",
-     "start_time": "2024-03-12T11:38:14.093059Z"
+     "end_time": "2024-03-12T14:27:27.798802Z",
+     "start_time": "2024-03-12T14:27:26.481696Z"
     }
    },
    "id": "381e2ac63f3b696a"
   },
   {
    "cell_type": "code",
-   "execution_count": 119,
+   "execution_count": 3,
    "outputs": [],
    "source": [
     "# Setup the scope we'll use in this notebook:\n",
-    "scope = \"trs-pricing-scope\"\n",
-    "code = \"trs-pricing-code\"\n",
+    "scope = \"trs-nb-pricing-scope\"\n",
+    "code = \"trs-nb-pricing-code\"\n",
     "\n",
     "coupon_rate = 0.015\n",
     "start_date = datetime(2016, 9, 21, tzinfo=pytz.utc)\n",
@@ -124,8 +124,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-03-12T11:38:15.442040Z",
-     "start_time": "2024-03-12T11:38:15.437390Z"
+     "end_time": "2024-03-12T14:27:27.799210Z",
+     "start_time": "2024-03-12T14:27:27.795959Z"
     }
    },
    "id": "384429388f3ae588"
@@ -143,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 120,
+   "execution_count": 4,
    "outputs": [
     {
      "name": "stdout",
@@ -175,8 +175,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-03-12T11:38:16.959285Z",
-     "start_time": "2024-03-12T11:38:15.440255Z"
+     "end_time": "2024-03-12T14:27:28.135132Z",
+     "start_time": "2024-03-12T14:27:27.799476Z"
     }
    },
    "id": "d56123295914f9d7"
@@ -187,7 +187,7 @@
     "## Creating Instruments\n",
     "A TotalReturnSwap is mainly composed of 2 parts, the AssetLeg and the FundingLeg. The AssetLeg is composed of direction (Pay/Receive) and the underlying instrument, that instrument could be inline definition of a Bond or ComplexBond or a ReferenceInstrument referencing already upserted Bond or ComplexBond. The second part is the FundingLeg which has to be either FixedLeg instrument or FloatLeg instrument inline.\n",
     "\n",
-    "One can insert a definition of a Bond or ComplexBond into TotalReturnSwap's AssetLeg directly without upserting it first, this is fairly common across Lusid. Upserting a ReferenceInstrument instead that references already existing instrument is new however and this is what will be focused on here. To do this, we will first upsert a Bond and then create a ReferenceInstrument that will point to it."
+    "One can insert a definition of a Bond or ComplexBond into TotalReturnSwap's AssetLeg directly without upserting it first, this is fairly common across Lusid. Upserting a ReferenceInstrument instead that references already existing instrument is new however. We will have a portfolio with two TRS instruments, one with AssetLeg having an underlying Bond inline and one with AssetLeg having an underlying with reference instrument referencing an already upserted Bond. To do this, we will first upsert a Bond and then create a ReferenceInstrument that will point to it."
    ],
    "metadata": {
     "collapsed": false
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 121,
+   "execution_count": 5,
    "outputs": [],
    "source": [
     "# Create and upsert a bond\n",
@@ -236,24 +236,24 @@
     "bond_luid = bond_upsert.values[bond_id].lusid_instrument_id\n",
     "\n",
     "# Create ReferenceInstrument that points to the already upserted Bond.\n",
-    "reference_instrument = lusid.ReferenceInstrument(instrument_id=bond_id, scope=\"default\", instrument_id_type=\"ClientInternal\", instrument_type=\"ReferenceInstrument\")\n"
+    "reference_instrument = models.ReferenceInstrument(instrument_id=bond_id, scope=\"default\", instrument_id_type=\"ClientInternal\", instrument_type=\"ReferenceInstrument\")\n"
    ],
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-03-12T11:38:17.347977Z",
-     "start_time": "2024-03-12T11:38:16.957888Z"
+     "end_time": "2024-03-12T14:27:28.318381Z",
+     "start_time": "2024-03-12T14:27:28.137356Z"
     }
    },
    "id": "344eaa14e341de72"
   },
   {
    "cell_type": "code",
-   "execution_count": 122,
+   "execution_count": 6,
    "outputs": [],
    "source": [
     "# Create a FixedLeg for the TotalReturnSwap\n",
-    "flow_conv = lusid.FlowConventions(\n",
+    "flow_conv = models.FlowConventions(\n",
     "    currency=dom_ccy,\n",
     "    payment_frequency=\"6M\",\n",
     "    day_count_convention=\"Act365\",\n",
@@ -264,7 +264,7 @@
     "    reset_days=0\n",
     ")\n",
     "\n",
-    "fixed_leg_definition = lusid.LegDefinition(\n",
+    "fixed_leg_definition = models.LegDefinition(\n",
     "    rate_or_spread=0.02,\n",
     "    pay_receive=\"Receive\",\n",
     "    conventions=flow_conv,\n",
@@ -272,10 +272,10 @@
     "    notional_exchange_type=\"None\"\n",
     ")\n",
     "\n",
-    "fixed_leg = lusid.FixedLeg(\n",
+    "fixed_leg = models.FixedLeg(\n",
     "    start_date=start_date,\n",
     "    maturity_date=maturity_date,\n",
-    "    notional=2*face_value,\n",
+    "    notional=face_value,\n",
     "    leg_definition=fixed_leg_definition,\n",
     "    instrument_type=\"FixedLeg\"\n",
     ")"
@@ -283,35 +283,35 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-03-12T11:38:17.353994Z",
-     "start_time": "2024-03-12T11:38:17.349357Z"
+     "end_time": "2024-03-12T14:27:28.331613Z",
+     "start_time": "2024-03-12T14:27:28.321337Z"
     }
    },
    "id": "15d1c970dde50a88"
   },
   {
    "cell_type": "code",
-   "execution_count": 123,
+   "execution_count": 7,
    "outputs": [],
    "source": [
-    "# Create and upsert TRS\n",
-    "trs_definition = lusid.TotalReturnSwap(\n",
+    "# Create and upsert TRS with Reference Instrument\n",
+    "trs_ref_definition = models.TotalReturnSwap(\n",
     "    start_date=start_date,\n",
     "    maturity_date=maturity_date,\n",
     "    asset_leg=lusid.AssetLeg(pay_receive=\"Pay\", asset=reference_instrument),\n",
     "    instrument_type=\"TotalReturnSwap\",\n",
     "    funding_leg=fixed_leg\n",
     ")\n",
-    "trs_id = \"gilt2047sTrs\"\n",
-    "trs_upsert = instruments_api.upsert_instruments(\n",
+    "trs_ref_id = \"gilt2047sTrsRefInstr\"\n",
+    "trs_ref_upsert = instruments_api.upsert_instruments(\n",
     "    {\n",
-    "        trs_id: models.InstrumentDefinition(\n",
+    "        trs_ref_id: models.InstrumentDefinition(\n",
     "        # instrument display name\n",
-    "        name=\"MyTRS\",\n",
+    "        name=\"MyTRSWithRefInstr\",\n",
     "        # unique instrument identifier\n",
-    "        identifiers={\"ClientInternal\": models.InstrumentIdValue(trs_id)},\n",
+    "        identifiers={\"ClientInternal\": models.InstrumentIdValue(trs_ref_id)},\n",
     "        # our gilt instrument definition\n",
-    "        definition=trs_definition\n",
+    "        definition=trs_ref_definition\n",
     "    )})\n",
     "\n",
     "    "
@@ -319,16 +319,51 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-03-12T11:38:17.449506Z",
-     "start_time": "2024-03-12T11:38:17.352636Z"
+     "end_time": "2024-03-12T14:27:28.511322Z",
+     "start_time": "2024-03-12T14:27:28.325938Z"
     }
    },
    "id": "bc38309c483738fc"
   },
   {
+   "cell_type": "code",
+   "execution_count": 8,
+   "outputs": [],
+   "source": [
+    "# Create and upsert TRS with Bond inline\n",
+    "trs_bond_definition = models.TotalReturnSwap(\n",
+    "    start_date=start_date,\n",
+    "    maturity_date=maturity_date,\n",
+    "    asset_leg=lusid.AssetLeg(pay_receive=\"Pay\", asset=bond_definition),\n",
+    "    instrument_type=\"TotalReturnSwap\",\n",
+    "    funding_leg=fixed_leg\n",
+    ")\n",
+    "trs_bond_id = \"gilt2047sTrsBondInline\"\n",
+    "trs_bond_upsert = instruments_api.upsert_instruments(\n",
+    "    {\n",
+    "        trs_bond_id: models.InstrumentDefinition(\n",
+    "            # instrument display name\n",
+    "            name=\"MyTRSWithBondInline\",\n",
+    "            # unique instrument identifier\n",
+    "            identifiers={\"ClientInternal\": models.InstrumentIdValue(trs_bond_id)},\n",
+    "            # our gilt instrument definition\n",
+    "            definition=trs_bond_definition\n",
+    "        )})\n",
+    "\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-03-12T14:27:28.665787Z",
+     "start_time": "2024-03-12T14:27:28.515432Z"
+    }
+   },
+   "id": "c7c9a8bdf59cb130"
+  },
+  {
    "cell_type": "markdown",
    "source": [
-    "## Creating Transaction"
+    "## Creating Transactions"
    ],
    "metadata": {
     "collapsed": false
@@ -337,14 +372,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": 9,
    "outputs": [],
    "source": [
     "\n",
-    "txn = lusid.TransactionRequest(\n",
-    "    transaction_id= trs_id,\n",
+    "txn_ref = lusid.TransactionRequest(\n",
+    "    transaction_id= trs_ref_id,\n",
     "    type=\"Buy\",\n",
-    "    instrument_identifiers={\"Instrument/default/ClientInternal\": trs_id},\n",
+    "    instrument_identifiers={\"Instrument/default/ClientInternal\": trs_ref_id},\n",
     "    transaction_date=trade_date.isoformat(),\n",
     "    settlement_date=(trade_date + timedelta(days = 2)).isoformat(),\n",
     "    units=1,\n",
@@ -353,16 +388,27 @@
     "    exchange_rate=1,\n",
     "    transaction_currency=dom_ccy\n",
     ")\n",
-    "\n",
+    "txn_bond = lusid.TransactionRequest(\n",
+    "    transaction_id= trs_bond_id,\n",
+    "    type=\"Buy\",\n",
+    "    instrument_identifiers={\"Instrument/default/ClientInternal\": trs_bond_id},\n",
+    "    transaction_date=trade_date.isoformat(),\n",
+    "    settlement_date=(trade_date + timedelta(days = 2)).isoformat(),\n",
+    "    units=1,\n",
+    "    transaction_price=lusid.TransactionPrice(price=1,type=\"Price\"),\n",
+    "    total_consideration=lusid.CurrencyAndAmount(amount=1,currency=dom_ccy),\n",
+    "    exchange_rate=1,\n",
+    "    transaction_currency=dom_ccy\n",
+    ")\n",
     "upsert_txn = transaction_portfolios_api.upsert_transactions(scope=scope,\n",
     "                                                          code=code,\n",
-    "                                                          transaction_request=[txn])"
+    "                                                          transaction_request=[txn_ref, txn_bond])"
    ],
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-03-12T11:38:19.921189Z",
-     "start_time": "2024-03-12T11:38:17.451505Z"
+     "end_time": "2024-03-12T14:27:29.328953Z",
+     "start_time": "2024-03-12T14:27:28.673144Z"
     }
    },
    "id": "4c47363f43ae4ce6"
@@ -379,7 +425,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 125,
+   "execution_count": 10,
    "outputs": [],
    "source": [
     "market_supplier = \"Lusid\"\n",
@@ -431,8 +477,8 @@
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-03-12T11:38:20.131152Z",
-     "start_time": "2024-03-12T11:38:19.924349Z"
+     "end_time": "2024-03-12T14:27:29.540515Z",
+     "start_time": "2024-03-12T14:27:29.339569Z"
     }
    },
    "id": "ff73181e6cbd5b1e"
@@ -450,12 +496,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 126,
+   "execution_count": 11,
    "outputs": [
     {
      "data": {
-      "text/plain": "   Valuation/PV/Amount Instrument/default/Name  Valuation/InstrumentAccrued\n0           -865.19863                   MyTRS                     2.054795",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>Valuation/PV/Amount</th>\n      <th>Instrument/default/Name</th>\n      <th>Valuation/InstrumentAccrued</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>-865.19863</td>\n      <td>MyTRS</td>\n      <td>2.054795</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/plain": "   Valuation/PV/Amount Instrument/default/Name  Valuation/InstrumentAccrued\n0           -865.19863       MyTRSWithRefInstr                     2.054795\n1           -865.19863     MyTRSWithBondInline                     2.054795",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>Valuation/PV/Amount</th>\n      <th>Instrument/default/Name</th>\n      <th>Valuation/InstrumentAccrued</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>-865.19863</td>\n      <td>MyTRSWithRefInstr</td>\n      <td>2.054795</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>-865.19863</td>\n      <td>MyTRSWithBondInline</td>\n      <td>2.054795</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
      "metadata": {},
      "output_type": "display_data"
@@ -491,13 +537,13 @@
     "\n",
     "pricing_date = trade_date + timedelta(weeks=52)\n",
     "valuation = run_valuation(pricing_date.isoformat())\n",
-    "display(valuation.head(1))"
+    "display(valuation.head(2))"
    ],
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-03-12T11:38:24.242072Z",
-     "start_time": "2024-03-12T11:38:20.133369Z"
+     "end_time": "2024-03-12T14:27:31.219154Z",
+     "start_time": "2024-03-12T14:27:29.549851Z"
     }
    },
    "id": "3edf9d400685591f"


### PR DESCRIPTION
# Pull Request Checklist

- [x] Changes follow the [style guide](https://github.com/finbourne/sample-notebooks/blob/master/docs/FINBOURNE%20notebook%20style%20guide.ipynb)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch
- [x] Notebook outputs do not contain any priviledged data

# Description of the PR
Added a notebook demonstrating pricing of TotalReturnSwap with AssetLeg's underlying being a ReferenceInstrument.