### PR TITLE
Fx Forward: use native instrument events for maturity

### DIFF
--- a/examples/use-cases/instruments/FX Forward.ipynb
+++ b/examples/use-cases/instruments/FX Forward.ipynb
@@ -2,11 +2,39 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:21:51.470407400Z",
+     "start_time": "2024-07-01T14:21:50.878173800Z"
+    },
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": "<IPython.core.display.HTML object>",
-      "text/html": "\n    <form action=\"javascript:code_toggle()\"><input type=\"submit\" id=\"toggleButton\" value=\"Toggle Docstring\"></form>\n    \n         <script>\n         function code_toggle() {\n             if ($('div.cell.code_cell.rendered.selected div.input').css('display')!='none'){\n                 $('div.cell.code_cell.rendered.selected div.input').hide();\n             } else {\n                 $('div.cell.code_cell.rendered.selected div.input').show();\n             }\n         }\n         </script>\n\n     "
+      "text/html": [
+       "\n",
+       "    <form action=\"javascript:code_toggle()\"><input type=\"submit\" id=\"toggleButton\" value=\"Toggle Docstring\"></form>\n",
+       "    \n",
+       "         <script>\n",
+       "         function code_toggle() {\n",
+       "             if ($('div.cell.code_cell.rendered.selected div.input').css('display')!='none'){\n",
+       "                 $('div.cell.code_cell.rendered.selected div.input').hide();\n",
+       "             } else {\n",
+       "                 $('div.cell.code_cell.rendered.selected div.input').show();\n",
+       "             }\n",
+       "         }\n",
+       "         </script>\n",
+       "\n",
+       "     "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -26,15 +54,7 @@
     "\"\"\"\n",
     "\n",
     "toggle_code(\"Toggle Docstring\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:04.757810Z",
-     "start_time": "2024-03-18T18:02:04.754769Z"
-    }
-   },
-   "execution_count": 3
+   ]
   },
   {
    "cell_type": "markdown",
@@ -56,11 +76,26 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:21:52.422667900Z",
+     "start_time": "2024-07-01T14:21:51.461409400Z"
+    },
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": "<IPython.core.display.HTML object>",
-      "text/html": "<style>.container { width:90% !important; }</style>"
+      "text/html": [
+       "<style>.container { width:90% !important; }</style>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -70,7 +105,7 @@
      "output_type": "stream",
      "text": [
       "LUSID Environment Initialised\n",
-      "LUSID API Version : 0.6.12757.0\n"
+      "LUSID API Version : 0.6.13212.0\n"
      ]
     }
    ],
@@ -115,18 +150,21 @@
     "\n",
     "print ('LUSID Environment Initialised')\n",
     "print ('LUSID API Version :', api_factory.build(lusid.api.ApplicationMetadataApi).get_lusid_versions().build_version)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:06.236917Z",
-     "start_time": "2024-03-18T18:02:04.951361Z"
-    }
-   },
-   "execution_count": 4
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:21:52.424665600Z",
+     "start_time": "2024-07-01T14:21:52.419658800Z"
+    },
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "# Set required APIs\n",
@@ -137,35 +175,42 @@
     "configuration_recipe_api = api_factory.build(lusid.api.ConfigurationRecipeApi)\n",
     "complex_market_data_api = api_factory.build(lusid.api.ComplexMarketDataApi)\n",
     "aggregation_api = api_factory.build(lusid.api.AggregationApi)\n",
-    "transaction_configuration_api = api_factory.build(lusid.api.TransactionConfigurationApi)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:06.240214Z",
-     "start_time": "2024-03-18T18:02:06.237792Z"
-    }
-   },
-   "execution_count": 5
+    "transaction_configuration_api = api_factory.build(lusid.api.TransactionConfigurationApi)\n",
+    "instrument_events_api = api_factory.build(lusid.api.InstrumentEventsApi)"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:21:52.686403100Z",
+     "start_time": "2024-07-01T14:21:52.677406Z"
+    },
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "# Define scopes\n",
     "scope = \"fx-forward-notebook-example\""
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:06.242655Z",
-     "start_time": "2024-03-18T18:02:06.240960Z"
-    }
-   },
-   "execution_count": 6
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:21:52.686403100Z",
+     "start_time": "2024-07-01T14:21:52.677406Z"
+    },
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "# Define a method to produce numeric axes\n",
@@ -201,27 +246,33 @@
     "        int_tenors.extend(tenors_in_days)\n",
     "\n",
     "        return int_tenors, int_rates"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:06.247232Z",
-     "start_time": "2024-03-18T18:02:06.243863Z"
-    }
-   },
-   "execution_count": 7
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "source": [
     "# Add required transaction configuration"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:21:52.825567400Z",
+     "start_time": "2024-07-01T14:21:52.677406Z"
+    },
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "default_side_definitions = [\n",
@@ -240,7 +291,17 @@
     "            currency=\"Txn:SettlementCurrency\",\n",
     "            rate=\"SettledToPortfolioRate\",\n",
     "            units=\"Txn:TotalConsideration\",\n",
-    "            amount=\"Txn:TotalConsideration\"))\n",
+    "            amount=\"Txn:TotalConsideration\")),\n",
+    "    lm.SidesDefinitionRequest(\n",
+    "        side=\"FxForwardPrincipal\",\n",
+    "        side_request=lm.SideDefinitionRequest(\n",
+    "            security = \"Txn:SettleCcy\",\n",
+    "            units = \"Txn:TotalConsideration\",\n",
+    "            currency = \"Txn:TradeCurrency\",\n",
+    "            rate = \"Txn:TradeToPortfolioRate\",\n",
+    "            amount = \"Txn:TotalConsideration\",\n",
+    "            notional_amount = \"Transaction/default/NotionalAmount\"\n",
+    "        ))\n",
     "]\n",
     "\n",
     "transaction_configuration_api.set_side_definitions(default_side_definitions, scope = scope)\n",
@@ -312,59 +373,7 @@
     "            )\n",
     "        ],\n",
     "        properties=None,\n",
-    "    ),\n",
-    "  lm.TransactionTypeRequest(\n",
-    "    aliases=[\n",
-    "        lm.TransactionTypeAlias(\n",
-    "            type= \"Principal\",\n",
-    "            description=\"all\",\n",
-    "            transaction_class=\"default\",\n",
-    "            transaction_roles=\"AllRoles\",\n",
-    "            is_default = False\n",
-    "        )\n",
-    "    ],\n",
-    "    movements=[\n",
-    "        lm.TransactionTypeMovement(\n",
-    "            movement_types=\"CashCommitment\",\n",
-    "            side=\"Side2\",\n",
-    "            direction=1,\n",
-    "            properties=None,\n",
-    "            mappings=[],\n",
-    "        )\n",
-    "    ],\n",
-    "     properties = {\n",
-    "        \"TransactionConfiguration/default/CashFlowType\":\n",
-    "            lm.PerpetualProperty(\n",
-    "                \"TransactionConfiguration/default/CashFlowType\",\n",
-    "                value= lm.PropertyValue(label_value=\"Principal\"))\n",
-    "    }),\n",
-    "    lm.TransactionTypeRequest(\n",
-    "    aliases=[\n",
-    "        lm.TransactionTypeAlias(\n",
-    "            type= \"CashFlow\",\n",
-    "            description=\"cash paid/received from instrument\",\n",
-    "            transaction_class=\"CashFlow\",\n",
-    "            transaction_roles=\"AllRoles\",\n",
-    "            is_default = False\n",
-    "        )\n",
-    "    ],\n",
-    "    movements=[\n",
-    "        lm.TransactionTypeMovement(\n",
-    "            movement_types=\"Carry\",\n",
-    "            side=\"Side1\",\n",
-    "            direction=1,\n",
-    "            properties=None,\n",
-    "            mappings=[],\n",
-    "            name=\"CarryCashFlow\"\n",
-    "        ),\n",
-    "          lm.TransactionTypeMovement(\n",
-    "            movement_types=\"CashReceivable\",\n",
-    "            side=\"Side2\",\n",
-    "            direction=1,\n",
-    "            properties=None,\n",
-    "            mappings=[]\n",
-    "          )\n",
-    "    ])\n",
+    "    )\n",
     "]\n",
     "\n",
     "# set the transaction types in the transaction type scope\n",
@@ -373,30 +382,44 @@
     "    transaction_type_request=transaction_type_requests,\n",
     "    scope=scope\n",
     ")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:06.621323Z",
-     "start_time": "2024-03-18T18:02:06.248231Z"
-    }
-   },
-   "execution_count": 8
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "source": [
     "# 1. Create Portfolio\n",
     "\n",
     "We begin by creating a portfolio that will contain the FX forward instrument that we will be looking to price."
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "outputs": [],
+   "execution_count": 7,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:21:53.036540Z",
+     "start_time": "2024-07-01T14:21:52.824251700Z"
+    },
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"name\":\"PortfolioWithIdAlreadyExists\",\"errorDetails\":[],\"code\":112,\"type\":\"https://docs.lusid.com/#section/Error-Codes/112\",\"title\":\"Could not create a portfolio with id 'FxForwardWithPipsCurve' because it already exists in scope 'fx-forward-notebook-example'.\",\"status\":400,\"detail\":\"Error creating portfolio with id 'FxForwardWithPipsCurve' in scope 'fx-forward-notebook-example' effective at 2010-01-01T00:00:00.0000000+00:00 because it already exists.\",\"instance\":\"https://fbn-kitk.lusid.com/app/insights/logs/0HN4PNII9LPIS:0000002C\",\"extensions\":{}}\n"
+     ]
+    }
+   ],
    "source": [
     "portfolio_code = \"FxForwardWithPipsCurve\"\n",
     "\n",
@@ -415,15 +438,7 @@
     "\n",
     "except lusid.ApiException as e:\n",
     "    print(e.body)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:06.991285Z",
-     "start_time": "2024-03-18T18:02:06.621937Z"
-    }
-   },
-   "execution_count": 9
+   ]
   },
   {
    "cell_type": "markdown",
@@ -436,14 +451,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:21:53.037541700Z",
+     "start_time": "2024-07-01T14:21:53.036540Z"
+    },
     "pycharm": {
      "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:06.994212Z",
-     "start_time": "2024-03-18T18:02:06.991804Z"
     }
    },
    "outputs": [],
@@ -501,14 +516,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:21:53.040540100Z",
+     "start_time": "2024-07-01T14:21:53.036540Z"
+    },
     "pycharm": {
      "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:06.997352Z",
-     "start_time": "2024-03-18T18:02:06.994815Z"
     }
    },
    "outputs": [],
@@ -528,14 +543,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:21:53.416924Z",
+     "start_time": "2024-07-01T14:21:53.036540Z"
+    },
     "pycharm": {
      "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:07.124257Z",
-     "start_time": "2024-03-18T18:02:06.998013Z"
     }
    },
    "outputs": [
@@ -543,7 +558,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "LUID_0000EDME\n"
+      "LUID_00003D9L\n"
      ]
     }
    ],
@@ -575,14 +590,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:21:54.233888600Z",
+     "start_time": "2024-07-01T14:21:53.421926800Z"
+    },
     "pycharm": {
      "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:07.793243Z",
-     "start_time": "2024-03-18T18:02:07.126305Z"
     }
    },
    "outputs": [
@@ -590,7 +605,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Transaction successfully updated at time: 2024-03-18 18:02:07.724546+00:00\n"
+      "Transaction successfully updated at time: 2024-07-01 15:11:03.924946+00:00\n"
      ]
     }
    ],
@@ -645,23 +660,88 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:21:54.292643600Z",
+     "start_time": "2024-07-01T14:21:54.234889100Z"
+    },
     "pycharm": {
      "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:07.805846Z",
-     "start_time": "2024-03-18T18:02:07.793975Z"
     }
    },
    "outputs": [
     {
      "data": {
-      "text/plain": "                       Date   Rate     Pair\n0 2021-01-01 00:00:00+00:00 1.2215  EUR/USD\n1 2021-01-04 00:00:00+00:00 1.2248  EUR/USD\n2 2021-01-05 00:00:00+00:00 1.2298  EUR/USD\n3 2021-01-06 00:00:00+00:00 1.2327  EUR/USD\n4 2021-01-07 00:00:00+00:00 1.2272  EUR/USD",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>Date</th>\n      <th>Rate</th>\n      <th>Pair</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>2021-01-01 00:00:00+00:00</td>\n      <td>1.2215</td>\n      <td>EUR/USD</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>2021-01-04 00:00:00+00:00</td>\n      <td>1.2248</td>\n      <td>EUR/USD</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2021-01-05 00:00:00+00:00</td>\n      <td>1.2298</td>\n      <td>EUR/USD</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>2021-01-06 00:00:00+00:00</td>\n      <td>1.2327</td>\n      <td>EUR/USD</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>2021-01-07 00:00:00+00:00</td>\n      <td>1.2272</td>\n      <td>EUR/USD</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Date</th>\n",
+       "      <th>Rate</th>\n",
+       "      <th>Pair</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2021-01-01 00:00:00+00:00</td>\n",
+       "      <td>1.2215</td>\n",
+       "      <td>EUR/USD</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2021-01-04 00:00:00+00:00</td>\n",
+       "      <td>1.2248</td>\n",
+       "      <td>EUR/USD</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2021-01-05 00:00:00+00:00</td>\n",
+       "      <td>1.2298</td>\n",
+       "      <td>EUR/USD</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2021-01-06 00:00:00+00:00</td>\n",
+       "      <td>1.2327</td>\n",
+       "      <td>EUR/USD</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2021-01-07 00:00:00+00:00</td>\n",
+       "      <td>1.2272</td>\n",
+       "      <td>EUR/USD</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                       Date   Rate     Pair\n",
+       "0 2021-01-01 00:00:00+00:00 1.2215  EUR/USD\n",
+       "1 2021-01-04 00:00:00+00:00 1.2248  EUR/USD\n",
+       "2 2021-01-05 00:00:00+00:00 1.2298  EUR/USD\n",
+       "3 2021-01-06 00:00:00+00:00 1.2327  EUR/USD\n",
+       "4 2021-01-07 00:00:00+00:00 1.2272  EUR/USD"
+      ]
      },
-     "execution_count": 14,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -676,14 +756,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:21:54.907770Z",
+     "start_time": "2024-07-01T14:21:54.285264700Z"
+    },
     "pycharm": {
      "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:08.131177Z",
-     "start_time": "2024-03-18T18:02:07.806386Z"
     }
    },
    "outputs": [
@@ -740,23 +820,112 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:21:54.939659200Z",
+     "start_time": "2024-07-01T14:21:54.917775100Z"
+    },
     "pycharm": {
      "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:08.137102Z",
-     "start_time": "2024-03-18T18:02:08.131998Z"
     }
    },
    "outputs": [
     {
      "data": {
-      "text/plain": "  Tenor  Points Mid\n0    1D      0.6375\n1    1W      1.4975\n2    2W      3.0275\n3    3W      4.5625\n4    1M      6.7525\n5    2M     19.5125\n6    3M     27.3225\n7    4M     34.0625\n8    5M     41.5175\n9    6M     49.2025",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>Tenor</th>\n      <th>Points Mid</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>1D</td>\n      <td>0.6375</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>1W</td>\n      <td>1.4975</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2W</td>\n      <td>3.0275</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>3W</td>\n      <td>4.5625</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>1M</td>\n      <td>6.7525</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>2M</td>\n      <td>19.5125</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>3M</td>\n      <td>27.3225</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>4M</td>\n      <td>34.0625</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>5M</td>\n      <td>41.5175</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>6M</td>\n      <td>49.2025</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Tenor</th>\n",
+       "      <th>Points Mid</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1D</td>\n",
+       "      <td>0.6375</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1W</td>\n",
+       "      <td>1.4975</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2W</td>\n",
+       "      <td>3.0275</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3W</td>\n",
+       "      <td>4.5625</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1M</td>\n",
+       "      <td>6.7525</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>2M</td>\n",
+       "      <td>19.5125</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>3M</td>\n",
+       "      <td>27.3225</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>4M</td>\n",
+       "      <td>34.0625</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>5M</td>\n",
+       "      <td>41.5175</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>6M</td>\n",
+       "      <td>49.2025</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  Tenor  Points Mid\n",
+       "0    1D      0.6375\n",
+       "1    1W      1.4975\n",
+       "2    2W      3.0275\n",
+       "3    3W      4.5625\n",
+       "4    1M      6.7525\n",
+       "5    2M     19.5125\n",
+       "6    3M     27.3225\n",
+       "7    4M     34.0625\n",
+       "8    5M     41.5175\n",
+       "9    6M     49.2025"
+      ]
      },
-     "execution_count": 16,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -769,14 +938,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:21:55.177592900Z",
+     "start_time": "2024-07-01T14:21:54.927492700Z"
+    },
     "pycharm": {
      "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:08.399548Z",
-     "start_time": "2024-03-18T18:02:08.137612Z"
     }
    },
    "outputs": [
@@ -839,21 +1008,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:21:55.770149500Z",
+     "start_time": "2024-07-01T14:21:55.182581600Z"
+    },
     "pycharm": {
      "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:08.584490Z",
-     "start_time": "2024-03-18T18:02:08.400236Z"
     }
    },
    "outputs": [
     {
      "data": {
-      "text/plain": "<Figure size 640x480 with 1 Axes>",
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjsAAAHDCAYAAADC/9uyAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/SrBM8AAAACXBIWXMAAA9hAAAPYQGoP6dpAABfw0lEQVR4nO3dd1yVdf/H8dcBWaJAqICk4kzFnZriHiSaZo5+Dfcuw6ws69ZyVlo2tDK14WrYvG1ojkxcpalhllmamoqlqGmAorLO9fvj5Lk9CrK5zoH38/E4DzjXdZ3r+hwc5833+g6LYRgGIiIiIsWUm9kFiIiIiBQmhR0REREp1hR2REREpFhT2BEREZFiTWFHREREijWFHRERESnWFHZERESkWFPYERERkWJNYUdERESKNYUdEREXMXXqVCwWS4Gdr2rVqgwZMqTAzifirBR2RIrYkiVLsFgsWT6+//57AI4cOYLFYuHFF1/M9DwvvvgiFouFI0eO2Ld16NDB4Vw+Pj40bNiQOXPmYLVas6ypb9++3HbbbQAMGTKEMmXKZHlsmTJlrvmAPHLkCEOHDqVGjRp4e3sTEhJCu3btmDJlisNxV9bn5uaGn58ftWvXZuDAgaxbt+56PzYHQ4YMyfLnt2bNmhyfp7i6+ufj5+dHo0aNeOmll0hJSTG7PJEiV8rsAkRKqunTp1OtWrVrttesWTNf561UqRIzZ84E4O+//2bZsmU88sgjnD59mmefffaa49PS0li3bp39Nbl18OBBmjdvjo+PD8OGDaNq1aqcOHGCXbt28fzzzzNt2rQs60tOTubgwYMsX76c9957j7vuuov33nsPDw+PbK/r5eXF22+/fc32Ro0a5el9FDdX/nwSEhL473//y2OPPcbOnTv58MMPAdi/fz9ubvqdV4o/hR0Rk3Tr1o1mzZoV+Hn9/f0ZMGCA/fn9999PnTp1eO2115g+fTru7u4Ox2/ZsoVz587RvXv3PF1v9uzZnD9/nt27dxMWFuaw79SpU9nWB/Dcc88xduxY5s2bR9WqVXn++eezvW6pUqWuOU9BuXDhAqVLly6Uc19Peno6VqsVT0/PfJ/r6p/PAw88QIsWLfjoo494+eWXCQ0NxcvLK9/XEXEFivQixZy3tzfNmzfn3LlzmYaPr776ivDwcKpWrZqn8x86dIhKlSpdE3QAgoKCcnQOd3d3Xn31VcLDw5k7dy6JiYl5quVq8+bNo169enh5eREaGkp0dDQJCQkOx3To0IH69esTGxtLu3btKF26NBMnTmTcuHGUK1cOwzDsxz744INYLBZeffVV+7aTJ09isViYP38+AKmpqUyePJmmTZvi7++Pr68vbdu2ZcOGDQ7XvfI25Zw5c6hRowZeXl78+uuvAHz77bc0b94cb29vatSowRtvvJGvn4WbmxsdOnSwXxuu7bNz+Rbr5s2bue+++yhXrhx+fn4MGjSIf/75x+F8P/zwA1FRUZQvXx4fHx+qVavGsGHD8lWjSGFRy46ISRITE/n7778dtlksFsqVK1fg17r8wRoQEHDNvlWrVtGjR488nzssLIxvvvmGmJgYOnXqlOfzuLu7c++99zJp0iS+/fbbHLU0Xf3z8/DwwN/fH7B15p02bRqRkZGMHj2a/fv3M3/+fHbu3Ml3333ncKvszJkzdOvWjXvuuYcBAwYQHByM1Wpl9uzZ7N27l/r16wO2VjA3Nze2bNnC2LFj7dsA2rVrB0BSUhJvv/029957LyNHjuTcuXMsXLiQqKgoduzYQePGjR1qXrx4MZcuXWLUqFF4eXkRGBjInj176NKlCxUqVGDq1Kmkp6czZcoUgoOD8/bD/dehQ4cAsv07NmbMGAICApg6dar953b06FE2btyIxWLh1KlT9vr+85//EBAQwJEjR1i+fHm+6hMpLAo7IiaJjIy8ZpuXlxeXLl3K13kzMjLsIeDMmTMsXLiQH374ge7du+Pj4+Nw7OHDh9m3b5+9VSIvxo4dy7vvvkvnzp1p3Lgx7du3p2PHjtx66625vhV0OVRc/lC+nuTkZCpUqOCwrX379mzcuJHTp08zc+ZMunTpwurVq+39UurUqcOYMWN47733GDp0qP118fHxLFiwgPvuu8++7fTp04AtzNSvX5/ExET27NlD37592bx5s/24LVu2EBgYSHh4OAA33HADR44ccbgVNXLkSPutxIULFzrU/Oeff3Lw4EGH99K7d28Mw2DLli1UqVIFsHUib9CgQbY/lytd/nuQmJjIxx9/zOeff07Dhg2pXbv2dV/n6enJ+vXr7YEwLCyMxx9/nBUrVtCzZ0+2bt3KP//8w9dff+1wK/aZZ57JVX0iRUVhR8Qkr7/+OjfddJPDtqv70+TFvn37rgkBPXv2vOZDFmy3sPz9/WnTpk2er1evXj12797N008/zcqVK9m9ezevvPIKZcqU4eWXX2bkyJE5PtflUWDnzp3L9lhvb29WrFjhsO2GG24A4JtvviE1NZWHH37YoQPuyJEjmThxIl999ZVD2PHy8nJ4DlChQgXq1KnD5s2bGT16NN999x3u7u6MHz+eTz75hAMHDlCrVi22bNlCmzZt7EPC3d3d7X+OVquVhIQErFYrzZo1Y9euXde8j759+zr8eWVkZLB27Vp69eplDzoAdevWJSoqilWrVmX7s4HMw2CrVq149913s33tqFGjHFq+Ro8ezcSJE1m1ahU9e/a0txCuXLmSRo0a5ahDuYiZFHZETHLLLbcUSAflq+ddqVq1Km+99RZWq5VDhw7x7LPPcvr0aby9va957VdffUWXLl0oVSp3/xVcfc2bbrqJd999l4yMDH799VdWrlzJrFmzGDVqFNWqVcu0FSsz58+fB6Bs2bLZHuvu7p7leY8ePQpwTQuGp6cn1atXt++/7MYbb8y0U3Dbtm3t4WLLli00a9aMZs2aERgYyJYtWwgODuann36iX79+Dq9bunQpL730Evv27SMtLc2+PbPRd1dvO336NBcvXqRWrVrXHFu7du0ch50rw6CXlxfVqlWjUqVKOXrt1dcuU6YMFStWtPf1ad++PX379mXatGnMnj2bDh060KtXL/r166dOz+KU1EFZxEldDicXL17MdP+FCxccjrvM19eXyMhIunTpwujRo1m1ahU7duxg4sSJ17x+48aN9vl1rrxuSkqKQ8fcywzD4NKlS5kGJ7AFkAYNGjBhwgQ+++wzAN5///0cvFubX375Bcj/8Pvcuvr23mVt2rThr7/+4o8//mDLli20bdsWi8VCmzZt2LJlC1u3bsVqtdK2bVv7a9577z2GDBlCjRo1WLhwIWvWrGHdunV06tQp07mOsrp2fl0Og5GRkbRt2zbHQScnLBYLn376Kdu2bWPMmDH89ddfDBs2jKZNm9oDq4gzUdgRcVIVKlSgdOnS7N+/P9P9+/fvp3Tp0pQvX/6652nYsCEDBgzgjTfeIC4uzr49JiaGlJQUunXr5nB8WFgY6enpmfabOXjwIBkZGZmOvLra5VarEydOZHss2G7fLFu2jNKlS+frthpgr+/qn11qaiqHDx/OUf2APcSsW7eOnTt32p+3a9eOLVu2sGXLFnx9fWnatKn9NZ9++inVq1dn+fLlDBw4kKioKCIjI3PcF6tChQr4+Phw4MCBa/Zl9XehoF197fPnz3PixIlrRuy1bNmSZ599lh9++IH333+fvXv32ufwEXEmCjsiTsrd3Z0uXbqwYsUKh5ACEBcXx4oVK+jSpUuO+vk8/vjjpKWl8fLLL9u3rVq1imbNml0zwudy+Jk7d+4153n99dcdjgHb7Z0rb9VceX649lZSZjIyMhg7diy//fYbY8eOxc/PL9vXXE9kZCSenp68+uqrDi1UCxcuJDExMcdzClWrVo0bb7yR2bNnk5aWRuvWrQFbCDp06BCffvopLVu2dLgNePnP48rrbt++nW3btuXomu7u7kRFRfH55587/Ln/9ttvrF27NkfnyK8333zT4c90/vz5pKen2//c//nnn2ta/i6PMtMMzeKM1GdHxCSrV69m375912xv1aoV1atXB2DGjBm0bNmSm2++mVGjRlG1alWOHDnCm2++icViYcaMGTm6Vnh4OLfddhtvv/02kyZNoly5cqxateqaTrlg+9AaMWIEr7zyCgcOHODWW28FbK0bq1atYsSIEQ6zFD///PPExsbSp08fGjZsCMCuXbt45513CAwM5OGHH3Y4f2JiIu+99x5gu5V2eQblQ4cOcc899/D000/n6D1dT4UKFZgwYQLTpk2ja9eu9OzZk/379zNv3jyaN2+eq8kI27Zty4cffkiDBg3sHaBvvvlmfH19+f3336/pr9OjRw+WL19O79696d69O4cPH2bBggWEh4fn+BbPtGnTWLNmDW3btuWBBx4gPT2d1157jXr16vHzzz/n/AeRR6mpqXTu3Jm77rrL/nNr06YNPXv2BGx9kubNm0fv3r2pUaMG586d46233sLPz++a26IiTsEQkSK1ePFiA8jysXjxYofjf/vtN+Puu+82goKCjFKlShlBQUHGPffcY/z222/XnLt9+/ZGvXr1Mr3uxo0bDcCYMmWK8csvvxiAsWPHjkyPzcjIMF555RWjUaNGhre3t+Ht7W00atTIePXVV42MjAyHY7/77jsjOjraqF+/vuHv7294eHgYVapUMYYMGWIcOnTomvqufK9lypQxatWqZQwYMMD4+uuvc/wzHDx4sOHr65vtcXPnzjXq1KljeHh4GMHBwcbo0aONf/7555qasvqZGYZhvP766wZgjB492mF7ZGSkARjr16932G61Wo0ZM2YYYWFhhpeXl9GkSRNj5cqVxuDBg42wsDD7cYcPHzYA44UXXsj0ups2bTKaNm1qeHp6GtWrVzcWLFhgTJkyxcjJf9s5/fmEhYUZgwcPtj+//Hdz06ZNxqhRo4wbbrjBKFOmjNG/f3/jzJkz9uN27dpl3HvvvUaVKlUMLy8vIygoyOjRo4fxww8/ZHtNETNYDCOTXogiUqzNmjWLl19+mRMnThToKtri2pYsWcLQoUPZuXNnoSxlImIW9dkRKYGqVq3K7NmzFXREpERQnx2REuiuu+4yuwQRkSKjlh0REREp1pwm7Dz33HNYLBaHkRuXLl0iOjqacuXKUaZMGfr27cvJkycdXhcXF0f37t0pXbo0QUFBjB8/nvT09CKuXkTE9Q0ZMgTDMNRfR4odpwg7O3fu5I033rAPW73skUceYcWKFXzyySds2rSJ48eP06dPH/v+jIwMunfvTmpqKlu3bmXp0qUsWbKEyZMnF/VbEBERESdl+mis8+fPc/PNNzNv3jyeeeYZGjduzJw5c0hMTKRChQosW7aMO++8E7AtcFi3bl22bdtGy5YtWb16NT169OD48eP2idEWLFjAE088wenTpzNd60ZERERKFtM7KEdHR9O9e3ciIyN55pln7NtjY2NJS0tzWOivTp06VKlSxR52tm3bRoMGDRxmgI2KimL06NHs3buXJk2aZHrNlJQUh1k+rVYrZ8+epVy5chqdIiIi4iIMw+DcuXOEhobi5pb1zSpTw86HH37Irl272Llz5zX74uPj8fT0JCAgwGF7cHAw8fHx9mOunur+8vPLx2Rm5syZTJs2LZ/Vi4iIiDM4duzYdRe7NS3sHDt2jIceeoh169ZluYJyYZkwYQLjxo2zP09MTKRKlSocO3Ys32vyiIiISAFLPA3P94KQGjD2HfvmpKQkKleuTNmyZa/7ctPCTmxsLKdOneLmm2+2b8vIyGDz5s3MnTuXtWvXkpqaSkJCgkPrzsmTJwkJCQEgJCSEHTt2OJz38mity8dkxsvLCy8vr2u2+/n5KeyIiIg4kzN/wQs94GICDPoAMvmczq4LimmjsTp37syePXvYvXu3/dGsWTP69+9v/97Dw4P169fbX7N//37i4uKIiIgAICIigj179nDq1Cn7MevWrcPPz4/w8PAif08iIiJSgE4ehqfaQkoyPL0ZqtTP02lMa9kpW7Ys9es7Fu3r60u5cuXs24cPH864ceMIDAzEz8+PBx98kIiICFq2bAlAly5dCA8PZ+DAgcyaNYv4+HieeuopoqOjM225ERERERcS+xW4ucG0LRAUlufTmD4a63pmz56Nm5sbffv2JSUlhaioKObNm2ff7+7uzsqVKxk9ejQRERH4+voyePBgpk+fbmLVIiIiki/JCeAbALeNgY6Dwef6fXKyY/o8O84gKSkJf39/EhMTs+yzY7VaSU1NLeLKXJOHhwfu7u5mlyEiIq7o4A/wTFe4/01o2ee6h+bk8xucvGXHWaSmpnL48GGsVqvZpbiMgIAAQkJCNG+RiIjk3G/fwrO3QeV60KBTgZ1WYScbhmFw4sQJ3N3dqVy58nUnLRLbz+vChQv2TuMVK1Y0uSIREXEJP30Dz98BNW+BCV/m+9bVlRR2spGens6FCxcIDQ2ldOnSZpfjEnx8fAA4deoUQUFBuqUlIiLXZxjw4SQIbw/j/wtePgV6eoWdbGRkZABona1cuhwM09LSFHZERCRraSng4QUTV4J3Gdv3BUz3ZHJIfU9yRz8vERHJ1oal8EgD2wzJZcsVStABhR0RERExw5p5MHcI1O9oCzqFSGGnBBoyZAi9evUyuwwRESmpvngR3oqGHg/DfQtsEwcWIoWdYmrIkCFYLBYsFguenp7UrFmT6dOnk56eziuvvMKSJUvMLlFEREqi4wfg/QnQ90kY8jIUQbcHdVAuKscPQMwiOHUEgqpCp2EQWqtQL9m1a1cWL15MSkoKq1atIjo6Gg8PDyZMmFCo1xUREbnG5TmMQ2vBy3ugUp0iu7RadopCzGIYWwe+eAG2fmz7OrYOxCwp1Mt6eXkREhJCWFgYo0ePJjIyki+//PKa21gdOnRgzJgxjBkzBn9/f8qXL8+kSZO4cnLtefPmUatWLby9vQkODubOO+8s1NpFRKQYsVrh7TGwZJzteREGHVDYKXzHD8C8EWBYwZrh+HXecDhxsMhK8fHxyXLJi6VLl1KqVCl27NjBK6+8wssvv8zbb78NwA8//MDYsWOZPn06+/fvZ82aNbRr167I6hYREReWkQ6vD4O186Fy3lYtzy/dxsqrf07YHlfyvQGCq0HqJfjzV9u2Va/Z7kdmtgKZxQL/fRZuexAqVIWygbbhd2eOOR7nXTZft7wMw2D9+vWsXbuWBx98kNOnT19zTOXKlZk9ezYWi4XatWuzZ88eZs+ezciRI4mLi8PX15cePXpQtmxZwsLCaNKkSZ7rERGREiItFV4ZANuXw0PvQ9t7TSlDYSevvn4DPp7muK1df3joPTjzJ4xvmv05rBmwYYntMfZdaD/Adpvr7TGOxzXqApPX5rrElStXUqZMGdLS0rBarfTr14+pU6cSHR19zbEtW7Z0mBsnIiKCl156iYyMDG699VbCwsKoXr06Xbt2pWvXrvTu3VszSouIyPWtehV2fmGbFfmWO0wrQ2Enr7rcB817Om7zvcH2tVwleCHW9v2q12DTu7ZgczU3d2g/8H8tOwCt7oLaEY7HeedtfZCOHTsyf/58PD09CQ0NpVSpvP1xly1bll27drFx40a+/vprJk+ezNSpU9m5cycBAQF5OqeIiJQAt42F8HZQ6xZTy1DYyasbKtoemfH0huo3277vMxE2vpP5cYZhG3pXseb/tvlXsD0KgK+vLzVr1sz+QGD79u0Oz7///ntq1aplX+qhVKlSREZGEhkZyZQpUwgICCAmJoY+ffoUSK0iIlJMXEiC2ffC/02Gm1qYHnRAYafwhdaCBxbaOiNbLNg671hsQeeBhY5Bx0RxcXGMGzeO++67j127dvHaa6/x0ksvAbbbYX/88Qft2rXjhhtuYNWqVVitVmrXrm1y1SIi4lTOnYWnoyD+IJl3VjWHwk5R6DQE6raB9Qv/N89O5+FOE3QABg0axMWLF7nllltwd3fnoYceYtSoUQAEBASwfPlypk6dyqVLl6hVqxYffPAB9erVM7lqERFxGgknYdqtkHACpm2Aao3NrsjOYlw5mUoJlZSUhL+/P4mJifj5+Tnsu3TpEocPH6ZatWp4e3ubVGHh6tChA40bN2bOnDkFds6S8HMTEZF/GQY81RZO/gFT10OlukVy2et9fl9JLTsiIiKSPxYLDH8NSvtBSA2zq7mGJhUUERGRvPlzH7w22Da/XPUmThl0QC07AmzcuNHsEkRExNUc+cnWR8c/CC4m2UYiOym17IiIiEjuHNgBUzpChSrw9CZb4HFiCjs5pH7cuaOfl4hIMXU6DqZFwo11Ycp6KFvO7IqypdtY2bg8qV5qaio+Pj4mV+M6Lly4AICHh4fJlYiISIEqXxmGzIY294C3r9nV5IjCTjZKlSpF6dKlOX36NB4eHri5qTHsegzD4MKFC5w6dYqAgAB7WBQRERe34wu4eM62jmPkcLOryRWFnWxYLBYqVqzI4cOHOXr0qNnluIyAgABCQkLMLkNERArClg/g1YEQ8X+2Ra+vWDjaFSjs5ICnpye1atUiNTXV7FJcgoeHh1p0RESKi/WLYP4I28LVDyx0uaADCjs55ubmppmARUSkZNn8vm1txy73w8jXwUW7cijsiIiISOYaRsLA5+GO8S7ZonOZa0Y0ERERKRyGASvnwD8nICAYej3u0kEHFHZERETkMsOAJY/C4kdg12qzqykwuo0lIiIiYLXCm6Nh3ZswYi50HmZ2RQVGYUdERERsI642LoXoxdBpiNnVFCiFHREREYGGt0LjKGh9t9mVFDiFHRERkZIq5SJ89yF0HAJt7zW7mkJjagfl+fPn07BhQ/z8/PDz8yMiIoLVq//XIapDhw5YLBaHx/333+9wjri4OLp3707p0qUJCgpi/PjxpKenF/VbERERcS0Xz8PMHvBWNMQfMruaQmVqy06lSpV47rnnqFWrFoZhsHTpUu644w5+/PFH6tWrB8DIkSOZPn26/TWlS5e2f5+RkUH37t0JCQlh69atnDhxgkGDBuHh4cGMGTOK/P2IiIi4hOQEeLY7xO2BSWuhYk2zKypUFsMwDLOLuFJgYCAvvPACw4cPp0OHDjRu3Jg5c+Zkeuzq1avp0aMHx48fJzg4GIAFCxbwxBNPcPr0aTw9PXN0zaSkJPz9/UlMTMTPz6+g3oqIiIjzOXcWpt8Kpw7DU2ug1i1mV5RnOf38dpp5djIyMvjwww9JTk4mIiLCvv3999+nfPny1K9fnwkTJnDhwgX7vm3bttGgQQN70AGIiooiKSmJvXv3ZnmtlJQUkpKSHB4iIiIlgrcvVAqHaRtdOujkhukdlPfs2UNERASXLl2iTJkyfPbZZ4SHhwPQr18/wsLCCA0N5eeff+aJJ55g//79LF++HID4+HiHoAPYn8fHx2d5zZkzZzJt2rRCekciIiJO6HQcnDsD1ZvAQ++aXU2RMj3s1K5dm927d5OYmMinn37K4MGD2bRpE+Hh4YwaNcp+XIMGDahYsSKdO3fm0KFD1KhRI8/XnDBhAuPGjbM/T0pKonLlyvl6HyIiIk7rxEGY2hn8g+D5HS6//ENumX4by9PTk5o1a9K0aVNmzpxJo0aNeOWVVzI9tkWLFgAcPHgQgJCQEE6ePOlwzOXnISEhWV7Ty8vLPgLs8kNERKRYOvYrTGoHnt7wxGclLuiAE4Sdq1mtVlJSUjLdt3v3bgAqVqwIQEREBHv27OHUqVP2Y9atW4efn5/9VpiIiEiJ9cePMLk9lC0PT2+GcpXMrsgUpt7GmjBhAt26daNKlSqcO3eOZcuWsXHjRtauXcuhQ4dYtmwZt912G+XKlePnn3/mkUceoV27djRs2BCALl26EB4ezsCBA5k1axbx8fE89dRTREdH4+XlZeZbExERMZ81HcIawaMfQ9lAs6sxjalh59SpUwwaNIgTJ07g7+9Pw4YNWbt2LbfeeivHjh3jm2++Yc6cOSQnJ1O5cmX69u3LU089ZX+9u7s7K1euZPTo0URERODr68vgwYMd5uUREREpcf7YBZXrQc3mMGVdibx1dSWnm2fHDJpnR0REio0f18Cs3tD3KbjzSbOrKVQuN8+OiIiI5NP2z+C5nrZFPXs+anY1TkNhR0REpDjYsgxe/D9o0QfG/9c2+koAhR0REZHi4Y9d0H4gPPQ+lPIwuxqnYvqkgiIiIpIPxw9AaC0Y9AIYBripHeNq+omIiIi4qv/OgIfDIW6vbcSVgk6m1LIjIiLiagwDlj0Jy2fC3dOgsibSvR6FHREREVdiGLDoYVj1Kgx+UaOuckBhR0RExJWc/wd+XA0j50HX0WZX4xIUdkRERFxBRjpcSLIt+/DyzxpangvqySQiIuLs0lLgpbvg6SiwWhV0ckktOyIiIs4s5SK80Ad+2QCPfaoRV3mgsCMiIuKsLp6DmT3h4A6YsBIaRZpdkUtS2BEREXFWv2yEwz/CpLVQt43Z1bgshR0RERFncykZvH2h+e0w7xCULWd2RS5NN/5EREScydnj8MQtsGK27bmCTr6pZUdERMRZnDoK0zrbRl817W52NcWGWnZEREScwfEDMKmtbYbkZ7ZA6E1mV1RsKOyIiIg4g0+mgZcvPL0ZgqqaXU2xottYIiIiZspIB/dScN8bkJIM/kFmV1TsqGVHRETELPu2wti6cPx32+grBZ1CobAjIiJihj0x8HQXCAyFGyqaXU2xprAjIiJS1GJXwbO3Qe3W8NRq8ClrdkXFmvrsiIiIFKULSfDqQGjcFR79CDy8zK6o2FPYERERKSqGAaX9YPpGuLEOlPIwu6ISQbexREREisLXb8DseyEjA8IaKOgUIYUdERGRwrZiNrxxP/gHg8VidjUljsKOiIhIYTEM+PQZWDIO+kyAYXPATR+9RU19dkRERApL7FfwwSS49xm480mzqymxFHZEREQKy823waS10LiL2ZWUaGpLExERKUgZGbb+ObFf2W5ZKeiYTmFHRESkoKSnwSsD4Ju3IDnB7GrkX7qNJSIiUhDSUuClu+HHVTDuY4joa3ZF8i+FHRERkYLw9hj4aS08/jk0vc3sauQKCjsiIiIFoc9EaNsf6ncwuxK5ivrsiIiI5NW5szBvhK1/TnA1BR0nZWrYmT9/Pg0bNsTPzw8/Pz8iIiJYvXq1ff+lS5eIjo6mXLlylClThr59+3Ly5EmHc8TFxdG9e3dKly5NUFAQ48ePJz09vajfioiIlDSJp2BKR9jxOfx9zOxq5DpMDTuVKlXiueeeIzY2lh9++IFOnTpxxx13sHfvXgAeeeQRVqxYwSeffMKmTZs4fvw4ffr0sb8+IyOD7t27k5qaytatW1m6dClLlixh8uTJZr0lEREpCc78BZPa2wLP9E22ta7EaVkMwzDMLuJKgYGBvPDCC9x5551UqFCBZcuWceeddwKwb98+6taty7Zt22jZsiWrV6+mR48eHD9+nODgYAAWLFjAE088wenTp/H09MzRNZOSkvD39ycxMRE/P79Ce28iIlIMpFyAcQ0hPRWmrIfQWmZXVGLl9PPbafrsZGRk8OGHH5KcnExERASxsbGkpaURGRlpP6ZOnTpUqVKFbdu2AbBt2zYaNGhgDzoAUVFRJCUl2VuHMpOSkkJSUpLDQ0REJEe8SsOdk+DpLQo6LsL0sLNnzx7KlCmDl5cX999/P5999hnh4eHEx8fj6elJQECAw/HBwcHEx8cDEB8f7xB0Lu+/vC8rM2fOxN/f3/6oXLlywb4pEREpfo7ugVVzbd93HAxBYebWIzlmetipXbs2u3fvZvv27YwePZrBgwfz66+/Fuo1J0yYQGJiov1x7Jg6lomIyHUc/AEmt4eYRbbJA8WlmD7PjqenJzVr1gSgadOm7Ny5k1deeYW7776b1NRUEhISHFp3Tp48SUhICAAhISHs2LHD4XyXR2tdPiYzXl5eeHl5FfA7ERGRYum3b+HZ26ByPXhqNXjo88PVmN6yczWr1UpKSgpNmzbFw8OD9evX2/ft37+fuLg4IiIiAIiIiGDPnj2cOnXKfsy6devw8/MjPDy8yGsXEZFi5vfv4ekoqN4UJn8NvgFmVyR5YGrLzoQJE+jWrRtVqlTh3LlzLFu2jI0bN7J27Vr8/f0ZPnw448aNIzAwED8/Px588EEiIiJo2bIlAF26dCE8PJyBAwcya9Ys4uPjeeqpp4iOjlbLjYiI5F/letBtDNw1Fbx8zK5G8sjUsHPq1CkGDRrEiRMn8Pf3p2HDhqxdu5Zbb70VgNmzZ+Pm5kbfvn1JSUkhKiqKefPm2V/v7u7OypUrGT16NBEREfj6+jJ48GCmT59u1lsSEZHi4PvltqBzY20Y+LzZ1Ug+Od08O2bQPDsiImK3YSnMGwa3PQRDXza7GrkOl5tnR0RExHRr5sHcIdBpOAx+0exqpIAo7IiIiACsnANvRUP3h+D+N8BNH5HFhf4kRUREAKo0gLumwNDZYLGYXY0UIIUdEREpuQwDtnwAGRnQsDPcPVVBpxhS2BERkZLJaoW3x8CcfvDLBrOrkUJk+gzKIiIiRS4jA+aPgI1LYfRb0Cgy+9eIy1LYERGRkiU9DV4ZAN//Fx56D9r2M7siKWQKOyIiUrK4uUNpP3jsE2jR2+xqpAgo7IiISMlwKRni9sBNLW23rqTEUAdlEREp/i4kwTNdYWZPW+iREkUtOyIiUrydO2tbufzEAZi0Brx9za5IipjCjoiIFF8JJ2HarZBwAqZtgOpNzK5ITKCwIyIixdel8+DhCdM3QeVws6sRkyjsiIhI8XPqCPjeACE14PmdmhW5hFMHZRERKV7+3AdPtoFFY23PFXRKPIUdEREpPo78DJPagW8ADHjO7GrESSjsiIhI8XBgB0zpAOUrw/SNcENFsysSJ6E+OyIiUjwc2A431oUnV4Gvv9nViBNRy46IiLi2v4/Zvt72oK1FR0FHrqKwIyIirmvnlzCmFsR+ZXteysPcesQpKeyIiIhr+vZDmNUHmt0ODW81uxpxYgo7IiLietYvgjn9oG0/eOQD28SBIllQ2BEREdeSkQ7r3oBb74MxS8BdY23k+vQ3REREXEdygm0OnSnrbQt6asJAyQG17IiIiPMzDPhgMoxrBMmJ4FNGQUdyTGFHREScm2HA0sfg06ehW7SGlkuu6TaWiIg4l+MHIGaRbTHPCmFw+ih89yGMmGsLOyK5pLAjIiLOI2YxzBthu0VlGLav1gzoNExBR/JMt7FERMQ5HD9gCzqG1RZwLn8F2LAEThw0tTxxXQo7IiLiHGIWZd3p2GKB9QuLth4pNhR2RETEOZw6Yrt1lSnDtl8kDxR2RETEOVjTbbeuMmWBoKpFWY0UIwo7IiLiHK43b45hQOfhRVeLFCsKOyIiYp7kBNizwfb92PfggYVgcQM3d3D796vFzba9Yk1TSxXXpaHnIiJijri9MKs3pCTD64fA0xs6D4PwdrbOyKeO2G5ddR6uoCP5YmrLzsyZM2nevDlly5YlKCiIXr16sX//fodjOnTogMVicXjcf//9DsfExcXRvXt3SpcuTVBQEOPHjyc9Pb0o34qIiOTG1k9gQgvw8Ibpm2xB57KKNWHATBj3ge2rgo7kk6ktO5s2bSI6OprmzZuTnp7OxIkT6dKlC7/++iu+vr7240aOHMn06dPtz0uXLm3/PiMjg+7duxMSEsLWrVs5ceIEgwYNwsPDgxkzZhTp+xERkRxY/Tq8PQZa3wMPvG1b0FOkEJkadtasWePwfMmSJQQFBREbG0u7du3s20uXLk1ISEim5/j666/59ddf+eabbwgODqZx48Y8/fTTPPHEE0ydOhVPT89CfQ8iIpJLTXvYRl11G6PFPKVIOFUH5cTERAACAwMdtr///vuUL1+e+vXrM2HCBC5cuGDft23bNho0aEBwcLB9W1RUFElJSezdu7doChcRkev7YxdMjbR1SA4Kg9seVNCRIuM0HZStVisPP/wwrVu3pn79+vbt/fr1IywsjNDQUH7++WeeeOIJ9u/fz/LlywGIj493CDqA/Xl8fHym10pJSSElJcX+PCkpqaDfjoiIXLbxHXjjPqhcHy4lg2+A2RVJCeM0YSc6OppffvmFb7/91mH7qFGj7N83aNCAihUr0rlzZw4dOkSNGjXydK2ZM2cybdq0fNUrIiLZSEuFJeNgzevQaSiMnOfYEVmkiDjFbawxY8awcuVKNmzYQKVKla57bIsWLQA4eNC2IFxISAgnT550OOby86z6+UyYMIHExET749ixY/l9CyIicrVDP0DMQlvIeWChgo6YxtSwYxgGY8aM4bPPPiMmJoZq1apl+5rdu3cDULFiRQAiIiLYs2cPp06dsh+zbt06/Pz8CA8Pz/QcXl5e+Pn5OTxERKSAxO0FqxXqtIJ5h6HraPXPEVOZGnaio6N57733WLZsGWXLliU+Pp74+HguXrwIwKFDh3j66aeJjY3lyJEjfPnllwwaNIh27drRsGFDALp06UJ4eDgDBw7kp59+Yu3atTz11FNER0fj5eVl5tsTESlZDAPWLoDxTSBmsW3bDZm3sIsUJYthZLnEbOFfPIukv3jxYoYMGcKxY8cYMGAAv/zyC8nJyVSuXJnevXvz1FNPObTGHD16lNGjR7Nx40Z8fX0ZPHgwzz33HKVK5axLUlJSEv7+/iQmJqqVR0QkL1IvwVvRELPINqR88Evgoak/pHDl9PPb1LDjLBR2RETy4fw/8HQUxO2BUQug42CzK5ISIqef304zGktERFxUaX+oeQvctwCq32x2NSLXUNgREZHcMwxYOQcqhUOTKBg51+yKRLLkFEPPRUTEhVxKhtn9bHPoHNxhdjUi2VLLjoiI5Fz8IXi+N5z6A8Z9BK3vMrsikWwp7IiISM4YBszpB6kXYeb3UKV+9q8RcQIKOyIicn1Wq20Bz7KBMPY98K+g9a3EpSjsiIhI1i4kwauD4OyfMHM7hNYyuyKRXFPYERGRzP35m61/TsIJW4uOu7vZFYnkiUZjiYjItbZ/Dk/cAm7u8PxOaH672RWJ5JladkRE5FqpF6FJV4heBD5lza5GJF/UsiMiIjbnzsKq12yjrtreC49+rKAjxYJadkREBI78ZOufcyERWvSGcpUgi8WaRVyNWnZEREq6LctgQoRtOPkLsbagI1KM5Kllx2q1smTJEpYvX86RI0ewWCxUq1aNO++8k4EDB2LRbwMiIq5h+2cwpz+0Hwj3vQFePmZXJFLgct2yYxgGPXv2ZMSIEfz11180aNCAevXqcfToUYYMGULv3r0Lo04RESlIGem2r0172JZ9eHCpgo4UW7lu2VmyZAmbN29m/fr1dOzY0WFfTEwMvXr14p133mHQoEEFVqSIiBSgAztsyz48vAxq3aL1raTYy3XLzgcffMDEiROvCToAnTp14j//+Q/vv/9+gRQnIiIF7Ju34am24FcBAm80uxqRIpHrsPPzzz/TtWvXLPd369aNn376KV9FiYhIAUtLgQX3wfyR0GkYTN8I5RR2pGTI9W2ss2fPEhwcnOX+4OBg/vnnn3wVJSIiBez8P/DTOnhgIXQeZnY1IkUq12EnIyODUqWyfpm7uzvp6en5KkpERArIb99CaG24IQRe/Q08vMyuSKTI5TrsGIbBkCFD8PLK/B9MSkpKvosSEZF8MgzbbMhLH4Uej8CgWQo6UmLlOuwMHjw422M0EktExEQpF+CN+2HTu9DjYej3rNkViZgq12Fn8eLFhVGHiIgUhIwMmNwB4n6Bh9+Htv3MrkjEdAW2NtbRo0dJTk6mTp06uLlpFQoREVO4u0O3MVC1ke0hIrkfer5o0SJefvllh22jRo2ievXqNGjQgPr163Ps2LECK1BERLJhGLD8OXh/ou15h0EKOiJXyHXYefPNN7nhhhvsz9esWcPixYt555132LlzJwEBAUybNq1AixQRkSxcPAcv/h+8PwEsbrbgIyIOcn0b68CBAzRr1sz+/IsvvuCOO+6gf//+AMyYMYOhQ4cWXIUiIpK547/D873hzDF4fDm00NqEIpnJdcvOxYsX8fPzsz/funUr7dq1sz+vXr068fHxBVOdiIhk7YsXwZoBz+1Q0BG5jly37ISFhREbG0tYWBh///03e/fupXXr1vb98fHx+Pv7F2iRIiLyL6sV/toHlcNh6Gxb2Cntl/3rREqwPM2zEx0dzd69e4mJiaFOnTo0bdrUvn/r1q3Ur1+/QIsUEREgOQHm9Id938GCI+AbYHJBIq4h12Hn8ccf58KFCyxfvpyQkBA++eQTh/3fffcd9957b4EVKCIi2ObNeb4XnD8L4z5U0BHJBYthqOt+UlIS/v7+JCYmOvRHEhFxCrGr4KX/g5Ca8PhnEFLd7IpEnEJOP79z3bKTlJSU6XZfX1/c3d1zezoREclOxVrQtr+tj463r9nViLicXI/GCggI4IYbbrjm4ePjQ+3atXnrrbcKo04RkZIl8TQsuM82j05oLRj9poKOSB7lumVnw4YNmW5PSEggNjaW8ePHU6pUKc21IyKSV4diYVYfSL0IUaOhWmOzKxJxaQXeZ2fRokXMnTuXXbt2FeRpC5X67IiI04hZAm/eD2ENYfx/oXxlsysScVo5/fwu8BU727dvz8GDB3N07MyZM2nevDlly5YlKCiIXr16sX//fodjLl26RHR0NOXKlaNMmTL07duXkydPOhwTFxdH9+7dKV26NEFBQYwfP5709PQCe08iIkXiyM/w+lBoNwCe3qygI1JACjzsJCYm5nhSwU2bNhEdHc3333/PunXrSEtLo0uXLiQnJ9uPeeSRR1ixYgWffPIJmzZt4vjx4/Tp08e+PyMjg+7du5OamsrWrVtZunQpS5YsYfLkyQX91kRECse5M7Y1rao2hOd3wui3wNPb7KpEio0CvY2VlpbGoEGDSEtL49NPP83160+fPk1QUBCbNm2iXbt2JCYmUqFCBZYtW8add94JwL59+6hbty7btm2jZcuWrF69mh49enD8+HGCg4MBWLBgAU888QSnT5/G09Mz2+vqNpaImGbfVnjxTuj7JHSLNrsaEZdSaEPPr2xVuVJiYiJ79+7FYrGwZcuW3J7Wfg6AwMBAAGJjY0lLSyMyMtJ+TJ06dahSpYo97Gzbto0GDRrYgw5AVFQUo0ePZu/evTRp0uSa66SkpJCSkmJ/ntVwehGRQmMYsHY+LH4YarWAln3Nrkik2Mp12PHz88NisVyzvXLlyvTt25f+/fvnaW0sq9XKww8/TOvWre3LTcTHx+Pp6UlAQIDDscHBwfbFRuPj4x2CzuX9l/dlZubMmUybNi3XNYqIFIi0FHjjftiwBLqNgcEvgUf2rdAikje5Djvz5s2jdOnSBV5IdHQ0v/zyC99++22Bn/tqEyZMYNy4cfbnSUlJVK6sjoAiUkTcStnWuXpwKXQYZHY1IsVersNO+fLl6dSpEz179uSOO+64plUlL8aMGcPKlSvZvHkzlSpVsm8PCQkhNTWVhIQEh9adkydPEhISYj9mx44dDue7PFrr8jFX8/LywsvLK991i4jkyp4N4F4KwtvC48shk1ZyESl4uR6N9dtvvxEVFcXHH39MWFgYLVq04Nlnn2XPnj25vrhhGIwZM4bPPvuMmJgYqlWr5rC/adOmeHh4sH79evu2/fv3ExcXR0REBAARERHs2bOHU6dO2Y9Zt24dfn5+hIeH57omEZECZxjw5UswPRK+XmDbpqAjUmTyNRorMTGRVatW8cUXX7BmzRoCAwPp2bMnPXv2pH379tmulfXAAw+wbNkyvvjiC2rXrm3f7u/vj4+PDwCjR49m1apVLFmyBD8/Px588EEAtm7dCtiGnjdu3JjQ0FBmzZpFfHw8AwcOZMSIEcyYMSNH70OjsUSk0FxKhnkj4LsPodcT0O9Z0DqCIgUip5/fBTb0PC0tjY0bN/Lll1/y5Zdfcu7cOV577TX69++f9cWz+M1m8eLFDBkyBLBNKvjoo4/ywQcfkJKSQlRUFPPmzXO4RXX06FFGjx7Nxo0b8fX1ZfDgwTz33HOUKpWzu3QKOyJSaGbcDns3wJglEHGn2dWIFCtFHnauZBgGu3fvJj09nebNmxf06Qucwo6IFLiMdFv/nMO7wd0DqtQzuyKRYse05SKWL19Oo0aNaNKkiUsEHRGRAmW1widPw+QOkJZqW8RTQUfEVHkKO2+88QZ33nkn/fr1Y/v27QDExMTQpEkTBg4cSOvWrQu0SBERl5CcCLN6w0dToFEXW8uOiJgu1/8Sn3vuOSZPnkzDhg3Zt28fX3zxBU8++SSvvfYaDz30EPfddx833HBDYdQqIuK8jv1qCzoJJ2HCCmja3eyKRORfuQ47ixcv5q233mLw4MFs2bKF9u3bs3XrVg4ePIivr29h1Cgi4vwObLf1zXl+J4TWMrsaEblCrjso+/j48Pvvv9tnHPby8mLr1q00bdq0UAosCuqgLCJ5kpEBu76C5j1tz9NSwEMTlooUlULroJySkoK3t7f9uaenp33hThGREuPcGXj2Ntutq2O/2rYp6Ig4pTz1nps0aZJ9fazU1FSeeeaZaxb/fPnll/NfnYiIM/rjR3ihD1w8B0+thcqarV3EmeU67LRr1479+/fbn7dq1Yo//vjD4ZisJgsUEXF5+7bCtM5QKRymbYCgqmZXJCLZyHXY2bhxYyGUISLiIqrfDH0mQs/HwMvH7GpEJAcKfFJBEZFiJ+EkPNPNNhuypzf83yQFHREXkuuWnT59+mS63d/fn5tuuokRI0ZQoUKFfBcmIlLkjh+AmEVw6ojt9lSnYXD+DLzQ1zYzcupFsysUkTzI9dDzoUOHZro9ISGBn376iYSEBDZv3kz9+vULpMCioKHnIkLMYtvq5BYLGMa/X61gcYNat8Bjn0JgqNlVisgVTFkI1Gq1MnLkSE6dOsWKFSsK6rSFTmFHpIQ7fgDG1rGFm2tYYM4vGnEl4oRMWQjUzc2NsWPHEhsbW5CnFREpXDGLbC05mXFzg03vFm09IlKgCryDsq+vLxcuXCjo04qIFJ5TR2y3rjJl2PaLiMsq8LCzbt06brrppoI+rYhI4QkMvU7YsWguHREXl+vRWF9++WWm2xMTE4mNjeXtt9/m7bffzndhIiJFIi0Ftn8GZBF2DAM6Dy/SkkSkYOU67PTq1SvT7WXLlqV27dq8/fbb3HPPPfmtS0SkcGVkAIZtPau7ptjm0nl/wr99dwzg31FZDyyEijVNLlZE8iPXYcdqzWy0goiIC/n7GLwyAOp3hLunQsfBtu0t+8D6hf+bZ6fzcAUdkWIg1312brvtNhITE+3Pn3vuORISEuzPz5w5Q3i4hmiKiJPa+gmMawinDkP9To77KtaEATNh3Ae2rwo6IsVCrsPOmjVrSElJsT+fMWMGZ8+etT9PT093WChURMQppKXC68PhpbugURd46Seo187sqkSkCOT6NtbVCnBOQhGRwlPKA6zpEL0IOg7Jel4dESl28h12REScVkYGfPECVKoLt9wBDy41uyIRMUGub2NZLBYsV/1GdPVzERHTnfkTpkXCsonw569mVyMiJsp1y45hGAwZMgQvLy8ALl26xP3334+vry+AQ38eERFTbPsvLBgJnqVhagzU72B2RSJiogJb9fxqixcvzlNBZtBCoCLFSHoaPNrYduvq/jehbKDZFYlIITFl1XNXpbAjUgwcigUvX6hUB86dgTKB6oQsUsyZsuq5iEiRs1rh81kwMQI+m2nbVracgo6I2Gk0loi4rjN/wWuD4JcNcMd4uOdpsysSESeksCMirikjHSa3h9SLMOUbaNAp+9eISImksCMiruVSMlgzoLQfRC+GyuG221YiIllQnx0RcR1//Ajjm8Lih23Pw9sq6IhIthR2RMT5Wa3w5UswoQV4lYY7Hje7IhFxIbqNJSLOLSMDZnSH3Wuh52PQ7xnw8DK7KhFxIQo7IuK8DAPc3W2dj3s+Co1uNbsiEXFBpt7G2rx5M7fffjuhoaFYLBY+//xzh/1Dhgyxr8V1+dG1a1eHY86ePUv//v3x8/MjICCA4cOHc/78+SJ8FyJS4FIuwJsP2G5dAfR6XEFHRPLM1LCTnJxMo0aNeP3117M8pmvXrpw4ccL++OCDDxz29+/fn71797Ju3TpWrlzJ5s2bGTVqVGGXLiKF5chP8Hgz2LAYfDSjuYjkn6m3sbp160a3bt2ue4yXlxchISGZ7vvtt99Ys2YNO3fupFmzZgC89tpr3Hbbbbz44ouEhoYWeM0iUkisVlj1Krz7hG1dq1mxtmHlIiL55PSjsTZu3EhQUBC1a9dm9OjRnDlzxr5v27ZtBAQE2IMOQGRkJG5ubmzfvj3Lc6akpJCUlOTwEBEnsPtr6BoNz21X0BGRAuPUHZS7du1Knz59qFatGocOHWLixIl069aNbdu24e7uTnx8PEFBQQ6vKVWqFIGBgcTHx2d53pkzZzJt2rTCLl9EcuKHleDpAw07w4Qvwd2p/1sSERfk1P+r3HPPPfbvGzRoQMOGDalRowYbN26kc+fOeT7vhAkTGDdunP15UlISlStXzletIpJLKRfhnfGw5nXoPNwWdhR0RKQQuNT/LNWrV6d8+fIcPHiQzp07ExISwqlTpxyOSU9P5+zZs1n28wFbPyAvL83TIWKaIz/DnH5w8hCMmAtdHzC7IhEpxpy+z86V/vzzT86cOUPFihUBiIiIICEhgdjYWPsxMTExWK1WWrRoYVaZInI9Viu80h8sbvD8D9AtGiwWs6sSkWLM1Jad8+fPc/DgQfvzw4cPs3v3bgIDAwkMDGTatGn07duXkJAQDh06xOOPP07NmjWJiooCoG7dunTt2pWRI0eyYMEC0tLSGDNmDPfcc49GYomY6fgBiFkEp45AUFXoNMy2cGfqJQgKgyc+h8AbwdPb5EJFpCSwGIZhmHXxjRs30rFjx2u2Dx48mPnz59OrVy9+/PFHEhISCA0NpUuXLjz99NMEBwfbjz179ixjxoxhxYoVuLm50bdvX1599VXKlCmT4zqSkpLw9/cnMTERPz/N6yGSLzGLYd4IW2uNYfz71QreZaB+R/jPF2ZXKCLFRE4/v00NO85CYUekgBw/AGPr2MJNZmZsg9oti7YmESm2cvr57VJ9dkTEycUsyrr/jZs77FSrjogUPYUdESk4p47Ybl1lyrDtFxEpYgo7IlJwylcGsgo7FltnZRGRIqawIyIF48yf8PO6rFt2DMM2eaCISBFT2BGR/PvpG3isCZw7A3c+ZZtDx80d3P79anGDBxZCxZpmVyoiJZBLzaAsIk7qhxVQrQk8vAz8ykOHwbB+4f/m2ek8XEFHREyjoedo6LlInpw7Cwd3QJOukJ5ma71xdze7KhEpQXL6+a2WHRHJvUOx8OKdkJ4Kcw+Cl4/ZFYmIZEl9dkQk5wwDvn4TJraCsuXh2a0KOiLi9BR2RCTnvngB3rjP1gfn2W9t61yJiDg53cYSkexZrbaRVW37Q7lK0Laf2RWJiOSYWnZE5Pq2fw6PNoakv6HcjQo6IuJyFHZEJHMZ6fDO4zCrN1SsBaU8za5IRCRPdBtLRK71zwl4+R7Y9x0MfglufyTrBT5FRJycwo6IXCv+EJw6DNM2QHhbs6sREckX3cYSERvDgG8/hIwMqNsG5h5Q0BGRYkEtOyICyYnw+jDYvhx8b4AmUeDhZXZVIiIFQmFHpKQ78jO80BeSTsMTn9uCjohIMaLbWCIl2Z+/wYSW4O0LL8TCLXeYXZGISIFTy45ISZSRYVu088Y6MHQ2tB+kZR9EpNhSy45ISXPyMExoYZss0GKBLvcp6IhIsaawI1KSxK6Cx5vCubNQoYrZ1YiIFAmFHZGSICMDPpgEM7pDnTa2/jnVbza7KhGRIqE+OyIlQdol2Pkl9J8BvZ6wLeopIlJCKOyIFGf7t0HZchB6Ezy/Ezy0vpWIlDz69U6kODIM+OpVmNQOPp9l26agIyIllFp2RIqbi+dh/gj47iPo8QgMfN7sikRETKWwI1KcGAZMi4Rje+HRj6HV/5ldkYiI6RR2RIqLyxMF3jMdKoTBjbXNrkhExCko7Ii4urRUWPooJP0NjyyDxl3MrkhExKmog7KIK/v7GExuD+vegPC2ZlcjIuKU1LIj4iqOH4CYRXDqCARVhdDa8O548CwNz3wLtW4xu0IREaeksCPiCmIWw7wRtrWsDMP21WqFyvVg+gbwK292hSIiTku3sUSc3fEDtqBjWMGa8b+vGPDnr5CcYHaFIiJOTWFHxNnFLLK15GTGYoH1C4u2HhERF2Nq2Nm8eTO33347oaGhWCwWPv/8c4f9hmEwefJkKlasiI+PD5GRkRw4cMDhmLNnz9K/f3/8/PwICAhg+PDhnD9/vgjfhUghO7jj35aczBi2PjwiIpIlU8NOcnIyjRo14vXXX890/6xZs3j11VdZsGAB27dvx9fXl6ioKC5dumQ/pn///uzdu5d169axcuVKNm/ezKhRo4rqLYgUvjPHr7PTYuusLCIiWbIYhmGYXQSAxWLhs88+o1evXoCtVSc0NJRHH32Uxx57DIDExESCg4NZsmQJ99xzD7/99hvh4eHs3LmTZs2aAbBmzRpuu+02/vzzT0JDQ3N07aSkJPz9/UlMTMTPz69Q3p9Ijl08B8ufg6qNoPVdcPhHGN/M1lfnahY3eG0/VKxZ9HWKiJgsp5/fTttn5/Dhw8THxxMZGWnf5u/vT4sWLdi2bRsA27ZtIyAgwB50ACIjI3Fzc2P79u1ZnjslJYWkpCSHh4jprFaIWQJjboKVL8M/J2zbqzWBBxbago2bO7j9+9XiZtuuoCMicl1OO/Q8Pj4egODgYIftwcHB9n3x8fEEBQU57C9VqhSBgYH2YzIzc+ZMpk2bVsAVi+TDmT/h+V5wKBZa32NbvLNClf/t7zQE6raxdUa+PM9O5+EKOiIiOeC0YacwTZgwgXHjxtmfJyUlUblyZRMrkhIrORF8/cE/GCreBMNegTqtMz+2Yk0YMLNo6xMRKQac9jZWSEgIACdPnnTYfvLkSfu+kJAQTp065bA/PT2ds2fP2o/JjJeXF35+fg4PkSJ18Tx8MAlG3QhH90ApD9u6VlkFHRERyTOnDTvVqlUjJCSE9evX27clJSWxfft2IiIiAIiIiCAhIYHY2Fj7MTExMVitVlq0aFHkNYtky2qFje/A2NrwxQvQ/WEIqmZ2VSIixZqpt7HOnz/PwYMH7c8PHz7M7t27CQwMpEqVKjz88MM888wz1KpVi2rVqjFp0iRCQ0PtI7bq1q1L165dGTlyJAsWLCAtLY0xY8Zwzz335HgklkiR+vQZ+GgKtLoLBs6CoDCzKxIRKfZMHXq+ceNGOnbseM32wYMHs2TJEgzDYMqUKbz55pskJCTQpk0b5s2bx0033WQ/9uzZs4wZM4YVK1bg5uZG3759efXVVylTpkyO69DQcylUp+Mg/iA06GQbYXXioFYoFxEpADn9/HaaeXbMpLAjheJSMnz2PHz5gq3z8Uu7s172QUREci2nn98lcjSWSKGyWmHLMnjvP3Dub7h9HPSZoKAjImIShR2RgmYYsHI21I6w9csJVgdkEREzKeyIFIS/j8H7E+C2sVDrFnh6M3j7ml2ViIjgxEPPRVxCygX4eBo8WBt+WgeJ/877pKAjIuI01LIjklcHdsALfW0Bp8cj0HcilFYHdxERZ6OwI5Jb585A2XIQUgPqd4S7pti+FxERp6TbWCI5deYveHUQjKkFSX/bAs/YdxR0REScnFp2RLKTchG+fBE+ew68fGHA8+B7g9lViYhIDinsiGRn7hDY8ZltHau+T9pWKRcREZehsCOSmYM7bV9rNoe7p0K/Z6FiTVNLEhGRvFGfHZErnT0Orw2GJ26BlXNs2yrVVdAREXFhatkRAUi9BF++BJ/NBE8fuG8BdB5hdlUiIlIAFHakZDh+AGIWwakjEFQVOg2D0Fr/25+eCuvegC73w51PgW+ASYWKiEhBU9iR4i9mMcwbYVuI0zBsXz+fZQs1v38PYxZDYCi89jt4eptdrYiIFDD12ZHi7fgBW9AxrGDNcPz6yXQ4+QcknbYdq6AjIlIsKexI8RazyNaSkxmLG7TsA1UbFW1NIiJSpBR2pHg7dcR26yozFuB0XFFWIyIiJlDYkeIrPQ0uJNpuWWXKYuusLCIixZo6KEvxk5EBW5bBx1NtfXKyYhjQeXiRlSUiIuZQy44UP9Z0+HASVGkAL/0E0Ytt/XPc3MHt368WN3hgoSYLFBEpAdSyI67PMOCHFfDJ0zDuQ9sq5C/99L81rKo2hLptYP3C/82z03m4go6ISAmhsCOuyzBg99e2VpyDO6FeB0hLse27erHOijVhwMwiL1FERMynsCOu69Nn4MPJUDsCpq6HBp3MrkhERJyQwo64lt+/h+REaBIFbftDjWbQpGvWc+mIiEiJp7AjruGPXfDBJNi1Cpr2sIWdkOq2h4iIyHUo7IhzO3cW5o+E7cshtDY88gG0usvsqkRExIUo7IhzSjgJAcFQ2g9SL8KYJdCuP7jrr6yIiOSO5tkR53LyMMwdCvdVhri9tnDz1CroOFhBR0RE8kSfHuIczvxpG121fiGULQeDXrTNlyMiIpJPCjviHP47A7Z9Cv1mQLdo8CptdkUiIlJMWAwjqyWhS46kpCT8/f1JTEzEz8/P7HJKhnNn4PNZEFITbh1pe17KE3zKml2ZiIi4iJx+fqvPjhSt5AT4YDKMrgZr5sGl87btZcsp6IiISKHQbSwpOn/thwktbUs6dBsDvR4Hv/JmVyUiIsWcwo4UrpQL8OMaaNkHKtayBZyOQ+CGimZXJiIiJYTCjhSOtBRY96at4/G5v+H1Q1ChCvSZYHZlIiJSwjh1n52pU6disVgcHnXq1LHvv3TpEtHR0ZQrV44yZcrQt29fTp48aWLFAsCGpTCmFix+GBp3gVf32YKOiIiICZy+ZadevXp888039uelSv2v5EceeYSvvvqKTz75BH9/f8aMGUOfPn347rvvzCi1ZDh+AGIWwakjEFQVOg2D0FqQkQHWdPDwgrhfoHYruGsqVKqTzQlFREQKl9OHnVKlShESEnLN9sTERBYuXMiyZcvo1KkTAIsXL6Zu3bp8//33tGzZsqhLLf5iFsO8EbYVxg3D9vXzWdBlFPyyEToMhj7/gUGztAq5iIg4Dae+jQVw4MABQkNDqV69Ov379ycuLg6A2NhY0tLSiIyMtB9bp04dqlSpwrZt2657zpSUFJKSkhweko3jB2xBx7CCNcPx69oF4F8BGt1qO1ZBR0REnIhTh50WLVqwZMkS1qxZw/z58zl8+DBt27bl3LlzxMfH4+npSUBAgMNrgoODiY+Pv+55Z86cib+/v/1RuXLlQnwXxUTMoqxDjMUNareGGk2LtiYREZEccOrbWN26dbN/37BhQ1q0aEFYWBgff/wxPj4+eT7vhAkTGDdunP15UlKSAk92Th6yteJkxoKtD4+IiIgTcuqWnasFBARw0003cfDgQUJCQkhNTSUhIcHhmJMnT2bax+dKXl5e+Pn5OTwkC8mJ8PkLsGu1rZ9Opiy2zsoiIiJOyKXCzvnz5zl06BAVK1akadOmeHh4sH79evv+/fv3ExcXR0REhIlVFiMZGfBoI/jgSWgcZbtdlRnDgM7Di7Y2ERGRHHLq21iPPfYYt99+O2FhYRw/fpwpU6bg7u7Ovffei7+/P8OHD2fcuHEEBgbi5+fHgw8+SEREhEZiZSer4eNgW9Jh5Rzo94xtvapR8yGsIZS7EWKWwLzh//bdMYB/R2U9sBAq1jTr3YiIiFyXU4edP//8k3vvvZczZ85QoUIF2rRpw/fff0+FChUAmD17Nm5ubvTt25eUlBSioqKYN2+eyVU7uayGj/edCMf2wo7PwT8Y2g+AOq3h5v/1m6LTEKjbBtYv/F9Q6jxcQUdERJyaxTCy7IhRYuR0iXiXd/wAjK2TdUfjoKrQ90loNwA8vYu0NBERkdzK6ee3U7fsSAG7PHw8s3hrcYNWd0PkiCIvS0REpDC5VAdlyafjv4P1OsPHTx8t0nJERESKgsJOSbF3E/zwJZk364CGj4uISHGlsFOc7dsK37xt+756U+gareHjIiJS4qjPjqvKcvXxdNj+Gax4GX7/Hqo1ho5DwacMDJsDVRtr+LiIiJQoGo2FC47Gymz4uGHAyNfhyxch/hDUaw+3PwpNu4PbVa05Jw5q+LiIiLi8nH5+K+zgYmHnesPHLW5wx3ho9X9alFNERIq9nH5+q8+Oq7nu6uMW20NBR0RExE5hx9WcOgLWjCx2Glp9XERE5CoKO67gjx9hwX1w7FdbH5usRlRp+LiIiMg1NBrLLNdbjBMg5QJ89xF8vQAO7IDAG6FFb9txn8/K/JwaPi4iInINhR0zZLUY5wMLoeNg2/NlT8FXc6BxV/jPF3DzbeD+7x/XAws1fFxERCSHNBqLIh6Nld1inH2fhH7PwJk/IT0NgqtlfpyGj4uISAmnhUCd1fUW4wQ4ccD2tVyl65+nYk0YMLNASxMRESmO1EG5qJ06YrvllBk3t+t0PhYREZG80CdrUfp9OxyKzTrsaDSViIhIgdNtrMJmGPDTOlg+E/ZuhKBqcLlfcWbHajSViIhIgVLYyY/sho8DJCfArN5QKRzG/xea3wGb3tVoKhERkSKi0VjkcTRWVotx3rfAtv+bt2DKN1DazzZyKqSG4zIPGk0lIiKSL1oINBdyHXayGz4O0LIvDJuT/agqERERyRMNPS9M1x0+boHIETD6zaKuSkRERDKh0Vh5cd3h4xa4eK5IyxEREZGsKezkRYWw6+zU8HERERFnorCTW+f/gYM7su6vo+HjIiIiTkVhJzcMA569DQ7/CN0fss127OZum/nYzd32XMPHRUREnIo6KOeEYUBaCnh6w+CX4IaKtgU6u43R8HEREREnp6HnZDN0LeUCvBUNCfHw5CrHuXJERETENBp6XhCOH4AX77StRH7fAgUdERERF6Swk5Xtn8HcIRAQAs9th7AGZlckIiIieaAOylf6aKqtNQdsyzk06gLP71TQERERcWHqs8MV9/zucMOvlAEPLIKOg207detKRETEKeW0z45adq5ktdpGXs0bDvGHFHRERESKAYWdzFgstiHlIiIi4vIUdjJl2ObOEREREZensJMprW8lIiJSXBSbsPP6669TtWpVvL29adGiBTt27Mj7ybS+lYiISLFRLMLORx99xLhx45gyZQq7du2iUaNGREVFcerUqdydyM1N61uJiIgUM8Vi6HmLFi1o3rw5c+fOBcBqtVK5cmUefPBB/vOf/2T7evvQtTcfwa/HAwo6IiIiLqDEDD1PTU0lNjaWyMhI+zY3NzciIyPZtm1b7k5291QFHRERkWLG5ZeL+Pvvv8nIyCA4ONhhe3BwMPv27cv0NSkpKaSkpNifJyYmAraEKCIiIq7h8ud2djepXD7s5MXMmTOZNm3aNdsrV65sQjUiIiKSH+fOncPf3z/L/S4fdsqXL4+7uzsnT5502H7y5ElCQkIyfc2ECRMYN26c/XlCQgJhYWHExcVd94eVmaSkJCpXrsyxY8eue7+woF9r5rXzW7dZXLXuK7nSe3ClWq/kqnUXN/pzkJwwDINz584RGhp63eNcPux4enrStGlT1q9fT69evQBbB+X169czZsyYTF/j5eWFl5fXNdv9/f3z/I/Kz8/PlNeaee381m0WV637Sq70Hlyp1iu5at3Fjf4cJDs5aaRw+bADMG7cOAYPHkyzZs245ZZbmDNnDsnJyQwdOtTs0kRERMRkxSLs3H333Zw+fZrJkycTHx9P48aNWbNmzTWdlkVERKTkKRZhB2DMmDFZ3rbKjpeXF1OmTMn01pazvtbMa+e3brO4at1XcqX34Eq1XslV6y5u9OcgBalYTCooIiIikhWXn1RQRERE5HoUdkRERKRYU9gRERGRYk1hR0RERIo1hR0RETGVxslIYSs2Q8+LwjvvvJOj4wYNGlQsrivmS05OxtfX1+wyRApV69ateeedd6hZs6bZpUgxpaHnueDm5kaZMmUoVapUlr+JWCwWzp49e832/ASW/Fw3v9eePn16jl47efLkHB1XVFy17qvVqFGDpUuX0qZNG7NLydbmzZtzdFy7du0KuZLc0S8T5rvrrrtYtWoVzz//PNHR0WaXI8VQiQs7+fkQrFevHidPnmTAgAEMGzaMhg0b5vi6+Qks+blufq/t5uZGaGgoQUFB133trl27clVTYXPVuq/2+OOPM2fOHB566CGeffZZPD09zS4pS25ublgsFiDr2xIWi4WMjIyiLCtb+f1lQgrGJ598wpgxY2jYsCGLFy+mUqVKZpckxUiJCzv5/RDcvn07ixYt4qOPPqJmzZoMHz6c/v37Z7tQXX4DS16vm99rd+/enZiYGKKiohg2bBg9evTAzc35u3q5at2Z+f777xk2bBhubm68++67NGnSxOySMlWuXDnKli3LkCFDGDhwIOXLl8/0uJws2leU8vtvUwrO6dOniY6OZt26dQwcOJBSpRx7Wrz88ssmVSYuzyhhbrvtNsPb29u44447jC+++MLIyMjI03kuXLhgLF261OjQoYNRunRpo1+/fsalS5eu+5rvv//eGDVqlOHv7280bdrUmDdvnpGYmFjo183vtf/66y9jxowZxk033WSEhIQYjz/+uLFv375c1W0GV607M5cuXTIee+wxw9vb27j99tuN3r17OzycQUpKivHhhx8aXbp0MXx8fIy+ffsaq1atMqxWq9mlZasg/m1K/qWnpxuTJ082SpUqZbRp08bo0KGD/dGxY0ezyxMXVuLCjmEU7Ifgpk2bjA4dOhhubm7G2bNnc/SavAaW/F63IK69adMmY8iQIUbZsmWNVq1aGRcuXMhV3WZx1bovS0xMNAYNGmT4+PgYAwYMMIYMGeLwcDZHjx41pk2bZlSvXt248cYbjYkTJxppaWlml5Wtgvi3KXnzyy+/GDfffLNRtWpVIyYmxuxypJgpkWHnSnn5EPzzzz+NZ5991qhZs6ZRsWJFY/z48cZvv/2Wp2vnJrAU1HXzcu3LLn8Y3HLLLYaPj4/L/PbrqnUbhmF8/fXXRqVKlYzmzZsbv/76q9nl5Moff/xhdOzY0XBzczPOnDljdjk5ltd/H5I3M2fONLy8vIyhQ4caSUlJZpcjxVCJDzu5+RD86KOPjK5duxo+Pj5Gr169jC+++MJIT0/P1fXyElgK4rp5vfZlW7duNUaMGGH4+fkZzZo1M15//XXjn3/+yXUNRc1V675s1KhRhpeXlzFt2rQ8/Zmb4dKlS8b7779vdO7c2ShdurTxf//3f8bq1avNLitbBfnLhOROSEiI8eWXX5pdhhRjJa6D8mXbtm1j0aJFfPzxx9x0000MHTqUfv36ERAQkOVr3NzcqFKlCv379yc4ODjL48aOHXvNto8//pjFixezadMmoqKiGDp0KN27d8fd3T3bWvNz3fxee9asWSxZsoS///6b/v37M3ToUJfowOmqdV+tfv36vPPOO9x8881ml5KtHTt2sHjxYj788EOqVq3K0KFDGTBgAIGBgWaXdl35+fchBePMmTOUK1fO7DKkGCtxYSc/H4JVq1a1D63NisVi4Y8//rhme34CS36um99rX35tjx49rjvs2dlGSbhq3VdLTU29bv3Hjh1jypQpLFq0qAirytzln/ngwYNp2rRplsf17NmzCKvKXn5/mZCCcfHiRWJjYwkMDCQ8PNxh36VLl/j4448115HkWYkLO2Z9COY3sGTGarXmaDh1fq7doUOHHL02JiYm2zqKkqvWnVs//fQTN998s1PMXZOTv4vOOM9OYfzblNz5/fff6dKlC3FxcVgsFtq0acOHH35IxYoVATh58iShoaFO93dHXEeJCzs5+RAE2LBhQxFUkz+enp789NNP1K1b1+xSpJB8+eWX193/xx9/8Oijj+pDQFxa7969SUtLY8mSJSQkJPDwww/z66+/snHjRqpUqaKwI/lW4sJOfuWnqfW3337j+++/p1WrVtSuXZt9+/bxyiuvkJKSwoABA+jUqVOmrxs3blym21955RUGDBhgv9ed09ao5ORkPv74Yw4ePEhoaCj33nuv0/eryIsTJ04wf/58vv32W06cOIGbmxvVq1enV69eDBkyxCX6ZFyelfh6/0ydsbVEJDeCg4P55ptvaNCgAWCbgfuBBx5g1apVbNiwAV9fX4UdyR9z+kU7r7i4OGPo0KGZ7tu/f78RFhZmWCwWw83NzWjXrp1x/Phx+/74+HjDzc0t09euXr3a8PT0NAIDAw1vb29j9erVRoUKFYzIyEijU6dOhru7u7F+/fpMX2uxWIzGjRs7TLDVoUMHw2KxGM2bN892wq26devah/3GxcUZYWFhhr+/v9G8eXMjMDDQCAoKMv74449MXxsbG+uw75133jFatWplVKpUyWjdurXxwQcfZHldM+3cudM+QVybNm0Md3d3Y+DAgcbdd99tBAQEGK1atXKJIa6hoaHG559/nuX+H3/8Mcu/c2azWq1GTEyM8eabbxorVqwwUlNTzS4pSytWrDAmTZpkfPvtt4ZhGMb69euNbt26GVFRUcYbb7xhcnXFX9myZTOdViE6OtqoVKmSsXnzZqf9ey6uQWHnKrt3787yH1WvXr2M7t27G6dPnzYOHDhgdO/e3ahWrZpx9OhRwzCuH3YiIiKMJ5980jAMw/jggw+MG264wZg4caJ9/3/+8x/j1ltvzfS1M2fONKpVq3ZNGCpVqpSxd+/ebN+TxWIxTp48aRiGYfTv399o1aqVkZCQYBiGYZw7d86IjIw07r333kxf27BhQ2PdunWGYRjGW2+9Zfj4+Bhjx4415s+fbzz88MNGmTJljIULF2ZbQ1Fr3bq1MXXqVPvzd99912jRooVhGIZx9uxZo3HjxsbYsWPNKi/Hbr/9dmPSpElZ7t+9e7dhsViKsKKsdevWzf736syZM0aLFi0Mi8ViVKhQwXBzczPq1KljnDp1yuQqr7VgwQKjVKlSRtOmTQ0/Pz/j3XffNcqWLWuMGDHCuO+++wwfHx9jzpw5ZpdZrDVv3tx45513Mt0XHR1tBAQEKOxIvpS4sPPFF19c9zF79uws/1EFBQUZP//8s/251Wo17r//fqNKlSrGoUOHrht2/Pz8jAMHDhiGYRgZGRlGqVKljF27dtn379mzxwgODs6y7h07dhg33XST8eijj9p/Q85L2Klevbrx9ddfO+z/7rvvjMqVK2f6Wh8fH+PIkSOGYRhGkyZNjDfffNNh//vvv2+Eh4dnW0NR8/HxMQ4dOmR/npGRYXh4eBjx8fGGYdgm6gsNDTWrvBzbvHnzdeeoOX/+vLFx48YirChrV/49Gz16tBEeHm5vFTx27JjRtGlT4/777zezxEyFh4fb/17HxMQY3t7exuuvv27fv3jxYqNu3bpmlVcizJgxw+jWrVuW+0ePHu00oV5cU4kLO5dvQVksliwfWQWW/DS1+vn5GQcPHrQ/L1OmjMOH8ZEjRwxvb+/r1n7u3Dlj0KBBRsOGDY09e/YYHh4eOQ47l3+jDg0NNfbs2eOw/3rXLleunPHDDz8YhmELe7t373bYf/DgQcPHxyfbGopaWFiY/ZaEYRjG8ePHDYvFYp8h+/Dhw9n+vCV3rgw7tWvXNr744guH/d98841RrVo1M0q7Lh8fH3vrrGEYhoeHh8O/kcOHDxulS5c2ozQRKSCuuQx0PlSsWJHly5djtVozfWS12jlAnTp1+OGHH67ZPnfuXO64447rzh9StWpVDhw4YH++bds2qlSpYn8eFxdnH2aZlTJlyrB06VImTJhAZGRkrjrrde7cmZtvvpmkpCT279/vsO/o0aNZTujVrVs35s+fD0D79u359NNPHfZ//PHH1KxZM8d1FJVevXpx//33s2bNGjZs2ED//v1p3749Pj4+AOzfv58bb7zR5CqLn8sjHf/55x9q1KjhsK9mzZocP37cjLKuq1y5chw9ehSA48ePk56eTlxcnH3/0aNHi2UHfpGSpJTZBRS1pk2bEhsbyx133JHp/uuNfOnduzcffPABAwcOvGbf3LlzsVqtLFiwINPXjh492iGc1K9f32H/6tWrsxyNdbV77rmHNm3aEBsbS1hYWLbHT5kyxeF5mTJlHJ6vWLGCtm3bZvra559/ntatW9O+fXuaNWvGSy+9xMaNG6lbty779+/n+++/57PPPstR3UXpmWee4cSJE9x+++1kZGQQERHBe++9Z99vsViYOXOmiRUWT0OGDMHLy4u0tDQOHz5MvXr17Pvi4+OvO0O5We644w6GDx/O4MGD+fLLLxk0aBCPPvqofSTc+PHj6dKli9llikg+lLih51u2bCE5OZmuXbtmuj85OZkffviB9u3bF3FlzishIYHnnnuOFStW8Mcff2C1WqlYsSKtW7fmkUceoVmzZmaXmKVLly6Rnp5+TcCTgjd06FCH5926deOuu+6yP3/88cf5+eefWbNmTVGXdl3Jyck88sgjbNu2jVatWvHaa6/x6quv8uSTT5KWlkb79u356KOPCAoKMrtUEcmjEhd2RMQcycnJuLu74+3tbXYpOXLp0iXS0tIoW7as2aWISD6VuD47ImKOs2fP8sADD5hdRo55e3tTtmxZjh07xrBhw8wuR0TyQS07IlIknGkdr9xw1bpF5H9KXAdlESkcOVnHyxm5at0iknNq2RGRAuGq63i5at0iknPqsyMiBSI/c1iZyVXrFpGcU9gRkQJxeQ6rrGTXemIWV61bRHJOfXZEpECMHz+e5OTkLPfXrFmTDRs2FGFFOeOqdYtIzqnPjoiIiBRruo0lIiIixZrCjoiIiBRrCjsiIiJSrCnsiIiISLGmsCMiIiLFmsKOiIiIFGsKOyIiIlKsKeyIiIhIsfb/EFTggLz7k30AAAAASUVORK5CYII="
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjsAAAHBCAYAAACPN3q5AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8pXeV/AAAACXBIWXMAAA9hAAAPYQGoP6dpAABeD0lEQVR4nO3dd3gU5drH8e+mB0hCTZOqVCGAAiKoBAhdmqCggIKgohQP0hRsoAICKnpE8ciLIFiwYqNIBxE5QhQF9QBKC5IQaQmEkITkef9Ys7qmkECS2d38Ptc112Zmnpm5Z4HMzTNPsRljDCIiIiIeysvqAERERESKk5IdERER8WhKdkRERMSjKdkRERERj6ZkR0RERDyakh0RERHxaEp2RERExKMp2RERERGPpmRHREREPJqSHZEStmjRImw2W57Lxo0bHWVtNhujRo3K9TwffvhhjvJDhgxxOpefnx9XXXUV48ePJzk5Oc+Yxo4dS5MmTQCYMmUKNpuN48eP51q2UaNGtG3b1mlbXFwcI0aMoG7dugQGBlKxYkWioqK49957iYuLc5TLPnf2UqZMGapWrUrnzp15+eWXOXPmzEW+Pbv8vsPx48cX6Bzu6ODBg9hsNhYtWpRvuY0bNzp9J97e3oSFhXHbbbfxyy+/OMpl/3mIeDofqwMQKa0WLlxI/fr1c2y/+uqrL+u8gYGBrF+/HoDTp0/z4Ycf8vzzz/Pjjz+yevXqXI/5+OOPGTp06CVd78iRI1x77bWUL1+ecePGUa9ePZKSkvj55595//332b9/P9WqVXM6ZtWqVYSEhJCens7Ro0dZt24dEydOZPbs2Xz++eeOxOticvsOIyMjL+k+PNH06dNp164d6enp7Nixg6eeeop169axa9currjiCu655x66dOlidZgixU7JjohFGjVqRPPmzYv8vF5eXlx//fWO9S5durB//37WrFnDgQMHqFWrllP57du3c+jQIfr27XtJ15s/fz7Hjx/n22+/dTp37969mTx5MllZWTmOadasGZUrV3as33777YwaNYro6Gh69uzJ3r178ff3v+i1i+s7PHfuHGXKlCny85b0tevUqeP4u9CmTRvKly/PsGHDWLRoEY8++ihVq1alatWqRXItEVem11gipUB2QnDs2LEc+z766CPq1atHw4YNL+ncJ06cwMvLi9DQ0Fz3e3kV7NdMkyZNePTRRzl8+DDvvffeJcXyT5999hmtWrWiTJkyBAUF0bFjR7755hunMtmvcr777jtuvfVWKlSowFVXXcXy5cux2Wxs377dUfajjz7CZrNx8803O52jcePGTsniK6+8Qps2bQgNDaVs2bJERUUxa9YsMjIynI5r27YtjRo1YvPmzbRu3ZoyZco4atiOHj1Kv379CAoKIiQkhP79+5OQkHBZ30d24nPo0CGne/+7mjVr0r17d5YtW0bjxo0JCAjgyiuv5N///rdTuaysLJ555hnq1atHYGAg5cuXp3Hjxrz00kuXFaNIcVCyI2KRzMxMLly44LRkZmYWy7UOHDiAj48PV155ZY59H3300SXX6gC0atWKrKws+vTpw5dffplv26CL6dmzJwCbN28uUPncvsNs77zzDr169SI4OJh3332XBQsWcOrUKdq2bcuWLVtynKtPnz7Url2bDz74gNdee43o6Gh8fX1Zu3ato8zatWsJDAxk06ZNjsQlMTGR3bt306FDB0e53377jQEDBrBkyRK++OILhg0bxuzZsxk+fHiO68bHxzNo0CAGDBjAihUrGDFiBKmpqXTo0IHVq1czY8YMPvjgA8LDw+nfv3/Bvsg8/PrrrwBUqVIl33I7d+5kzJgxPPTQQyxbtozWrVvzr3/9i+eee85RZtasWUyZMoU77riD5cuX89577zFs2DBOnz59WTGKFAsjIiVq4cKFBsh18fb2dioLmJEjR+Z6ng8++MAAZsOGDY5tgwcPNmXLljUZGRkmIyPDHD9+3MybN894eXmZyZMn5zjHzp07DWBiY2Md25588kkDmD/++CPX6zZs2NBER0c71rOysszw4cONl5eXAYzNZjMNGjQwDz30kDlw4IDTsRc7d2pqqgFM165dc92fLb/vMCMjw2RmZprIyEgTFRVlMjMzHcedOXPGhIaGmtatW+eI6YknnshxnRtvvNG0b9/esV67dm0zYcIE4+XlZTZt2mSMMebtt982gNm7d2+usWZmZpqMjAyzePFi4+3tbU6ePOnYFx0dbQCzbt06p2PmzZtnAPPpp586bb/33nsNYBYuXJjv97NhwwYDmPfee89kZGSYc+fOmc2bN5vatWsbb29v88MPPzjd+9/VqFHD2Gw2s3PnTqftHTt2NMHBwSYlJcUYY0z37t1N06ZN841DxFWoZkfEIosXL2b79u1Oy3//+9/LPm9KSgq+vr74+vpSuXJlHnjgAfr378+0adNylP3oo4+oWbMm11577SVfz2az8dprr7F//35effVV7r77bjIyMpgzZw4NGzZk06ZNBT6XMaZQ187tO/Tx8WHPnj0cPXqUO++80+k1Wrly5ejbty/btm3j3LlzTufKrXYrJiaGr7/+mtTUVA4dOsSvv/7K7bffTtOmTVmzZg1gr+2pXr06derUcRz3/fff07NnTypVqoS3tze+vr7cddddZGZmsnfvXqdrVKhQgfbt2ztt27BhA0FBQY6armwDBgwo1PfTv39/fH19KVOmDG3atCEzM5MPP/yQxo0b53tcw4YNczQSHzBgAMnJyXz33XcAXHfddfzwww+MGDHismv0RIqbGiiLWKRBgwYXbVzr7e2d56ut7Fc2vr6+TtsDAwMdr4ESEhJ4/vnneffdd2ncuDGPPPKIU9kPP/wwx0Pex8f+ayG/6/7zmgA1atTggQcecKy///773HHHHUyYMIFvv/02v9t0yG5LUtAeVXl9hydOnAAgIiIix77IyEiysrI4deqUU0Pg3Mp26NCBqVOnsmXLFg4dOkTlypW55ppr6NChA2vXruXpp59m3bp1Tq+wDh8+zE033US9evV46aWXqFmzJgEBAXz77beMHDmS1NRUp2vkdt0TJ04QFhaWY3t4eHg+30ZOM2fOpH379nh7e1O5cuUcveLyktt1srdlf7eTJk2ibNmyvPXWW7z22mt4e3vTpk0bZs6cWSyNxkUuh2p2RFxYWFgYv//+e677srf/86Ho5eVF8+bNad68Od27d2fVqlU0bNiQqVOnOo1588svv/DLL7/kSHayz5fbdY0xxMfH5/og/qd+/frRuHFjdu/efdGy2T777DOAHOP4FFalSpUAe3uYfzp69CheXl5UqFDBaXtu4820bNmScuXKsXbtWtasWUNMTAw2m42YmBhHTdLhw4edkp1PPvmElJQUPv74YwYNGsSNN95I8+bN8fPzyzXW3K5bqVKlXBuTF7aB8pVXXknz5s255pprCpzo5HWd7G3Z362Pjw9jx47lu+++4+TJk7z77rvExcXRuXPnHLVmIlZTsiPiwjp06MCGDRv4448/nLYbY/jggw+oWbMmtWvXzvcc/v7+vPLKK5w/f55nnnnGsf2jjz4iMjLSqZs6QPv27bHZbLn2iFq1ahXJyclOD/fcEgqAs2fPEhcXV+Bamh9++IHp06dTs2ZN+vXrV6Bj8lKvXj2uuOIK3nnnHadXYykpKXz00UeOHloX4+vrS5s2bVizZg3r16+nY8eOANx00034+Pjw2GOPOZKfbNnJy9+7zhtjmD9/foHjb9euHWfOnHEkf9neeeedAp/jcvz000/88MMPOa4dFBSU6yvP8uXLc+uttzJy5EhOnjzJwYMHSyROkYLSaywRi+zevdup91C2q666ytFb5oknnuDzzz+nZcuWPPLII9SpU4eEhATmz5/P9u3bef/99wt0rejoaLp168bChQt55JFHqFWrFh9++CF9+vTJUbNw1VVXMWrUKGbPns3p06fp1q0bgYGBbN++nWeffZbmzZs7tR2ZNm0aX3/9Nf3796dp06YEBgZy4MAB5s6dy4kTJ5g9e3aOeGJjYwkJCSEjI8MxqOCSJUsIDQ3l888/z7MWpKC8vLyYNWsWAwcOpHv37gwfPpy0tDTHPT377LMFPldMTAzjxo0DcCR5gYGBtG7dmtWrV9O4cWOnbvcdO3bEz8+PO+64g4kTJ3L+/HnmzZvHqVOnCnzNu+66izlz5nDXXXcxbdo06tSpw4oVK/jyyy8LfI7LERkZSc+ePZkyZQoRERG89dZbrFmzhpkzZzqSxB49ejjGOapSpQqHDh3ixRdfpEaNGk7tl0RcgqXNo0VKofx6EgFm/vz5TuX37dtnBg0aZCIiIoyPj48pX7686dSpU44ePMb81RsrN7t27TJeXl7m7rvvNr/++muOnlx/l5WVZebNm2eaN29uypQpY/z8/EydOnXMww8/bM6cOeNUdtu2bWbkyJGmSZMmpmLFisbb29tUqVLFdOnSxaxYscKpbHbvn+zF39/fREREmE6dOpmXXnrJJCcnF+o73L59e77lPvnkE9OyZUsTEBBgypYta2JiYszXX3+da0x59RD74YcfDGDq1KnjtH3atGkGMGPHjs1xzOeff26aNGliAgICzBVXXGEmTJhgVq5cmeM7j46ONg0bNsz1ukeOHDF9+/Y15cqVM0FBQaZv375m69atheqN9cEHH+RbLq/eWDfffLP58MMPTcOGDY2fn5+pWbOmeeGFF5zKPf/886Z169amcuXKxs/Pz1SvXt0MGzbMHDx4MN9riljBZkwhuz+IiNubNWsWzz33HPHx8Xh7e1sdjriQmjVr0qhRI7744gurQxEpMmqzI1IKTZw4kcTERCU6IlIqKNkRERERj6bXWCIiIuLRXKZmZ8aMGdhsNsaMGePYZoxhypQpREZGEhgYSNu2bfnpp5+cjktLS2P06NFUrlyZsmXL0rNnT44cOVLC0YuIiIircolkZ/v27bz++us5hjCfNWsWL7zwAnPnzmX79u2Eh4fTsWNHzpw54ygzZswYli1bxtKlS9myZQtnz56le/fuxTahooiIiLgXy5Ods2fPMnDgQObPn+80oqkxhhdffJFHH32UPn360KhRI958803OnTvnGFgrKSmJBQsW8Pzzz9OhQweuueYa3nrrLXbt2uU0U7GIiIiUXpYPKjhy5EhuvvlmOnTo4DS664EDB0hISKBTp06Obf7+/kRHR7N161aGDx9ObGwsGRkZTmUiIyNp1KgRW7dupXPnzrleMy0tjbS0NMd6VlYWJ0+epFKlSrkO3S4iIiKuxxjDmTNniIyMdJr0958sTXaWLl3Kd999x/bt23Psy56H5Z9z8ISFhTkmC0xISMDPzy/HHDdhYWH5ziEzY8YMpk6dernhi4iIiAuIi4ujatWqee63LNmJi4vjX//6F6tXryYgICDPcv+saTHGXLT25WJlJk2axNixYx3rSUlJVK9enbi4OIKDgwt4ByIiIlIiMi/A/BHwyxaYFQv+gQAkJydTrVo1goKC8j3csmQnNjaWxMREmjVr5tiWmZnJ5s2bmTt3Lnv27AHstTcRERGOMomJiY7anvDwcNLT0zl16pRT7U5iYiKtW7fO89r+/v5Ok/RlCw4OVrIjIiLiSjLS4cUBsONT+NdbUCUsR5GLVYJY1kA5JiaGXbt2sXPnTsfSvHlzBg4cyM6dO7nyyisJDw9nzZo1jmPS09PZtGmTI5Fp1qwZvr6+TmXi4+PZvXt3vsmOiIiIuIG0VJh1C+z4HCZ8BDf0v6TTWFazExQURKNGjZy2lS1blkqVKjm2jxkzhunTp1OnTh3q1KnD9OnTKVOmjGPG5ZCQEIYNG8a4ceOoVKkSFStWZPz48URFRTlmJxYRERE3Fbcb9m6DyV9Ak46XfBrLe2PlZ+LEiaSmpjJixAhOnTpFy5YtWb16tdO7uTlz5uDj40O/fv1ITU0lJiaGRYsWac4fERERd5V6BvzKQO0W8NpBCMy/Tc7FaLoI7A2cQkJCSEpKyrfNTmZmJhkZGSUYmXvy9fVVsikiIpcm+Tg83Rka3ARDX8y/aAGf3y5ds+MqjDEkJCRw+vRpq0NxG+XLlyc8PFzjFomISMGdioepHSH5D2g/tMhOq2SnALITndDQUMqUKaMHeD6MMZw7d47ExEQAp550IiIiefrjMEyJgfRUeGoTVK1fZKdWsnMRmZmZjkSnUqVKVofjFgID7eMfJCYmEhoaqldaIiJycatehaxMeOYrCKtVpKe2fG4sV5fdRqdMmTIWR+Jesr8vtXESEZF8Zfw5fdOAafDstiJPdEDJToHp1VXh6PsSEZGL2v89jKoD//savL0hJLRYLqNkR0RERErenm/gyXZQPhyuaFCsl1KyU0pNmTKFpk2bWh2GiIiURrs3wlMdoUZjeHItBFUs1ssp2fFgQ4YMwWazYbPZ8PX15corr2T8+PGkpKQwfvx41q1bZ3WIIiJS2lzIgHn3Qr3W8NhKKFP8c1KqN1ZJOboP1r8BiQchtKZ9/IDIOsV+2S5durBw4UIyMjL46quvuOeee0hJSWHevHmUK1eu2K8vIiLikJUFPr7wxGqoEAF+ASVyWdXslIT1C+HB+vDpbNj6vv3zwfqwflGxX9rf35/w8HCqVavGgAEDGDhwIJ988kmO11hDhgyhd+/eTJ06ldDQUIKDgxk+fDjp6emOMh9++CFRUVEEBgZSqVIlOnToQEpKSrHfg4iIeIDNb9vb6JxPsfe4KqFEB1SzU/yO7oNX7wGTBdkTc2R/vjoMGtwIEbVLLJzAwMA8u4OvW7eOgIAANmzYwMGDB7n77rupXLky06ZNIz4+njvuuINZs2Zxyy23cObMGb766is024iIiFzUmvnwn+HQbgj4llySk03JzqU6FW9f/q5sBXu2mn4ejvxs37biZbDZ/kpw/s5mg4+mQbfRUKWmvYFW0h9wIs65XEBQkbzy+vbbb3nnnXeIiYnJdb+fnx9vvPEGZcqUoWHDhjz11FNMmDCBp59+mvj4eC5cuECfPn2oUaMGAFFRUZcdk4iIeLgvXoSFD0HXUTD0JfAq+ZdKSnYu1er/wPtTnbe1GQj/egtOHIEJzS5+jqxM2LDIvjy4BKIH2V9z/d8o53JNOsETX15SmF988QXlypXjwoULZGRk0KtXL15++WVeffXVHGWbNGniNHhiq1atOHv2LHFxcTRp0oSYmBiioqLo3LkznTp14tZbb6VChQqXFJeIiJQCv263Jzq9H4ZBM+z/ybeAkp1L1Wk4tOjpvK3snw/+SlVhdqz95xUvw6Yl9sTmn7y8IfrOv2p2AFr3g3qtnMsFXPrU9u3atWPevHn4+voSGRmJr69voc9hs9nw9vZmzZo1bN26ldWrV/Pyyy/z6KOP8t///pdatYp+tEsREfEAtVvAtC32nlcWDjarZOdSVYiwL7nxC4Arr7X/3GcybFycezljoO+jzm12QqrYlyJStmxZatcuWJugH374gdTUVMfcVtu2baNcuXJUrVoVsCc9N9xwAzfccANPPPEENWrUYNmyZYwdO7bI4hURETdnDCwaCxF1oMsIqH+D1RGpN1axi6wDIxaAzctek+P156fNy769BBsnX0x6ejrDhg3j559/ZuXKlTz55JOMGjUKLy8v/vvf/zJ9+nR27NjB4cOH+fjjj/njjz9o0KB4R70UERE3kpkJr91nb6djc50UQzU7JaH9EHuvq3UL/hpnJ2aYSyU6ADExMdSpU4c2bdqQlpbG7bffzpQpUwAIDg5m8+bNvPjiiyQnJ1OjRg2ef/55unbtam3QIiLiGjIvwMuD4eulMPpNaHuX1RE52Iz6DpOcnExISAhJSUkEBzuP5Hj+/HkOHDhArVq1CAgo+e5yJWXIkCGcPn2aTz75pEjOV1q+NxER+dM7j8EnM+Ghd6HVrSVyyfye33+nmh0RERG5fD3GQlR7++JiXOeFmoiIiLiX1DPw0iBIPGQfK84FEx1QzY78adGiRVaHICIi7uTsKXimK/z+i33AwNAaVkeUJyU7IiIiUjhJf8DTneCPwzBlPVxVgIF0LaRkp4DUjrtw9H2JiHiozEx4urN9yqSnN0H1RlZHdFFKdi4ie8Thc+fOOQbbk4s7d+4cwCWN2CwiIi7M2xsGTIPwqyCyrtXRFIiSnYvw9vamfPnyJCYmAlCmTBlsFg557eqMMZw7d47ExETKly+Pt7e31SGJiEhROLrXPiPAHU/Dte41xpqSnQIIDw8HcCQ8cnHly5d3fG8iIuLmDu+GqR2gXEXoOQ7Kudck0Ep2CsBmsxEREUFoaCgZGRlWh+PyfH19VaMjIuIpfouFpzpBlerw+Gq3S3RAyU6heHt76yEuIiKlx5FfYEp7uKIBPLbSLRMdULIjIiIieYmoAz3HQ/cxEBhkdTSXTMmOiIiIOItdDgFB0LAN3Pa41dFcNk0XISIiIn/Z+gHM7A3r/s/qSIqMkh0RERGx27gY5twOrfvBiAVWR1NklOyIiIgIrF8ELw+G9kNh9GLw8ZxBYZXsiIiICNRuAX0fhftft4+S7EGU7IiIiJRWxsCGNyHtHFRvCAOeAQ+cJcDSZGfevHk0btyY4OBggoODadWqFStXrnTsHzJkCDabzWm5/vrrnc6RlpbG6NGjqVy5MmXLlqVnz54cOXKkpG9FRETEvRgDb02CuUPg20+tjqZYWZrsVK1alWeffZYdO3awY8cO2rdvT69evfjpp58cZbp06UJ8fLxjWbFihdM5xowZw7Jly1i6dClbtmzh7NmzdO/enczMzJK+HREREfeQlQULHoRPZsLdc+CmO6yOqFjZjDHG6iD+rmLFisyePZthw4YxZMgQTp8+zSeffJJr2aSkJKpUqcKSJUvo378/AEePHqVatWqsWLGCzp07F+iaycnJhISEkJSURHBwcFHdioiIiOsxBl4dBhsWwX2vQaf7rI7okhX0+e0ybXYyMzNZunQpKSkptGrVyrF948aNhIaGUrduXe69916nyThjY2PJyMigU6dOjm2RkZE0atSIrVu35nmttLQ0kpOTnRYREZFSwWaD0Fr2HldunOgUhuUjKO/atYtWrVpx/vx5ypUrx7Jly7j66qsB6Nq1K7fddhs1atTgwIEDPP7447Rv357Y2Fj8/f1JSEjAz8+PChWc5+oICwsjISEhz2vOmDGDqVOnFut9iYiIuJT08/DTJrims0eMilwYltfs1KtXj507d7Jt2zYeeOABBg8ezM8//wxA//79ufnmm2nUqBE9evRg5cqV7N27l+XLl+d7TmMMtnxak0+aNImkpCTHEhcXV6T3JCIi4lLSzsGzPWF2HziVd2WAp7K8ZsfPz4/atWsD0Lx5c7Zv385LL73Ef/7znxxlIyIiqFGjBvv27QMgPDyc9PR0Tp065VS7k5iYSOvWrfO8pr+/P/7+/kV8JyIiIi7oXDJM7w4HvoNJX0CFcKsjKnGW1+z8kzGGtLS0XPedOHGCuLg4IiIiAGjWrBm+vr6sWbPGUSY+Pp7du3fnm+yIiIiUCmdOwtQOcOhHeGINRLWzOiJLWFqzM3nyZLp27Uq1atU4c+YMS5cuZePGjaxatYqzZ88yZcoU+vbtS0REBAcPHmTy5MlUrlyZW265BYCQkBCGDRvGuHHjqFSpEhUrVmT8+PFERUXRoUMHK29NRETEBRgIKAdT18OV11odjGUsTXaOHTvGnXfeSXx8PCEhITRu3JhVq1bRsWNHUlNT2bVrF4sXL+b06dNERETQrl073nvvPYKCghznmDNnDj4+PvTr14/U1FRiYmJYtGgR3h421LWIiEiBnfgdTBZUrgZT1nnkqMiF4XLj7FhB4+yIiIjHOHYApsRA+FXw5JqLl3djbjfOjoiIiFym3/fAYzeBlzc88H9WR+MylOyIiIh4goM/wuNtoEwIPLMZQmtYHZHLULIjIiLiCRIPQJUa8PQmqBBhdTQuxfJxdkREROQyHN0HEbXhul7QrDuog04OqtkRERFxVz+sgXFNYM18+7oSnVwp2REREXFH2z+3j4zcqB1E32l1NC5NyY6IiIi7+fo9+zxXzXvAxGXgH2h1RC5NbXZERETciTHw9ftww+0waiF461F+MfqGRERE3EVSIoSEwkPv2pMcL72gKQh9SyIiIu7g0+dgVF04Hge+fkp0CkHflIiIiCszBt6bAosnQLfRUKmq1RG5Hb3GEhERcVXGwOKJ8NlzMHA69JlkdURuScmOiIiIqzpxBNa/AUNfgpsftDoat6VkR0RExNVkZkJmBlSuBnP3QlAlqyNya2qzIyIi4koy0mHOHfBCf/trLCU6l03JjoiIiKtIPw+z+8L2T6Hd3WCzWR2RR9BrLBEREVdwPgVm9ob/bYFHPoNrOlsdkcdQsiMiIuIKtrwLe7fBY6ugYbTV0XgUJTsiIiJWyrxgHw05Zhg07gChNa2OyOOozY6IiIhVTiXAxObwzYf29jlKdIqFanZERESscDwOpnaA82ehWkOro/FoSnZERERKWsJ+mNLe/vPTmyH8Kmvj8XB6jSUiIlLSXr8ffPzgma+U6JQA1eyIiIiUFGPsbXNGLQKbF1QItzqiUkE1OyIiIiVh73/h0RsgKREqRirRKUFKdkRERIrbT5vtjZFtXuDjb3U0pY6SHRERkeL0/ZfwTBeo0xIe/xLKhlgdUamjNjsiIiLF5fQxmHULRLWH8R+CX4DVEZVKSnZERESKS/kwmLwc6t8Avn5WR1Nq6TWWiIhIUVu7AN593P5zVDslOhZTsiMiIlKUVrwM8+6B5OP2ruZiOSU7IiIiRWXZTFjwIPQcB/e9ah9TRyynZEdERKQobH4b3noE+j0Jd81WouNC1EBZRESkKFzf1z6Ozk13WB2J/INqdkRERC5VVha8OR4O/mDvVq5ExyVZmuzMmzePxo0bExwcTHBwMK1atWLlypWO/cYYpkyZQmRkJIGBgbRt25affvrJ6RxpaWmMHj2aypUrU7ZsWXr27MmRI0dK+lZERKS0ybwALw+GL+bA4d1WRyP5sDTZqVq1Ks8++yw7duxgx44dtG/fnl69ejkSmlmzZvHCCy8wd+5ctm/fTnh4OB07duTMmTOOc4wZM4Zly5axdOlStmzZwtmzZ+nevTuZmZlW3ZaIiHi6jHR44Xb4eimMeQfaDLQ6IsmHzRjX6hdXsWJFZs+ezdChQ4mMjGTMmDE8/PDDgL0WJywsjJkzZzJ8+HCSkpKoUqUKS5YsoX///gAcPXqUatWqsWLFCjp37lygayYnJxMSEkJSUhLBwcHFdm8iIuIh5gyAbR/B+A+gRU+roym1Cvr8dpk2O5mZmSxdupSUlBRatWrFgQMHSEhIoFOnTo4y/v7+REdHs3XrVgBiY2PJyMhwKhMZGUmjRo0cZXKTlpZGcnKy0yIiIlJg3UbD5C+U6LgJy5OdXbt2Ua5cOfz9/bn//vtZtmwZV199NQkJCQCEhYU5lQ8LC3PsS0hIwM/PjwoVKuRZJjczZswgJCTEsVSrVq2I70pERDxOyml4+1G4kAH1WkGTjlZHJAVkebJTr149du7cybZt23jggQcYPHgwP//8s2O/7R/jFBhjcmz7p4uVmTRpEklJSY4lLi7u8m5CREQ8W/JxeLI9rJ4Hx/ZbHY0UkuXJjp+fH7Vr16Z58+bMmDGDJk2a8NJLLxEeHg6Qo4YmMTHRUdsTHh5Oeno6p06dyrNMbvz9/R09wLIXERGRXJ2KhyfawsnfYepGuKKe1RFJIVme7PyTMYa0tDRq1apFeHg4a9ascexLT09n06ZNtG7dGoBmzZrh6+vrVCY+Pp7du3c7yoiIiFyyMyfhsTb2V1hPbYKaja2OSC6BpSMoT548ma5du1KtWjXOnDnD0qVL2bhxI6tWrcJmszFmzBimT59OnTp1qFOnDtOnT6dMmTIMGDAAgJCQEIYNG8a4ceOoVKkSFStWZPz48URFRdGhQwcrb01ERDxBuQrQ9i5oMwjCalkdjVwiS5OdY8eOceeddxIfH09ISAiNGzdm1apVdOxob/Q1ceJEUlNTGTFiBKdOnaJly5asXr2aoKAgxznmzJmDj48P/fr1IzU1lZiYGBYtWoS3t7dVtyUiIu4u7meI3wfX9YLbHrc6GrlMLjfOjhU0zo6IiDjs/x6e6gihtWDGNtB/nl2W242zIyIiYrk938CT7SDsSnj8SyU6HkLJjoiICMAvW+w1OjWi4Mm1EFTR6oikiCjZERERAQitCa37w2OroIyaNHgSJTsiIlK6fb/KPmhgpaowcgEElLU6IiliSnZERKT02vw2TO8Oy1+yOhIpRkp2RESkdFozH/59J0TfCf2mWB2NFCMlOyIiUvos/ze8dh90HgEjFqjXlYdTsiMiIqWPfxnoPRHueRm89Cj0dJaOoCwiIlJijIFd66FxDHS4x+popAQpnRUREc9nDLwxBqZ2gF+3Wx2NlDDV7IiIiGfLzITX74e1/wf3vgq1W1gdkZQwJTsiIuK5Mi/Ay4Ph66UwahG0G2x1RGIBJTsiIuK5LmRAUiI8tBRa32Z1NGIRJTsiIuJ50lLhxBGIrANPrAabzeqIxEJqoCwiIp4l9QxM6wbPdLHX7CjRKfVUsyMiIp7j7Cl7onPkZ5i8HHx8rY5IXICSHRER8QxJf8DTneCPw/DkOqjd3OqIxEUo2REREc9w7Dc4lwxPbYQaUVZHIy5EyY6IiLi3U/EQXAXqXg///p9eXUkOaqAsIiLu6+g+eKQlvD3Zvq5ER3KhZEdERNzT4d3w+E0QUA66j7E6GnFhSnZERMT9/BYLT7SF8uHw1CaoGGl1ROLC1GZHRETcz5Z3Ibw2PLYSylWwOhpxcUp2RETEfaSchrLl4c5ZkJ4KAWWtjkjcgF5jiYiIe4hdDvfXgL3/BS8vJTpSYEp2RETE9X3zEcy6BRq1h1pNrY5G3IxeY4mIiGs5ug/WvwGJByG0JpSrCG8/Aq37w+g31b1cCk3JjoiIuI71C+HVe+yTdxpj/8zKhAY3wYNLwNvb6gjFDek1loiIuIaj++yJjsmyJzjZnwD/+xoSD1gbn7gtJTsiIuIa1r9hr8nJjc0G6xaUbDziMZTsiIiIa0g8aH91lStj3y9yCZTsiIiIawgMsr+6ypXN3lhZ5BIo2REREdcQWS/vfcZAzLCSi0U8ipIdERGxTlYWbP/M/nOvcXD/62DzAi9v+8CBXt729RELIKK2tbGK21LXcxERscbZU/DSIPh+JTz3PdRsAh3vhUbt7I2Rs8fZiRmmREcui6U1OzNmzKBFixYEBQURGhpK79692bNnj1OZIUOGYLPZnJbrr7/eqUxaWhqjR4+mcuXKlC1blp49e3LkyJGSvBURESmMQ7vg4Raw9xt4dIU90ckWURsGzYCx79o/lejIZbI02dm0aRMjR45k27ZtrFmzhgsXLtCpUydSUlKcynXp0oX4+HjHsmLFCqf9Y8aMYdmyZSxdupQtW7Zw9uxZunfvTmZmZknejoiIFMSv22HS9RBQDmbugGu6WB2ReDhLX2OtWrXKaX3hwoWEhoYSGxtLmzZtHNv9/f0JDw/P9RxJSUksWLCAJUuW0KFDBwDeeustqlWrxtq1a+ncuXPx3YCIiBRejSZwyyPQcxz4l7E6GikFXKqBclJSEgAVK1Z02r5x40ZCQ0OpW7cu9957L4mJiY59sbGxZGRk0KlTJ8e2yMhIGjVqxNatW0smcBERyV/SH/BMN/h1B/j6wW2PK9GREuMyDZSNMYwdO5Ybb7yRRo0aObZ37dqV2267jRo1anDgwAEef/xx2rdvT2xsLP7+/iQkJODn50eFChWczhcWFkZCQkKu10pLSyMtLc2xnpycXDw3JSIi9gRndh9IPw/pqVZHI6WQyyQ7o0aN4scff2TLli1O2/v37+/4uVGjRjRv3pwaNWqwfPly+vTpk+f5jDHY8hh2fMaMGUydOrVoAhcRkbytXwivP2BvgDzhI6hU1eqIpBRyiddYo0eP5rPPPmPDhg1UrZr/P4SIiAhq1KjBvn37AAgPDyc9PZ1Tp045lUtMTCQsLCzXc0yaNImkpCTHEhcXVzQ3IiIif0k5DW9Pgug74alNSnTEMpYmO8YYRo0axccff8z69eupVavWRY85ceIEcXFxREREANCsWTN8fX1Zs2aNo0x8fDy7d++mdevWuZ7D39+f4OBgp0VERIrIyaNw5gSULQ/P7YQH5oNfgNVRSSlmabIzcuRI3nrrLd555x2CgoJISEggISGB1FT7O92zZ88yfvx4vvnmGw4ePMjGjRvp0aMHlStX5pZbbgEgJCSEYcOGMW7cONatW8f333/PoEGDiIqKcvTOEhGREvK/r2FCM3hjjH29Qu49aUVKkqVtdubNmwdA27ZtnbYvXLiQIUOG4O3tza5du1i8eDGnT58mIiKCdu3a8d577xEUFOQoP2fOHHx8fOjXrx+pqanExMSwaNEivL29S/J2RERKL2Pgy3nwxr+gbisY/JzVEYk42IwxxuogrJacnExISAhJSUl6pSUiUljGwGv3wdr/g24P2hMdH1+ro5JSoKDPb5fpjSUiIm7KZrMPFPjgEogeZHU0Ijko2RERkUvz4zrYHwu9J0K3UVZHI5Inl+h6LiIibsQY+GQ2PN3JnvBkXrA6IpF8qWZHREQKLvUsvDoMtr5vn9/qjmdAnUHExSnZERGRgvvwafhuOYz/EFr1tToakQJRsiMiIhd35gQEVYJbH4d2Q6BqA6sjEikwtdkREZG8ZWXB+0/ByNrwx2EILKdER9yOanZERCR3KUnw8l2w43PoN0VzW4nbUrIjIiI5HfkFZvaG08dg0ufQ7GarIxK5ZEp2REQkJ5sXBFWGSV9AZB2roxG5LGqzIyIidpmZ8PkcOJ8CV9SDaVuU6IhHUM2OiIjYe1vNuQN2rYOIOtC8u30aCBEPcFnJzvHjxzl48CA2m42aNWtSqVKloopLRERKyv7vYXYfSD0Dj6+GxjFWRyRSpC7pNdZPP/1EmzZtCAsLo2XLllx33XWEhobSvn179uzZU9QxiohIcTnxOzx6g30MnVmxSnTEIxW6ZichIYHo6GiqVKnCCy+8QP369THG8PPPPzN//nxuuukmdu/eTWhoaHHEKyIiRSHzAnh5Q6Ur7LOVX9sN/AOtjkqkWNiMMaYwBzz88MOsXbuWr7/+moCAAKd9qamp3HjjjXTq1IkZM2YUaaDFKTk5mZCQEJKSkggODrY6HBGR4nUqAZ7vB9f3he7/sjoakUtW0Od3oV9jrVmzhocffjhHogMQGBjIhAkT+PLLLwt7WhERKQl7t8HEZhC/D2o3tzoakRJR6GRn//79XHvttXnub968Ofv377+soEREpBisfh0ebwNVasLsWKh/g9URiZSIQrfZOXPmTL5VRUFBQZw9e/ayghIRkSKWlQVb34cO98KQOeDrZ3VEIiXmkrqenzlzJtfXWGB/f1bIZkAiIlJcjsfZp3yo3RweXQ6+/lZHJFLiCp3sGGOoW7duvvttGohKRMR6P22C526DsFowY5sSHSm1Cp3sbNiwoTjiEBGRomIMLH8J3hwPV7eBse9pNGQp1Qqd7ERHRxdHHCIiUlTeHA+fvwA9x8OgGeCtmYGkdCv0v4CsrCyysrLw8fnr0GPHjvHaa6+RkpJCz549ufHGG4s0SBERKYQbb4faLeyfIlL4QQXvvvtufH19ef311wF7Y+WGDRty/vx5IiIi+Pnnn/n000/p1q1bsQRcHDSooIi4ve9XwapXYfyH6mklpUaxDSr49ddfc+uttzrWFy9ezIULF9i3bx8//PADY8eOZfbs2ZcWtYiIFI4x8NF0mNYNsjIh47zVEYm4nEInO7///jt16tRxrK9bt46+ffsSEhICwODBg/npp5+KLkIREcnduWSY3RfeeRT6PgaTPocyqp0W+adCJzsBAQGkpqY61rdt28b111/vtF+DCoqIlIDYL+DHtfDwJ3DHU+BV6F/pIqVCof9lNGnShCVLlgDw1VdfcezYMdq3b+/Y/9tvvxEZGVl0EYqIiLPDu+2fNw2Al/fCdb2sjUfExRU62Xn88cd58cUXueqqq+jcuTNDhgwhIiLCsX/ZsmXccIPmWxERKXKZmfDOY/BQFOzeaN9WIdzSkETcQaG7nrdr144dO3awdu1awsPDue2225z2N23alOuuu67IAhQREeDsKXhxAPywGgbOgIYa80ykoArd9dwTqeu5iLi0hP3wVEdIOQ0PvQtNO1kdkYhLKOjzu9A1O4sXL851e0hICPXq1aN+/fqFPaWIiOSnQoR92ofbnrDPcyUihVLomp0KFSrkuv3s2bNkZWXRrVs33nnnHYKCgookwJKgmh0RcTmZF+ztc9oMhBpRVkcj4pKKbVDBU6dO5bqkpaWxbds2Dh8+zNSpUy8reBGRUi0pEaZ2hM+egwPfWx2NiNsrskEZvLy8aNGiBc8//zyff/55UZ1WRKR0+XU7TGgGR36GKeuh7V1WRyTi9op8BKratWtz5MiRApWdMWMGLVq0ICgoiNDQUHr37s2ePXucyhhjmDJlCpGRkQQGBtK2bdscIzSnpaUxevRoKleuTNmyZenZs2eBYxARcRnp52Fmb6h4BcyOhYZtrI5IxCMUebLz22+/UbVq1QKV3bRpEyNHjmTbtm2sWbOGCxcu0KlTJ1JSUhxlZs2axQsvvMDcuXPZvn074eHhdOzYkTNnzjjKjBkzhmXLlrF06VK2bNnC2bNn6d69O5mZmUV9eyIiRS8jDVLPgF8APLoSnt4ElQr2e1RELq7Iup4bY/j+++8ZOnQoHTp04Lnnniv0Of744w9CQ0PZtGkTbdq0wRhDZGQkY8aM4eGHHwbstThhYWHMnDmT4cOHk5SURJUqVViyZAn9+/cH4OjRo1SrVo0VK1bQuXPni15XDZRFxDInj9rnt6pUFcZ/YHU0Im6l2BooV6hQgYoVK+ZY/P39adGiBVdccQVTpky5pKCTkpIAqFixIgAHDhwgISGBTp3+GlPC39+f6Ohotm7dCkBsbCwZGRlOZSIjI2nUqJGjzD+lpaWRnJzstIiIlLhftsCEa+F4HPQcb3U0Ih6r0OPsvPjii7luDw4Opn79+jRo0OCSAjHGMHbsWG688UYaNWoEQEJCAgBhYWFOZcPCwjh06JCjjJ+fX44u8WFhYY7j/2nGjBnqMSYi1lr1KrzxL6jXGsa9D+XDLn6MiFySQic7ERERtGvXDl9f3yINZNSoUfz4449s2bIlxz6bzea0bozJse2f8iszadIkxo4d61hPTk6mWrVqlxC1iMglOnsKuoyEu2aDT9H+PhURZ4V+jXX//fdTpUoV+vfvzzvvvMPp06cvO4jRo0fz2WefsWHDBqfGzeHh9gnu/llDk5iY6KjtCQ8PJz09nVOnTuVZ5p/8/f0JDg52WkREil3iIVi/yP5z38kw9EUlOiIloNDJzv79+9m8eTNRUVG8+OKLhIeHExMTw7///W8OHjxYqHMZYxg1ahQff/wx69evp1Yt52HQa9WqRXh4OGvWrHFsS09PZ9OmTbRu3RqAZs2a4evr61QmPj6e3bt3O8qIiFjuh7UwsRl89AyknYOL1E6LSNG57N5YR48e5bPPPnPUzNStW5devXrRs2dPmjdvnu+xI0aM4J133uHTTz+lXr16ju0hISEEBgYCMHPmTGbMmMHChQupU6cO06dPZ+PGjezZs8cxJcUDDzzAF198waJFi6hYsSLjx4/nxIkTxMbG4u3tfdF7UG8sESk2xsCnz8Hbj0BUB/tEnkEVrY5KxCMU+PltitDZs2fNBx98YO68805TqVIlM23atHzLA7kuCxcudJTJysoyTz75pAkPDzf+/v6mTZs2ZteuXU7nSU1NNaNGjTIVK1Y0gYGBpnv37ubw4cMFjjspKckAJikpqVD3KyJyUZ8+Z0wfjHlrkjEXLlgdjYhHKejzu8jG2fm733//nYiICE6cOEGVKlWK+vRFTjU7IlLkMi+Atw+knLZ3MW/e3eqIRDxOsY2zk5+EhARGjx5N7dq18fLycotER0SkyO34AkbXg8SDULa8Eh0RixU62Tl9+jQDBw6kSpUqREZG8u9//5usrCyeeOIJrrzySrZt28Ybb7xRHLGKiLi2rCx4bwrM6AHVo6Cc2uaIuIJCj7MzefJkNm/ezODBg1m1ahUPPfQQq1at4vz586xcuZLo6OjiiFNExLWlnIaX7oTvlsMdT0OfyeBV5NMPisglKHSys3z5chYuXEiHDh0YMWIEtWvXpm7dunmOrCwiUiqcOAIHd8Lk5XBtV6ujEZG/KXSyc/ToUa6++moArrzySgICArjnnnuKPDAREbfw/Spo2BaqN4JXfgVff6sjEpF/KHQda1ZWltNUEd7e3pQtW7ZIgxIRcXmZF2DJw/BMV9j4pn2bEh0Rl1Tomh1jDEOGDMHf3/6P+vz589x///05Ep6PP/64aCIUEXE1ycdhzh2wez0Mfg463md1RCKSj0InO4MHD3ZaHzRoUJEFIyLi8lJOw8TmkJYCT6yBqPZWRyQiF1HoZGfhwoXFEYeIiHsoWx66PwQtb4Eq1a2ORkQKQP0iRUQuJiMd/m80rJlvX+/+LyU6Im6k0DU77dq1w5bLbL0hISHUq1ePkSNHUq1atSIJTkSkxB3dB+vfsI9+HFoTmveAtx6Gff+FYXOtjk5ELkGhk52mTZvmuv306dOsWLGCuXPnsmXLljzLiYi4rPUL4dV7wGazz1Zus8GyZ6FMCEzdCPVbWx2hiFyCIp8IdOTIkRw4cIAVK1YU5WmLlSYCFRGO7oMH64PJyrnP5gUv74GI2iUfl4jkyZKJQAGGDx/O999/X9SnFREpXuvfsNfk5MZmg3ULSjYeESkyRZ7sBAYGcv78+aI+rYhI8Uo8aH91lStj3y8ibqnIk53Vq1dTt27doj6tiEjxycqCpMTcX2EBYLM3VhYRt1ToBsqfffZZrtuTkpLYvn07CxYsYNGiRZcbl4hIyZl3j300ZGxALrU7xkDMsJKOSkSKSKGTnd69e+e6PSgoiPr167No0SJuu+22y41LRKT4ZaSDrx+0uxtuvANO/A6vDvuz7Y4B/uyVNWKBGieLuLFCJztZWXlV84qIuIm0c/DmeDi6xz7lw9U3/bWvwY32xsjZ4+zEDFOiI+LmCt1mp1u3biQlJTnWp02bxunTpx3rJ06c4Oqrry6S4EREitzBH2FiC9iwEFrdlrMHVkRtGDQDxr5r/1SiI+L2Cp3srFq1irS0NMf6zJkzOXnypGP9woUL7Nmzp2iiExEpSqtehYdbgI8vzIqFzvfn3d1cRDxGoV9j/VMRj0koIlJ8srKgywgYOAP8AqyORkRKyGUnOyIiLi12OfwWC/2egG6jrI5GRCxQ6NdYNpstx0SguU0MKiJiqbRUmD8KpneH33ZA5gWrIxIRixS6ZscYw5AhQ/D39wfg/Pnz3H///ZQtWxbAqT2PiIglDu2COXdAwq9wz1z7qyv9p0yk1Cp0sjN48GCn9UGDBuUoc9ddd116RCIil2vlXHtyM2sHVG9kdTQiYrEin/XcHWnWcxEPcPoYHPoRmnSE8yng5a1GyCIerqDPbzVQFhH3F7sCXrkbAoPgpV8goKzVEYmICynyiUBFREpM+nlY8C+YfjNc2QymfW0fQ0dE5G9UsyMi7us/98PXS2HoS9BttBohi0iulOyIiHsxBpISoXwY3PY49BwHNaKsjkpEXJiSHRFxH0mJ8MowiN8Lc3ZD+FVWRyQibkDJjoi4h++/hLmD7VM+jFqotjkiUmBqoCwiru+Dp+GZLlCzKbzwIzS72eqIRMSNqGZHRFyXMfZGx7VbwN1zoNuD4KX/o4lI4Vj6W2Pz5s306NGDyMhIbDYbn3zyidP+IUOGOObiyl6uv/56pzJpaWmMHj2aypUrU7ZsWXr27MmRI0dK8C5EpMgZA6vmwfP97D9f0wW6j1GiIyKXxNLfHCkpKTRp0oS5c+fmWaZLly7Ex8c7lhUrVjjtHzNmDMuWLWPp0qVs2bKFs2fP0r17dzIzM4s7fBEpDsnHYWZvmD8CgqvAhQyrIxIRN2fpa6yuXbvStWvXfMv4+/sTHh6e676kpCQWLFjAkiVL6NChAwBvvfUW1apVY+3atXTu3LnIYxaRYvTDWnj5LriQDo98Ci16Wh2RiHgAl68T3rhxI6GhodStW5d7772XxMREx77Y2FgyMjLo1KmTY1tkZCSNGjVi69ateZ4zLS2N5ORkp0VEXMBvO6BaQ3sjZCU6IlJEXDrZ6dq1K2+//Tbr16/n+eefZ/v27bRv3560tDQAEhIS8PPzo0KFCk7HhYWFkZCQkOd5Z8yYQUhIiGOpVq1asd6HiOTjyP9g9ev2n3tPhMe/hIqR1sYkIh7FpZOd/v37c/PNN9OoUSN69OjBypUr2bt3L8uXL8/3OGMMtnyGjZ80aRJJSUmOJS4urqhDF5GLMQZW/wcmXAvLX7LPc+XlpUbIIlLk3KrreUREBDVq1GDfvn0AhIeHk56ezqlTp5xqdxITE2ndunWe5/H398ff37/Y4xWRPJw5Aa/eA99+Ap2Gw5AXwC/A6qhExEO51X+hTpw4QVxcHBEREQA0a9YMX19f1qxZ4ygTHx/P7t278012RMRiS5+AnzfDxGUw/DXwL2N1RCLiwSyt2Tl79iy//vqrY/3AgQPs3LmTihUrUrFiRaZMmULfvn2JiIjg4MGDTJ48mcqVK3PLLbcAEBISwrBhwxg3bhyVKlWiYsWKjB8/nqioKEfvLBGxyNF9sP4NSDwIoTWhzSDIzIBaTWHANOgzGSpdYXGQIlIaWJrs7Nixg3bt2jnWx44dC8DgwYOZN28eu3btYvHixZw+fZqIiAjatWvHe++9R1BQkOOYOXPm4OPjQ79+/UhNTSUmJoZFixbh7e1d4vcjIn9av9D+mspm+2sU5GXPQmAQLDgGZcvbFxGREmAzxhirg7BacnIyISEhJCUlERwcbHU4Iu7t6D54sD6YrJz7bF7w8h6IqF3ycYmIxyno89ut2uyIiBtY/4a9Jic3NhusW1Cy8YhIqadkR0SKVuJB+6urXBn7fhGREqRkR0SKVmpy7q+wALDZGyuLiJQgJTsiUjTSz8O8e+G7FUAer7GMgZhhJRqWiIhbDSooIi4qYT88dyv8/guMWGBviPzqsD/b7hjgz15ZIxaocbKIlDglOyJy+Q7uhHNJMG0rXHmNfVuDG+2NkbPH2YkZpkRHRCyhrueo67nIJcnMhG0fQevb7DU46ec15YOIlKiCPr9VsyMihZeUCHMGwE8b7LU1V16rREdEXJaSHREpnP9thef72ad+eGKtPdEREXFh6o0lIgX3yxZ4ItreBue57yGq3UUPERGxmmp2ROTisrLAywvqXg9D5kCn4eDja3VUIiIFopodEclf3M8wrin872vw9oFuo5ToiIhbUbIjInn76l145Dr7iMhBla2ORkTkkug1lojklJEOb46DlXOhzSAY/hoElLU6KhGRS6JkR0RyOpdkn/bh3leh8/15z2IuIuIGlOyIyF9+XAfVroYKEfDSz+Drb3VEIiKXTW12RMTe2+qDp+GpjrDiZfs2JToi4iFUsyNS2p05AS/dCTtXQb8pcOtjVkckIlKklOyIlGYZ6TC5NSQfh0dXwjWdrY5IRKTIKdkRKY2Msb+68vWDAdPhquYQWsPqqEREioWSHZHS5nwK/Od+CK4Cd78ArfpaHZGISLFSA2WR0uToXph0Pfz3Y7iqmdXRiIiUCNXsiJQW2z6GuUOgQiQ8+y1Ub2h1RCIiJULJjkhpseNzaNoFRi6AwCCroxERKTFKdkQ82cmjcHg3NO0Ew/9jn8BToyGLSCmjNjsinmr3Rhh/DSwYDZkX7D2vlOiISCmkZEfE0xgDy2bC1Bio3gie+Qq8VYkrIqWXfgOKeJq3JsEnM6HPZLj9KfD2tjoiERFLKdkR8RSZmfbEpuN90OBGaN7d6ohERFyCXmOJeIL1C2HCtZCSBOFXKtEREfkbJTsi7iwtFV69B14ZCnWuAx8/qyMSEXE5eo0l4i6O7oP1b0DiQQitCY07wOIJ8PsvMPINaH+31RGKiLgkJTsi7mD9QnsNjs1m721ls9kbIQeHwvRvoFZTqyMUEXFZSnZEXN3RffZEx2SB+XNb9mfyHxBQzqrIRETcgtrsiLi69W/kPRigzQbrFpRsPCIibsbSZGfz5s306NGDyMhIbDYbn3zyidN+YwxTpkwhMjKSwMBA2rZty08//eRUJi0tjdGjR1O5cmXKli1Lz549OXLkSAnehUgxi9sNWZl57DT2NjwiIpInS5OdlJQUmjRpwty5c3PdP2vWLF544QXmzp3L9u3bCQ8Pp2PHjpw5c8ZRZsyYMSxbtoylS5eyZcsWzp49S/fu3cnMzOvhIOJmMtLz2WmzN1YWEZE82Ywx5uLFip/NZmPZsmX07t0bsNfqREZGMmbMGB5++GHAXosTFhbGzJkzGT58OElJSVSpUoUlS5bQv39/AI4ePUq1atVYsWIFnTt3LtC1k5OTCQkJISkpieDg4GK5P5ECy8qCjW9C/K8wcBoc+QXGNLK32fknmxe8vAciapd8nCIiFivo89tl2+wcOHCAhIQEOnXq5Njm7+9PdHQ0W7duBSA2NpaMjAynMpGRkTRq1MhRJjdpaWkkJyc7LSIu4eev4OEW9nFzjh+yJz5VG8CIBfbExssbvP78tHnZtyvRERHJl8v2xkpISAAgLCzMaXtYWBiHDh1ylPHz86NChQo5ymQfn5sZM2YwderUIo5Y5DJkZcFLg2DLu3BVc5j2NdRv/df+9kPsU0CsW/DXODsxw5ToiIgUgMsmO9ls/+iFYozJse2fLlZm0qRJjB071rGenJxMtWrVLi9QkUuRehb8AuyzkofWglGLIPpOe+3NP0XUhkEzSjxEERF357KvscLDwwFy1NAkJiY6anvCw8NJT0/n1KlTeZbJjb+/P8HBwU6LSInKyoINb8LourBmvn3bwGnQbnDuiY6IiFwyl/2tWqtWLcLDw1mzZo1jW3p6Ops2baJ1a3v1frNmzfD19XUqEx8fz+7dux1lRFzO/76GR1rC3CFwdRu4tpvVEYmIeDRLX2OdPXuWX3/91bF+4MABdu7cScWKFalevTpjxoxh+vTp1KlThzp16jB9+nTKlCnDgAEDAAgJCWHYsGGMGzeOSpUqUbFiRcaPH09UVBQdOnSw6rZE8vbTJniiLVzVDJ75yt4OR0REipWlyc6OHTto166dYz27Hc3gwYNZtGgREydOJDU1lREjRnDq1ClatmzJ6tWrCQoKchwzZ84cfHx86NevH6mpqcTExLBo0SK8vb1L/H5EcnU+Bb5bAa1vgwY3wYSP4Lreel0lIlJCXGacHStpnB0pFllZsPltePsROHsS5v4Kla6wOioREY/h9uPsiLi1Pd/A5Fbw8l1QrzW8+LMSHRERi7h813MRt/T1e3AhA57aBA3bWB2NiEippmRHpCiknYNPZ0O5StBtFAycAT5+oLZjIiKW02sskcuR3S5ndD34aDqcO23f7h+oREdExEWoZkfkUp05CdO6wb7/Qss+cNdsCL/S6qhEROQflOyIFNaZExBUCcpVgFrXwKBnoVFbq6MSEZE86DWWSEGlnYP3n4Lh1eHHdWCzwfB5SnRERFycanZELsYYe++qJRPh9DHoPgZqt7A6KhERKSAlOyIX8+VrMH8EtLzlz3Y5V1kdkYiIFIKSHZHcnPgdftsB1/WC6DvhivoQ1e7ix4mIiMtRsiPyd2mp8Pnz8PEMCK4C13SFwHJKdERE3JiSHRGwt8vZ+j4sngin46Hbg3Dr4+DrZ3VkIiJymZTsSOlxdB+sfwMSD0JoTWg/FCLr2PfZbLDhTXtX8rvW/rVdRETcnmY9R7OelwrrF8Kr99iTGmP++qzXCnpPhBY9If08+AVYHamIiBRQQZ/fqtkRz3d0nz3RMVmQndpnf/7vazh2wP6zEh0REY+kQQXF861/w16TkxsvbzidULLxiIhIiVKyI54v8aD9lVWujH2/iIh4LL3GEs9ljH1ah583219h5cpmb6wsIiIeSzU74pl+2QJPtoOnOkJw5bxfYxkDMcNKNjYRESlRSnbEM618BVJOwyOfwfM7YcQbYPOyt9Hx+vPT5gUjFkBEbaujFRGRYqSu56jruUc4+AMsfQKuvxXa3gnnkiGgnD2xyRb/K6xb8Nc4OzHDlOiIiLgxdT2X0uHIL7D0SfjmA/sEnTH32LeXyeUvfURtGDSjZOMTERHLKdkR97V7I0yNgYpV4YH/g7Z3gY+v1VGJiIiLUbIj7uWPw7BrHbS/G+rfAPfPhzYDwdff6shERMRFKdkR93DyKHw0HdbOh3IVodWtEBgEMUOtjkxERFyckh1xbcbAW5NgxUvgFwj9p0DX0RBYzurIRETETSjZEdd05qS9N5WvH1xIh94PQ/eHoGyI1ZGJiIib0Tg74lrOJcP7T8GIWvZu4gB3v2Cv0VGiIyIil0A1O+IazqfAyrnwySxIS4HOD8D1fayOSkREPICSHXENscth6eP2cXL6PgqVrrA6IhER8RBKdsQaGemw/g04vBvunWvvXVX3eqhS3erIRETEw6jNjpSszAuwfiE8WA/mj4BzSfZtXl5KdEREpFioZkdKTuYFmNAMDv1or8mZ9AVUb2h1VCIi4uGU7EjxMga+/RSadgL/MtDtQbjyWrjyGqsjExGRUkKvsaR4GAM7vrDX5My6BbZ/Zt/eYZgSHRERKVEunexMmTIFm83mtISHhzv2G2OYMmUKkZGRBAYG0rZtW3766ScLIxYA9nwDk1rBjB72gQGf2gg33m51VCIiUkq5/Gushg0bsnbtWse6t7e34+dZs2bxwgsvsGjRIurWrcszzzxDx44d2bNnD0FBQVaEWzoc3WfvSZV4EEJrQvuhEFkH0lLBPxDOnAAMPLEaGncAm83igEVEpDRz+WTHx8fHqTYnmzGGF198kUcffZQ+feyDz7355puEhYXxzjvvMHz48JIOtXRYvxBevceewBhj//xkFlRtAJWqwuOroNnN9kVJjoiIuACXfo0FsG/fPiIjI6lVqxa33347+/fvB+DAgQMkJCTQqVMnR1l/f3+io6PZunVrvudMS0sjOTnZaZECOLrPnuiYLMjKdP6M+8me4GQnQEp0RETERbh0stOyZUsWL17Ml19+yfz580lISKB169acOHGChIQEAMLCwpyOCQsLc+zLy4wZMwgJCXEs1apVK7Z78Cjr38g7ifHyhpNHleSIiIjLcelkp2vXrvTt25eoqCg6dOjA8uXLAfvrqmy2fzxcjTE5tv3TpEmTSEpKcixxcXFFH7ynMQb2brPX5ORewN6GR0RExMW4dLLzT2XLliUqKop9+/Y52vH8sxYnMTExR23PP/n7+xMcHOy0SB4yL8CWpfYu5D9tzKegzd5YWURExMW4VbKTlpbGL7/8QkREBLVq1SI8PJw1a9Y49qenp7Np0yZat25tYZQeZu7dMOcOCKoEIxeCLY+/MsZAzLCSjU1ERKQAXLo31vjx4+nRowfVq1cnMTGRZ555huTkZAYPHozNZmPMmDFMnz6dOnXqUKdOHaZPn06ZMmUYMGCA1aG7try6joO92/iqV6H+jRDVDno8ZF+uvPav418d9mfbHAP82StrxAKIqF3y9yIiInIRLp3sHDlyhDvuuIPjx49TpUoVrr/+erZt20aNGjUAmDhxIqmpqYwYMYJTp07RsmVLVq9erTF28pNX1/E7Z8KJI7B2vr131V3P2ZOdvyc5AO2HQIMbYd2Cv5KlmGFKdERExGXZjDHG6iCslpycTEhICElJSZ7dfufoPniwvj2ZyU2ZELj5X9B1FIRUKdnYRERECqmgz2+XrtmRIpbddTy39NbmZa+huX1qiYclIiJSnNyqgbJcpmP7867VsWEfJ0dERMTDKNkpLVJOw3cr7e10cqWu4yIi4pmU7HiyYwfgw2fsCU7Z8tB1hLqOi4hIqaM2O+4qv+7je7fBZ8/Dfz+GMuXhhtvtvaUGPQuR9dV1XEREShX1xsINe2Pl1n08O2HZuQq+fg/Ca9vHx2k7GALKOh8f/6u6jouIiNsr6PNbyQ5uluzk133c5gV3vwhVqkOz7uDtXeLhiYiIlJSCPr/VZsfd5DfzuM0Gp47Cdb2U6IiIiPxJyY67STyYd/dxzTwuIiKSgxoou4MTv8O6/4OIOvY2NjYvMJm5FFT3cRERkX9SsmOl/HpUZWXBD2tg9Wuw43PwC4C+j9nLfDIr9/Op+7iIiEgOSnaskteEnCP+D9rfDbFfwLO9oEZjuGcu3DQAyvzZ+GrEAnUfFxERKSD1xsKC3lgXm5Bz7j6oUgP2x0Kdlrk3SFb3cRERKeU0Eagru9iEnOsWwKAZUPf6vM8RUdteRkRERPKl3lhWOLY/7zmqbKhHlYiISBFSzU5J+uMwfPYcfL8y75od9agSEREpUqrZKQlxP8PLg2HkVbD5bWg3JO+aHfWoEhERKVKq2bkc+XUd/7t598DxOLhrNsTcA4HloNa16lElIiJSAtQbi0vsjZXnZJz/BxUiYdmz0H8qNGxjf31VPhx8/ZzPoR5VIiIil0y9sYrT0X32RMdk/dXuJvvzlaH2z6uag9efbwmrVM/9POpRJSIiUuyU7FyK/LqOA9xwOzz0Tt4TdoqIiEiJUQPlS5F4MO8Gxtm1OUp0REREXIKSnUuRb9dwdR0XERFxJUp2CiszE84l5z3Vg7qOi4iIuBQlO4X17mOw5jVo2cc+tYOXt/3VlZe3fV1dx0VERFyKGigXVPp58AuAm/8FTTpCVHt1HRcREXEDSnYuxhhY8TJ88SI8+1+oEG5fQF3HRURE3ICSnfyknrGPp7P1fej+EJQtb3VEIiIiUkhKdvIS9zPM6gOnjsL4D6FVX6sjEhERkUugBsp/994U++jIACmnIKAszNqhREdERMSNaW4s/ja3Ri8vgn0MPDDf3tg4K+uvQQJFRETEpRR0biw9yf8uK8veIHneffaeVkp0RERE3J6e5rmx2exdykVERMTtKdnJlbGPnSMiIiJuT8lOrjS/lYiIiKfwmGTn1VdfpVatWgQEBNCsWTO++uqrSz+Z5rcSERHxGB6R7Lz33nuMGTOGRx99lO+//56bbrqJrl27cvjw4cKdyMtL81uJiIh4GI/oet6yZUuuvfZa5s2b59jWoEEDevfuzYwZF5/OwdF17fWHCO4+QomOiIiIGyg1Xc/T09OJjY2lU6dOTts7derE1q1bC3ey/lOU6IiIiHgYt58u4vjx42RmZhIWFua0PSwsjISEhFyPSUtLIy0tzbGelJQE2DNEERERcQ/Zz+2LvaRy+2Qnm81mc1o3xuTYlm3GjBlMnTo1x/Zq1aoVS2wiIiJSfM6cOUNISEie+90+2alcuTLe3t45anESExNz1PZkmzRpEmPHjnWsnz59mho1anD48OF8v6zcJCcnU61aNeLi4vJ9X1gcx1t1bFEcbxV3jTubu8XvbvFmc9e4PYn+DKQgjDGcOXOGyMjIfMu5fbLj5+dHs2bNWLNmDbfccotj+5o1a+jVq1eux/j7++Pv759je0hIyCX/owoODr6sf5CXc7xVxxbF8VZx17izuVv87hZvNneN25Poz0AupiCVFG6f7ACMHTuWO++8k+bNm9OqVStef/11Dh8+zP333291aCIiImIxj0h2+vfvz4kTJ3jqqaeIj4+nUaNGrFixgho1algdmoiIiFjMI5IdgBEjRjBixIhLOtbf358nn3wy11dbxXmslde2Mm4ruWvc2dwtfneLN5u7xu1J9GcgRckjBhUUERERyYvbDyooIiIikh8lOyIiIuLRlOyIiIiIR1OyIyIiIh5NyY6IiFjq7NmzVocgHk7JjogL00NASoOoqCg2b95sdRjiwTxmnJ2S8NRTTxWo3BNPPKFrW8wdY85NVFQUb775Jm3atLE6lItavHhxgcrdddddxRxJ4bhr3J7ktttuo0OHDowePZrp06drbB0pcqVunJ3LeQh6eXkRGRlJaGhontPJ22w2vvvuO5e69uU++C/3vq3gjjHnZuLEibz44otu8RDw8vKiXLly+Pj45Pudnzx5soQjy5+7xu1ptm3bxtChQ7HZbCxZsoRrr73W6pDEg5S6ZOdyHoLdunVjw4YNdO7cmaFDh3LzzTfj7e3t8te+3Af/5d63Fdwx5ry4y0OgYcOGHDt2jEGDBjF06FAaN25sdUgF4q5xe6K0tDQee+wx5s6dS8eOHfHxcX758PHHH1sUmbg9U8p07drVBAQEmF69eplPP/3UXLhwoVDHHz161EyfPt3UrVvXhIeHm4kTJ5r//e9/Ln3ty73u5VzbSu4Yc17Onz9vxo8fbwICAkyPHj3MLbfc4rS4im3btpn77rvPhISEmGbNmplXX33VJCUlWR3WRblr3J4mKSnJ3HXXXSYwMNAMGjTIDBkyxGkRuVSlLtkxpugegps2bTJDhgwxQUFBpnXr1ubcuXMue+2ifPBfyn1bzR1j/jt3ewicO3fOvPnmm6Zt27amTJkyZsCAAeb8+fNWh3VR7hq3J/jyyy9N1apVzXXXXWd++eUXq8MRD1Mqk52/u5yHYPYvxuuuu84EBgYW+n+CVl37ch/8l3vfVnDHmLO580Ng06ZNpm3btsbLy8ucPHnS6nAKzF3jdlf33Xef8ff3N1OnTr2kmmeRiyn1yc6lPAS3bt1q7rnnHhMcHGyaN29uXnnlFXPq1Cm3ufalPviL6r5LkjvG/Hfu+BA4cuSImTZtmqldu7aJiIgwEyZMcIskzV3j9gQNGzY0sbGxVochHqzUJjuX8hCcOXOmqV+/vqlSpYoZM2aM+fHHH93q2pf64C+q+y5J7hhzbtzpIfDee++ZLl26mMDAQNO7d+9Lbh9W0tw1bk+SlpZmdQji4Updb6xZs2axcOFCTpw4wcCBAxk6dChRUVEFOtbLy4vq1avTvXt3/Pz88iz3wgsvuNS1L+e6l3ttq7hjzLlJT0/PN/64uDiefPJJ3njjjRKMKnfZ3/nAgQMJCwvLs9yDDz5YglFdnLvG7WlSU1OJjY2lYsWKXH311U77zp8/z/vvv6+xjuSSlbpk53Iegm3btsVms+V7fpvNxvr1613q2pf74L/c+7aCO8Z8KX744QeuvfZaMjMzrQ6FmjVrFug7379/fwlFVDDuGrcn2bt3L506deLw4cPYbDZuuukm3n33XSIiIgA4duwYkZGRLvH3XNxTqUt2CvIQBNiwYYMl1y7sA9gYc9FzlpYHvyf67LPP8t2/f/9+xo0bp4eAuLVbbrmFCxcusHDhQk6fPs3YsWPZvXs3GzdupHr16kp25LKVumTH0/j5+fHDDz/QoEEDq0NxOfHx8cybN48tW7YQHx+Pt7c3tWrVonfv3gwZMsQtBhn08vLCZrPlORgk2BNVPQTEnYWFhbF27Vqn1+sjR47kiy++YMOGDZQtW1bJjlwWzY31DxdrA3G575V/+eUXtm3bRuvWralXrx7/+9//eOmll0hLS2PQoEG0b98+1+PGjh2b6/bMzEyeffZZKlWqBBSsDcqpU6d488032bdvH5GRkQwePJiqVavmWf7777+nfPny1KpVC4C33nqLefPmcfjwYWrUqMGoUaO4/fbbL3rdkrRjxw46dOhArVq1CAwMZO/evQwcOJD09HTGjx/PggUL+PLLLwkKCrI61HxFRETwyiuv0Lt371z379y5k2bNmpVsUAWUkZHB8uXL2bdvHxEREdxyyy2ULVvW6rBy9fnnn7Njxw66dOlCq1atWL9+Pc899xxZWVn06dOH++67z+oQPVpqamqO0ZJfeeUVvLy8iI6O5p133rEoMvEYVrWMdlU7d+40Xl5eue7bs2ePqVGjhrHZbMbLy8tER0ebo0ePOvYnJCTkeawxxqxcudL4+fmZihUrmoCAALNy5UpTpUoV06FDBxMTE2N8fHzMunXrcj3WZrOZpk2bmrZt2zotNpvNtGjRwrRt29a0a9cu12MjIiLM8ePHjTHG7N+/34SHh5vw8HDTsWNHU7VqVRMSEpJvF9trrrnGrF+/3hhjzPz5801gYKB58MEHzbx588yYMWNMuXLlzIIFC/I83go33HCDmTJlimN9yZIlpmXLlsYYY06ePGmaNm1qHnzwQavCK7AePXqYxx9/PM/9O3fuNDabrQQjylurVq0cvfsSExNNVFSU8fPzM3Xq1DEBAQGmevXq5siRI9YGmYt58+YZHx8f06xZMxMcHGzeeustExQUZO655x4zfPhwExgYaF588UWrw/RoLVq0MIsXL85138iRI0358uXz/d0qcjGlLtn59NNP813mzJmT5z+q3r17m+7du5s//vjD7Nu3z/To0cPUqlXLHDp0yBhz8WSnVatW5tFHHzXGGPPuu++aChUqmMmTJzv2T5482XTs2DHXY6dPn25q1aqVIxny8fExP/30U773bLPZzLFjx4wxxtx+++2mbdu2JiUlxRhjn4age/fu5tZbb83z+DJlyjju8ZprrjH/+c9/nPa//fbb5uqrr843hpIWGBhofvvtN8d6Zmam8fX1NQkJCcYYY1avXm0iIyOtCq/ANm/ebFauXJnn/rNnz5qNGzeWYER5+/vfs3vvvdc0bdrUxMfHG2OMOX78uGndurUZOnSolSHmqkGDBub11183xhizfv16ExAQYF555RXH/oULF5oGDRpYFV6pMH36dNO1a9c89z/wwAMuk9SLeyp1yU52rYzNZstzySthCQ0NzTFey4gRI0z16tXNb7/9dtFkJzg42Ozbt88YY3/4+vj4OI2hsmvXLhMWFpbn8d9++62pW7euGTdunElPTzfGFD7ZyS1h2rZtm6latWqex1eqVMns2LHDGGP/Dnbu3Om0/9dffzWBgYH5xlDSatSoYbZs2eJYP3r0qLHZbI7Rog8cOGACAgKsCs8j/f3vWd26dc0XX3zhtH/Dhg2mZs2aVoSWr8DAQEcyb4wxvr6+ZteuXY71AwcOmDJlylgRmogUES+rX6OVtIiICD766COysrJyXfKa+Rvyfq/cs2dPoqOj2bt3b4Hj8PLyIiAggPLlyzu2BQUFkZSUlOcxLVq0IDY2lj/++IPmzZuza9euAvUsAxzl0tLScowlEhYWxh9//JHnsV27dmXevHkAREdH8+GHHzrtf//996ldu3aB4igpvXv35v7772fVqlVs2LCBgQMHEh0dTWBgIAB79uzhiiuusDhKz5P99+z06dOONl7ZatWqRXx8vBVh5atSpUocOnQIgKNHj3LhwgUOHz7s2H/o0CEqVqxoVXgiUgRKXQPlZs2a8d133+XZ4DO/ni/169dnx44dOXo+vfzyyxhj6NmzZ77XrlmzJr/++qsjMfjmm2+oXr26Y39cXJxjXIm8lCtXjjfffJOlS5fSsWPHAvdOiImJwcfHh+TkZPbu3UvDhg0d+w4fPkzlypXzPHbmzJnccMMNREdH07x5c55//nk2btxIgwYN2LNnD9u2bWPZsmUFiqOkPPPMM8THx9OjRw8yMzNp1aoVb731lmO/zWZjxowZFkbomYYMGYK/vz8ZGRkcOnTIqRF/fHy8U3LvKnr16sWwYcMYPHgwn332GXfddRfjxo1z9ISbMGECnTp1sjpMEbkMpS7ZmTBhAikpKXnur127dp5j7Nxyyy28++673HnnnTn2zZ07l6ysLF577bU8z/3AAw84JSeNGjVy2r9y5co8e2P90+23386NN95IbGwsNWrUyLfsk08+6bRepkwZp/XPP/+cm266Kc/jIyMj+f7773n22Wf5/PPPMcbw7bffEhcXxw033MDXX39N8+bNCxR3SSlXrhzvvfce58+f58KFC5QrV85pvx5eRW/w4MGOn3v16sXZs2ed9n/00Uc0bdq0hKO6uJkzZ5KWlsbSpUu58cYb+fe//81LL71Er169yMjIIDo6WomxiJvTODsiUiJSUlLw9vYmICDA6lAK5Pz582RkZLj88AQicnGlrs2OiFjj5MmTjBgxwuowCiwgIICgoCDi4uIYOnSo1eGIyGVQzY6IlAhXmserMNw1bhH5S6lrsyMixaMg83i5IneNW0QKTjU7IlIk3HUeL3eNW0QKTm12RKRIXM4YVlZy17hFpOCU7IhIkcgewyovF6s9sYq7xi0iBac2OyJSJC5nDCsruWvcIlJwarMjIiIiHk2vsURERMSjKdkRERERj6ZkR0RERDyakh0RERHxaEp2RERExKMp2RERERGPpmRHREREPJqSHREREfFo/w82KjQeOJnd2wAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -907,14 +1078,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:21:55.771150700Z",
+     "start_time": "2024-07-01T14:21:55.751811600Z"
+    },
     "pycharm": {
      "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:08.588296Z",
-     "start_time": "2024-03-18T18:02:08.585380Z"
     }
    },
    "outputs": [],
@@ -989,14 +1160,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:21:56.334672800Z",
+     "start_time": "2024-07-01T14:21:55.755810200Z"
+    },
     "pycharm": {
      "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:08.952637Z",
-     "start_time": "2024-03-18T18:02:08.589273Z"
     }
    },
    "outputs": [
@@ -1004,8 +1175,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Configuration recipe loaded into LUSID at time 2024-03-18 18:02:08.692593+00:00.\n",
-      "Configuration recipe loaded into LUSID at time 2024-03-18 18:02:08.858906+00:00.\n"
+      "Configuration recipe loaded into LUSID at time 2024-07-01 15:27:23.967658+00:00.\n",
+      "Configuration recipe loaded into LUSID at time 2024-07-01 15:27:24.200462+00:00.\n"
      ]
     }
    ],
@@ -1038,14 +1209,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 19,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:21:56.336657500Z",
+     "start_time": "2024-07-01T14:21:56.293371100Z"
+    },
     "pycharm": {
      "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:08.959358Z",
-     "start_time": "2024-03-18T18:02:08.956246Z"
     }
    },
    "outputs": [],
@@ -1107,23 +1278,74 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 20,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:21:57.132099300Z",
+     "start_time": "2024-07-01T14:21:56.299873900Z"
+    },
     "pycharm": {
      "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:10.900025Z",
-     "start_time": "2024-03-18T18:02:08.960117Z"
     }
    },
    "outputs": [
     {
      "data": {
-      "text/plain": "                   InstrumentName      ClientInternal  \\\n0  EUR/USD 6M FX Forward 20210720  FWD-EURUSD20210720   \n\n   Market Value (Portfolio Currency)  Forward Rate (Interpolated)  \\\n0                             0.0000                       1.2155   \n\n   FX Spot Rate  Holding/default/Units PnL (1-day)  \n0        1.2106                 1.0000        None  ",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>InstrumentName</th>\n      <th>ClientInternal</th>\n      <th>Market Value (Portfolio Currency)</th>\n      <th>Forward Rate (Interpolated)</th>\n      <th>FX Spot Rate</th>\n      <th>Holding/default/Units</th>\n      <th>PnL (1-day)</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>EUR/USD 6M FX Forward 20210720</td>\n      <td>FWD-EURUSD20210720</td>\n      <td>0.0000</td>\n      <td>1.2155</td>\n      <td>1.2106</td>\n      <td>1.0000</td>\n      <td>None</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>InstrumentName</th>\n",
+       "      <th>ClientInternal</th>\n",
+       "      <th>Market Value (Portfolio Currency)</th>\n",
+       "      <th>Forward Rate (Interpolated)</th>\n",
+       "      <th>FX Spot Rate</th>\n",
+       "      <th>Holding/default/Units</th>\n",
+       "      <th>PnL (1-day)</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>EUR/USD 6M FX Forward 20210720</td>\n",
+       "      <td>FWD-EURUSD20210720</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>1.2155</td>\n",
+       "      <td>1.2106</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                   InstrumentName      ClientInternal  \\\n",
+       "0  EUR/USD 6M FX Forward 20210720  FWD-EURUSD20210720   \n",
+       "\n",
+       "   Market Value (Portfolio Currency)  Forward Rate (Interpolated)  \\\n",
+       "0                             0.0000                       1.2155   \n",
+       "\n",
+       "   FX Spot Rate  Holding/default/Units PnL (1-day)  \n",
+       "0        1.2106                 1.0000        None  "
+      ]
      },
-     "execution_count": 22,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1147,21 +1369,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 21,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:21:57.851877600Z",
+     "start_time": "2024-07-01T14:21:57.123100Z"
+    },
     "pycharm": {
      "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:10.981770Z",
-     "start_time": "2024-03-18T18:02:10.900662Z"
     }
    },
    "outputs": [
     {
      "data": {
-      "text/plain": "<Figure size 640x480 with 1 Axes>",
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAlAAAAG6CAYAAADH1Xg8AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/SrBM8AAAACXBIWXMAAA9hAAAPYQGoP6dpAABhY0lEQVR4nO3deZyN5f/H8deZYRbDDIPBlDX7vibrjLLv0g+FBqHFkkSlshYiispS2StEWVIiYVBRmiiVhGzZ1xkGY5br98fJ+XYyw5zZ7jkz7+fjcR7Tue/rvu/POR1z3nNf133dNmOMQURERESSzcPqAkRERETcjQKUiIiIiIsUoERERERcpAAlIiIi4iIFKBEREREXKUCJiIiIuEgBSkRERMRFClAiIiIiLlKAEhEREXGRApSIiIiIixSgRETc3JgxY7DZbFaXIZKtKECJZBILFizAZrMl+dixYwcAhw8fxmazMWXKlET3M2XKFGw2G4cPH3YsCw0NddqXr68vVatWZdq0aSQkJCRZU+fOnWndujUAvXr1Infu3Em2zZ07N7169XJadvjwYXr37s0999yDj48PhQsXpnHjxowePdqp3b/r8/DwwN/fn3LlytGzZ082bNhwu7fNSa9evZJ8/9atW5fs/WR14eHhPPjggxQuXBgvLy+CgoJo164dK1assLo0EbeRw+oCRMTZuHHjKFmy5C3LS5cunar93n333UycOBGAc+fOsXjxYp555hnOnj3L+PHjb2kfGxvLhg0bHNu46sCBA9SpUwdfX1/69OlDiRIlOHnyJD/99BOTJk1i7NixSdYXHR3NgQMHWLFiBR9++CFdunThww8/JGfOnHc8rre3N3PmzLllebVq1VL0OrKa0aNHM27cOMqUKcPjjz9O8eLFOX/+PGvXrqVz58589NFHPPLII1aXKZLpKUCJZDKtWrWidu3aab7fgIAAevTo4Xj+xBNPUL58ed5++23GjRuHp6enU/tt27Zx+fJl2rRpk6Ljvfnmm1y5coXdu3dTvHhxp3Vnzpy5Y30Ar732GoMHD2bmzJmUKFGCSZMm3fG4OXLkuGU/aeXq1avkypUrXfZ9O3FxcSQkJODl5ZWq/XzyySeMGzeOhx56iMWLFzsF0uHDh7N+/XpiY2NTWy5g3XslklHUhSeSTfn4+FCnTh0uX76caKD54osvqFixIiVKlEjR/g8ePMjdd999S3gCCAoKStY+PD09eeutt6hYsSLvvPMOkZGRKarlv2bOnEmlSpXw9vYmODiYAQMGcOnSJac2oaGhVK5cmYiICBo3bkyuXLl48cUXGTp0KPnz58cY42g7aNAgbDYbb731lmPZ6dOnsdlszJo1C4AbN24watQoatWqRUBAAH5+fjRq1IjNmzc7HfffXbTTpk3jnnvuwdvbm99//x2Ab775hjp16uDj48M999zDu+++m+zXPXLkSAIDA5k3b16iZ/NatGhB27Ztgf91Kf+7Kxjs3X82m43w8PA7vldt27alVKlSidZSr169W/5Q+PDDD6lVqxa+vr4EBgbSrVs3jh07luzXJ5KRFKBEMpnIyEjOnTvn9Dh//ny6HOvml3XevHlvWbd27VrH+KeUKF68OMeOHWPTpk2pqNAeoh5++GGuXr3KN998k6xt/vv+/Tt4jRkzhgEDBhAcHMzUqVPp3Lkz7777Ls2bN7/l7Mv58+dp1aoV1atXZ9q0aTRp0oRGjRpx4cIFfvvtN0e7bdu24eHhwbZt25yWATRu3BiAqKgo5syZQ2hoKJMmTWLMmDGcPXuWFi1asHv37ltew/z583n77bfp378/U6dOJTAwkD179tC8eXPOnDnDmDFj6N27N6NHj2blypV3fE/279/PH3/8QceOHcmTJ0+y3kdXJPZede3alUOHDrFz506ntkeOHGHHjh1069bNsWz8+PE8+uijlClThjfeeIMhQ4awceNGGjdufEu4FckM1IUnksk0bdr0lmXe3t5cv349VfuNj4/n3LlzgP3Lbu7cufz444+0adMGX19fp7aHDh3ijz/+cJw9SYnBgwfzwQcf8MADD1C9enVCQkJo0qQJzZo1c7lrp3LlyoD9rNadREdHU7BgQadlISEhhIeHc/bsWSZOnEjz5s358ssv8fCw/w1Zvnx5Bg4cyIcffkjv3r0d2506dYrZs2fz+OOPO5adPXsWsAekypUrExkZyZ49e+jcuTNbt251tNu2bRuBgYFUrFgRgHz58nH48GGnbrh+/fo5ulHnzp3rVPPff//NgQMHnF5Lp06dMMawbds2ihUrBtgH+lepUuWO78vevXsBktU2JRJ7r6KiovD29ubjjz+mTp06juXLli3DZrPRpUsXwB6oRo8ezauvvsqLL77oaPfggw9So0YNZs6c6bRcJDPQGSiRTGbGjBls2LDB6fHll1+mer9//PEHBQsWpGDBgpQvX57XX3+d9u3bs2DBglvafvHFFwQEBNCwYcMUH69SpUrs3r2bHj16cPjwYaZPn07Hjh0pVKgQ77//vkv7unn13+XLl+/Y1sfH55b3b+rUqQB8/fXX3LhxgyFDhjjCE9iDjL+/P1988YXTvry9vZ0CFeB4/26GpW+//RZPT0+GDx/O6dOn2b9/P2APUA0bNnRML+Dp6ekITwkJCVy4cIG4uDhq167NTz/9dMvr6Ny5s1N4io+PZ/369XTs2NERngAqVKhAixYt7vi+REVFAaTL2SdI/L3y9/enVatWLFu2zKnL8+OPP+a+++5zvI4VK1aQkJBAly5dnM4cFi5cmDJlytzSzSmSGegMlEgmc++996bJIPL/zgtUokQJ3n//fRISEjh48CDjx4/n7Nmz+Pj43LLtF198QfPmzcmRw7VfEf89ZtmyZfnggw+Ij4/n999/5/PPP2fy5Mn079+fkiVLJnq2LTFXrlwBkvfl7+npmeR+jxw5AkC5cuWclnt5eVGqVCnH+pvuuuuuRAduN2rUiLVr1wL2oFS7dm1q165NYGAg27Zto1ChQvz888+3XM22cOFCpk6dyh9//OHUXZjYVZf/XXb27FmuXbtGmTJlbmlbrlw5Rz1J8ff3B5IXQlMiqfeqa9eurFq1iu3bt1O/fn0OHjxIREQE06ZNc7TZv38/xphEXxuQrKsvRTKaApSIm7kZeK5du5bo+qtXrzq1u8nPz88pWDRo0ICaNWvy4osvOg1+vnr1KuHh4bd03/n4+BATE4Mx5pagZIzh+vXriYYxsIeaKlWqUKVKFerVq0eTJk346KOPkh2gfv31VyD1Uzm46r9dmzc1bNiQ999/n7/++ott27bRqFEjbDYbDRs2ZNu2bQQHB5OQkECjRo0c23z44Yf06tWLjh07Mnz4cIKCgvD09GTixImJdk0mdeyUKl++PAB79uxJVvukJuaMj49PdHlS9bZr145cuXKxbNky6tevz7Jly/Dw8OD//u//HG0SEhKw2Wx8+eWXt1wNCtx2/jERq6gLT8TNFCxYkFy5crFv375E1+/bt49cuXJRoECB2+6natWq9OjRg3fffZejR486lm/atImYmBhatWrl1L548eLExcUl+mV/4MAB4uPjE73i7r9unl07efLkHduC/Qt78eLF5MqVK1VdioCjvv++dzdu3ODQoUPJqh9wBKMNGzawc+dOx/PGjRuzbds2tm3bhp+fH7Vq1XJs88knn1CqVClWrFhBz549adGiBU2bNk322LaCBQvi6+vr6CL8t6Q+C/9WtmxZypUrx+rVqx1n9G4nX758ALcM4P7vWbo78fPzo23btixfvpyEhAQ+/vhjGjVqRHBwsKPNPffcgzHGcVbyv4/77rvPpWOKZAQFKBE34+npSfPmzVmzZo1T8AE4evQoa9asoXnz5on+Jf9fzz33HLGxsbzxxhuOZWvXrqV27doUKlTIqe3NQPXOO+/csp8ZM2Y4tQF711Zicwrd7Gr6bzdaYuLj4xk8eDB79+5l8ODBjm6olGratCleXl689dZbTmNy5s6dS2RkZLLnvCpZsiR33XUXb775JrGxsTRo0ACwB6uDBw/yySefcN999zl1gd78//Hv437//fds3749Wcf09PSkRYsWrFq1yun/+969e1m/fn2y9jF27FjOnz9P3759iYuLu2X9V199xeeffw7YQw3gNDA+Pj6e9957L1nH+reuXbty4sQJ5syZw88//0zXrl2d1j/44IN4enoyduxYp/cH7O9Xel2FKpIa6sITyWS+/PJL/vjjj1uW169f3zGnzoQJE7jvvvuoWbMm/fv3p0SJEhw+fJj33nsPm83GhAkTknWsihUr0rp1a+bMmcPIkSPJnz8/a9euvWUwMED16tXp27cv06dPZ//+/TRr1gywn4VZu3Ytffv2dZrte9KkSURERPDggw9StWpVAH766ScWLVpEYGAgQ4YMcdp/ZGQkH374IWDvRrw5E/nBgwfp1q0br7zySrJe0+0ULFiQESNGMHbsWFq2bEn79u3Zt28fM2fOpE6dOi5NwNmoUSOWLl1KlSpVHGdratasiZ+fH3/++ect45/atm3LihUr6NSpE23atOHQoUPMnj2bihUrJuuMENgD0Lp162jUqBFPPfUUcXFxvP3221SqVIlffvnljtt37dqVPXv2MH78eHbt2sXDDz/smIl83bp1bNy4kcWLFwP2iwDuu+8+RowYwYULFwgMDGTp0qWJBq87ad26NXny5GHYsGF4enrSuXNnp/X33HMPr776KiNGjODw4cOOqRYOHTrEypUr6d+/P8OGDXP5uCLpyohIpjB//nwDJPmYP3++U/u9e/earl27mqCgIJMjRw4TFBRkunXrZvbu3XvLvkNCQkylSpUSPW54eLgBzOjRo82vv/5qAPPDDz8k2jY+Pt5Mnz7dVKtWzfj4+BgfHx9TrVo189Zbb5n4+Hintt9++60ZMGCAqVy5sgkICDA5c+Y0xYoVM7169TIHDx68pb5/v9bcuXObMmXKmB49epivvvoq2e9hWFiY8fPzu2O7d955x5QvX97kzJnTFCpUyDz55JPm4sWLt9SU1HtmjDEzZswwgHnyySedljdt2tQAZuPGjU7LExISzIQJE0zx4sWNt7e3qVGjhvn8889NWFiYKV68uKPdoUOHDGBef/31RI+7ZcsWU6tWLePl5WVKlSplZs+ebUaPHm1c+XW+ceNG06FDB8dnp2DBgqZdu3Zm9erVTu0OHjxomjZtary9vU2hQoXMiy++aDZs2GAAs3nzZke7O71XxhjTvXt3A5imTZsm2ebTTz81DRs2NH5+fsbPz8+UL1/eDBgwwOzbty/Zr00ko9iM+c/5UhHJtiZPnswbb7zByZMnkxxELCIiGgMlIv9SokQJ3nzzTYUnEZE70BkoERERERdZegZq69attGvXjuDgYGw2G6tWrbpt+xUrVtCsWTMKFiyIv78/9erVu+Xqk4kTJ1KnTh3y5MlDUFAQHTt2vOUS3+vXrzNgwADy589P7ty56dy5M6dPn07rlyciIiJZlKUBKjo6mmrVqjkugb6TrVu30qxZM9auXUtERARNmjShXbt27Nq1y9Fmy5YtDBgwgB07drBhwwZiY2Np3rw50dHRjjbPPPMMa9asYfny5WzZsoUTJ07w4IMPpvnrExERkawp03Th2Ww2Vq5cSceOHV3arlKlSnTt2pVRo0Yluv7s2bMEBQWxZcsWGjduTGRkJAULFmTx4sU89NBDgP0eYRUqVGD79u2asE1ERETuyK3ngUpISODy5csEBgYm2SYyMhLA0SYiIoLY2FinW0iUL1+eYsWK3TZAxcTEEBMT43TsCxcukD9/fg24FRERcRPGGC5fvkxwcLDTTcVd5dYBasqUKVy5coUuXbokuj4hIYEhQ4bQoEEDKleuDMCpU6fw8vIib968Tm0LFSrEqVOnkjzWxIkTGTt2bJrVLiIiItY5duwYd999d4q3d9sAtXjxYsaOHcvq1asJCgpKtM2AAQP49ddf+eabb1J9vBEjRjB06FDH88jISIoVK8axY8dSfXsJERGRTCfiS5jdD/IWgpfXQUBBqytKE1FRURQtWpQ8efKkaj9uGaCWLl1K3759Wb58eZJ3cx84cCCff/45W7dudUqYhQsX5saNG1y6dMnpLNTp06cpXLhwksf09vbG29v7luX+/v4KUCIiknUkJMCysbB8HNTpAIMXQa6s9z2X2uE3bjeR5pIlS+jduzdLlixJ9MafxhgGDhzIypUr2bRpEyVLlnRaX6tWLXLmzMnGjRsdy/bt28fRo0epV69eutcvIiKSqX27FD55BR4ZD8+tyJLhKS1YegbqypUrHDhwwPH80KFD7N69m8DAQIoVK8aIESM4fvw4ixYtAuzddmFhYUyfPp26des6xiz5+voSEBAA2LvtFi9ezOrVq8mTJ4+jTUBAgKPdY489xtChQwkMDMTf359BgwZRr149XYEnIiLZ15WLkDsfNOgGhUtDmXutrihzs+42fMZs3rw50ZumhoWFGWPsNwYNCQlxtP/vDUf/294Yk6wbsV67ds089dRTJl++fCZXrlymU6dO5uTJky7VHhkZaQATGRmZindAREQkE/hmqTE9/I35dYvVlaS7tPr+zjTzQLmbqKgoAgICiIyMvO0YqPj4eGJjYzOwMhHImTMnnp6eVpchIpldfBx8+AJ8NhUaPQJPvg/euayuKl0l9/v7TtxyELk7MMZw6tQpLl26ZHUpkk3lzZuXwoULa54yEUlc1Dl4oyv8tgV6T4M2g0G/L5JNASqd3AxPQUFB5MqVS19ikmGMMVy9epUzZ84AUKRIEYsrEpFMycMTblyHMRuhUojV1bgdBah0EB8f7whP+fPnt7ocyYZ8fX0BOHPmDEFBQerOE5H/CV8ElUKhYDEY/43OOqWQ201j4A5ujnnKlStr9yNL5nbz86cxeCICQGwMvPsEvB1mn6oAFJ5SQWeg0pG67cRK+vyJiMP54zDlIfjrJ/tA8aZ9ra7I7SlAiYiIZGWxN+DlRhAfC69u0/xOaURdeJJljRkzhurVq1tdhoiINYyxT1OQ0wsenw2vRyg8pSEFqMzsxH74cAS88bD954n96X7IXr16YbPZbnn8e8Z4ERHJ5GKu2sc6vfeU/Xn15hAQZG1NWYy68DKrTfNhZl/7AD9j7D9XTYan5sL9vdL10C1btmT+/PlOywoWdP0u3Ddu3MDLyyutykpSbGwsOXPmTPfjiIi4hdOH4PUH4fg++3eGpAudgcqMTuy3hyeTAAnxzj9nPgYn0/dskLe3N4ULF3Z6eHp6smXLFu699168vb0pUqQIL7zwAnFxcY7tQkNDGThwIEOGDKFAgQK0aNGCYcOG0bZtW0ebadOmYbPZWLdunWNZ6dKlmTNnDgA7d+6kWbNmFChQgICAAEJCQvjpp5+c6rPZbMyaNYv27dvj5+fH+PHjAXjttdcoVKgQefLk4bHHHuP69etO24WHh3Pvvffi5+dH3rx5adCgAUeOHEnz909ExDK7v4LnasPVKJi4Axo9bHVFWZYCVEa7eNJ+FcS/H6cP2dfduG5/vmJC0peW2mzw6fj/bXv5gn155Nlb93vxZJqVffz4cVq3bk2dOnX4+eefmTVrFnPnzuXVV191ardw4UK8vLz49ttvmT17NiEhIXzzzTfEx8cDsGXLFgoUKEB4eLhjvwcPHiQ0NBSAy5cvExYWxjfffMOOHTsoU6YMrVu35vLly07HGTNmDJ06dWLPnj306dOHZcuWMWbMGCZMmMCPP/5IkSJFmDlzpqN9XFwcHTt2JCQkhF9++YXt27fTv39/XakmIlnLj2ugTF2Y/COUqGp1NVlbGtyXL1u63c0Ir127Zn7//Xdz7dq1WzdcOtqYB3F+TOtuX3di/63r7vQI/8C+7dp3bl23dLTLryssLMx4enoaPz8/x+Ohhx4yL774oilXrpxJSEhwtJ0xY4bJnTu3iY+PN8bYb/Zco0YNp/1dvHjReHh4mJ07d5qEhAQTGBhoJk6caOrWrWuMMebDDz80d911V5L1xMfHmzx58pg1a9Y4lgFmyJAhTu3q1atnnnrqKadldevWNdWqVTPGGHP+/HkDmPDwcJffE3d128+hiGQd0ZHG7N5g/+/YG8bExVlbTyaXVjcT1hiojNb8cajT3nmZXz77z/x326+SWPs2bPnA3m33Xx6eENITWg+yPy9Ywv6zfhcoV8+5bb6U3cKjSZMmzJo163/l+fkxYMAA6tWr53TGpkGDBly5coW///6bYsWKAVCrVi2nfeXNm5dq1aoRHh6Ol5cXXl5e9O/fn9GjR3PlyhW2bNlCSMj/biFw+vRpXn75ZcLDwzlz5gzx8fFcvXqVo0ePOu23du3aTs/37t3LE0884bSsXr16bN68GYDAwEB69epFixYtaNasGU2bNqVLly66zYmIuLe//4DJneDKBZj5F/j4WV1RtqEAldHyFUk62Hj5QKma8OCL9qn2E2MMdH4JipR2Xh5Q0P5IA35+fpQuXfrODZPY9r9CQ0MJDw/H29ubkJAQAgMDqVChAt988w1btmzh2WefdbQNCwvj/PnzTJ8+neLFi+Pt7U29evW4cePGHY9zJ/Pnz2fw4MGsW7eOjz/+mJdffpkNGzZw3333uf5CRUSs9v0qePtR+x/fr2xVeMpgGgOVGQWXsV85YfOwn3Hy+OenzcO+/L/hKQNUqFCB7du3Y4xxLPv222/JkycPd9999223vTkOauPGjY6xTqGhoSxZsoQ///zTsezmPgcPHkzr1q2pVKkS3t7enDt3Lln1ff/9907LduzYcUu7GjVqMGLECL777jsqV67M4sWL77hvEZFM5+u59jNP1ZrDa9/DXeWsrijbUYDKrO7vBW/vgw7DoV4X+8+396X7FAZJeeqppzh27BiDBg3ijz/+YPXq1YwePZqhQ4fi4XH7j1Hjxo25fPkyn3/+uVOA+uijjyhSpAhly5Z1tC1TpgwffPABe/fu5fvvv6d79+6OG+PeztNPP828efOYP38+f/75J6NHj+a3335zrD906BAjRoxg+/btHDlyhK+++or9+/dToUKFlL0hIiJWqtESer8Jw5aDbx6rq8mW1IWXmRUpDT0mWl0FAHfddRdr165l+PDhVKtWjcDAQB577DFefvnlO26bL18+qlSpwunTpylfvjxgD1UJCQlO458A5s6dS//+/alZsyZFixZlwoQJDBs27I7H6Nq1KwcPHuS5557j+vXrdO7cmSeffJL169cD9hvr/vHHHyxcuJDz589TpEgRBgwYwOOPP56Cd0NExAKHf4b5z8CzyyD/XdB2iNUVZWs28+8+GUm2qKgoAgICiIyMxN/f32nd9evXOXToECVLlsTHx8eiCiW70+dQJAvZ+hHM6gd3lYcXVkOBolZX5LZu9/3tCp2BEhERyaziYmHRcPhiOoQ+Cv1ng/edhzVI+lOAEhERyawO/wwb3oO+70DLp5KeZFkynAKUiIhIZnP0V7irApSuDbMOQd5CVlck/6Gr8ERERDKTr96D4TXtZ55A4SmT0hkoERGRzODGdZg7CL6eY++ue+AxqyuS21CAEhERsVp0JIxrBkd+gQHzLZvzT5JPAUpERMRqufyhfAPoPwvuqXXn9mI5BSgRERErGANr3rRPmlynvX1mcXEbGkQuIiKS0a5Hw5uPwMJn4dBuq6uRFFCAyoSOX7rGr8cjk3wcv3TN6hJTZcGCBeTNm9fxfMyYMVSvXj1V+zx8+DA2m43du3enaj/upFevXnTs2NHqMkTEVacOwoh6ELHGfluWLqOsrkhSQF14mczxS9e4f0o4MXEJSbbxzuHBpmGh3JU3bWej7dWrF5cuXWLVqlVput87GTZsGIMGDUr344SGhrJly5ZblsfGxpIjh/4piEgGMAbeDoPY6zDxeyhWyeqKJIX0rZHJXIy+cdvwBBATl8DF6BtpHqCskjt3bnLnzp0hx+rXrx/jxo1zWpbS8HTjxg28vLzSoqzbio2NJWfOnOl+HBFJRwkJcPk8BBSEwR9A7nzgl9fqqiQV1IUnSQoNDWXQoEEMGTKEfPnyUahQId5//32io6Pp3bs3efLkoXTp0nz55ZeObcLDw7HZbHzxxRdUrVoVHx8f7rvvPn799dckj5NYF96cOXOoUKECPj4+lC9fnpkzZzqt/+GHH6hRowY+Pj7Url2bXbt2Jes15cqVi8KFCzs9bvr000+pVKkS3t7elChRgqlTpzptW6JECV555RUeffRR/P396d+/Pw899BADBw50tBkyZAg2m40//vgDsIcsPz8/vv76awDWrVtHw4YNyZs3L/nz56dt27YcPHjQsf3NrsiPP/6YkJAQfHx8+Oijj4iPj2fo0KGO7Z577jl0H3ARNxEdCZM6wpgHID4OCpVUeMoCFKDkthYuXEiBAgX44YcfGDRoEE8++ST/93//R/369fnpp59o3rw5PXv25OrVq07bDR8+nKlTp7Jz504KFixIu3btiI2NTdYxP/roI0aNGsX48ePZu3cvEyZMYOTIkSxcuBCAK1eu0LZtWypWrEhERARjxoxh2LBhqXqdERERdOnShW7durFnzx7GjBnDyJEjWbBggVO7KVOmUK1aNXbt2sXIkSMJCQkhPDzcsX7Lli0UKFDAsWznzp3ExsZSv359AKKjoxk6dCg//vgjGzduxMPDg06dOpGQ4HzW8YUXXuDpp59m7969tGjRgqlTp7JgwQLmzZvHN998w4ULF1i5cmWqXrOIZICjv8HzdeD3rdDjNfBUx0+WYSRFIiMjDWAiIyNvWXft2jXz+++/m2vXrrm83z1/XzLFn//8jo89f19Ki5fhJCwszHTo0MHxPCQkxDRs2NDxPC4uzvj5+ZmePXs6lp08edIAZvv27cYYYzZv3mwAs3TpUkeb8+fPG19fX/Pxxx8bY4yZP3++CQgIcKwfPXq0qVatmuP5PffcYxYvXuxU2yuvvGLq1atnjDHm3XffNfnz53d6f2fNmmUAs2vXriRfX0hIiMmZM6fx8/NzPIYOHWqMMeaRRx4xzZo1c2o/fPhwU7FiRcfz4sWLm44dOzq1+eWXX4zNZjNnzpwxFy5cMF5eXuaVV14xXbt2NcYY8+qrr5r69esnWdPZs2cNYPbs2WOMMebQoUMGMNOmTXNqV6RIETN58mTH89jYWHP33Xc7/f/6r9R8DkUkDWz/1JhH/IwZUtmYE/utrkb+cbvvb1coCsttVa1a1fHfnp6e5M+fnypVqjiWFSpkv0fTmTNnnLarV6+e478DAwMpV64ce/fuvePxoqOjOXjwII899hj9+vVzLI+LiyMgIACAvXv3OroHEzve7XTv3p2XXnrJ8fzm1YB79+6lQ4cOTm0bNGjAtGnTiI+Px9PTE4DatWs7talcuTKBgYFs2bIFLy8vatSoQdu2bZkxYwZgPyMVGhrqaL9//35GjRrF999/z7lz5xxnno4ePUrlypUd7f59nMjISE6ePEndunUdy3LkyEHt2rXVjSeS2dVqB0/NAR8/qyuRNKYAJbf138HLNpvNaZnNZgO4pQsqpa5cuQLA+++/7xQYAEeISY2AgABKly6d4u39/Jx/CdpsNho3bkx4eDje3t6EhoZStWpVYmJi+PXXX/nuu++cuhfbtWtH8eLFef/99wkODiYhIYHKlStz48aN2x5HRNxE1DnYNB86DIP7HrQ/JEvSGChJFzt27HD898WLF/nzzz+pUKHCHbcrVKgQwcHB/PXXX5QuXdrpUbJkSQAqVKjAL7/8wvXr1xM9XkpUqFCBb7/91mnZt99+S9myZe8Y3G6OgwoPDyc0NBQPDw8aN27M66+/TkxMDA0aNADg/Pnz7Nu3j5dffpkHHniAChUqcPHixTvWFhAQQJEiRfj+++8dy+Li4oiIiEjBKxWRdHMwAobXgtWvw7ljVlcj6UxnoDKZfH5eeOfwuOM8UPn80v/y+dQYN24c+fPnp1ChQrz00ksUKFAg2ZM+jh07lsGDBxMQEEDLli2JiYnhxx9/5OLFiwwdOpRHHnmEl156iX79+jFixAgOHz7MlClTUlXvs88+S506dXjllVfo2rUr27dv55133rnl6r/EhIaG8swzz+Dl5UXDhg0dy4YNG0adOnUcZ5Py5ctH/vz5ee+99yhSpAhHjx7lhRdeSFZ9Tz/9NK+99hplypShfPnyvPHGG1y6dCnFr1dE0tjmhfDu41CsCjy3AgoUtboiSWcKUJnMXXl92TQslIvRN5Jsk8/PK9PPAfXaa6/x9NNPs3//fqpXr86aNWuSPWdS3759yZUrF6+//jrDhw/Hz8+PKlWqMGTIEMA+b9SaNWt44oknqFGjBhUrVmTSpEl07tw5xfXWrFmTZcuWMWrUKF555RWKFCnCuHHj6NWr1x23rVKlCnnz5qVs2bKO+axCQ0OJj493Gv/k4eHB0qVLGTx4MJUrV6ZcuXK89dZbTm2S8uyzz3Ly5EnCwsLw8PCgT58+dOrUicjIyBS+YhFJM9+vgnd6wf19oN8M8PK50xaSBdiMRqGmSFRUFAEBAURGRuLv7++07vr16xw6dIiSJUs6DXTODsLDw2nSpAkXL150ul2LZLzs/DkUyRCxMZDT2z63U8QX9hsC/zMuVDKv231/u0JjoERERFy19xsYWAZ+32af2+neDgpP2YwClIiISHIZA1/OgNFNoGAJCC5rdUViEY2BkjQVGhqquYlEJGuKuQbvPQnhC6HN0/Do65BD96nMrhSgREREkuP6Ffhzh/1mwCE9rK5GLKYAJSIicjt7NsHdFSBfEXhzj846CaAxUCIiIokzBlZNhnHN4PPp9mUKT/IPnYESERH5r2uX4Z3esONT6PwSdB1rdUWSyShAiYiI/Ft8PIwMgVMH7LOK1+1kdUWSCSlAiYiI3GQMeHpCpxegeFW4u7zVFUkmpTFQkm5CQ0Mdt18BKFGiBNOmTbOsHhGRJMXHw5JRsGCo/XmDLgpPclsKUOLk7NmzPPnkkxQrVgxvb28KFy5MixYt+PbbbwGw2WysWrUqWftasWIFr7zySjpWKyKSBq5chInt4NNXISDIfhZK5A7UhSdOOnfuzI0bN1i4cCGlSpXi9OnTbNy4kfPnzyd7Hzdu3MDLy4vAwMB0rFREJA0c/gUmd4Loi/DSl1CjhdUViZvQGaiMYgxER2f8w4W/pC5dusS2bduYNGkSTZo0oXjx4tx7772MGDGC9u3bU6JECQA6deqEzWZzPB8zZgzVq1dnzpw5Tjeu/W8X3n/NmTOHvHnzsnHjRgB+/fVXWrVqRe7cuSlUqBA9e/bk3LlzKXq7RUSSZf0s8M0DkyMUnsQlOgOVUa5ehdy5M/64V66An1+ymubOnZvcuXOzatUq7rvvPry9vZ3W79y5k6CgIObPn0/Lli3x9PR0rDtw4ACffvopK1ascFqelMmTJzN58mS++uor7r33Xi5dusT9999P3759efPNN7l27RrPP/88Xbp0YdOmTa69ZhGR24mPg8M/wz21oPebYBLAO5fVVYmbUYAShxw5crBgwQL69evH7NmzqVmzJiEhIXTr1o2qVatSsGBBAPLmzUvhwoWdtr1x4waLFi1ytLmd559/ng8++IAtW7ZQqVIlAN555x1q1KjBhAkTHO3mzZtH0aJF+fPPPylbVjfsFJE0EHkGpnaFQ7tg9mHwy2t1ReKmFKAySq5c9rNBVhzXBZ07d6ZNmzZs27aNHTt28OWXXzJ58mTmzJlDr169ktyuePHiyQpPU6dOJTo6mh9//JFSpUo5lv/8889s3ryZ3ImcpTt48KAClIik3v4f4PXOEHcDXvhM4UlSRQEqo9hsye5Ks5qPjw/NmjWjWbNmjBw5kr59+zJ69OjbBii/ZL62Ro0a8cUXX7Bs2TJeeOEFx/IrV67Qrl07Jk2adMs2RYoUcfk1iIg4+X4lvNENStWEYZ9A/rusrkjcnAKU3FHFihUdUxfkzJmT+Pj4FO/r3nvvZeDAgbRs2ZIcOXIwbNgwAGrWrMmnn35KiRIlyJFDH0sRSWMla0CrgdB9AuT0vnN7kTvQVXjicP78ee6//34+/PBDfvnlFw4dOsTy5cuZPHkyHTp0AOyTYW7cuJFTp05x8eLFFB2nfv36rF27lrFjxzom1hwwYAAXLlzg4YcfZufOnRw8eJD169fTu3fvVAU2EcnGzv8N07pD9CUIKgG9pio8SZrRn/rikDt3burWrcubb77JwYMHiY2NpWjRovTr148XX3wRsI9hGjp0KO+//z533XUXhw8fTtGxGjZsyBdffEHr1q3x9PRk0KBBfPvttzz//PM0b96cmJgYihcvTsuWLfHwUM4XERf9tgWmdoEcXnD+uMY7SZqzGaMpV1MiKiqKgIAAIiMj8ff3d1p3/fp1Dh065DQnkkhG0+dQsiVj4Iu3YOGzUKERPPuxfXZxkX/c7vvbFToDJSIi7unEftg0D84ctnfR3d8HYqJh4VBo+wz0eA089TUn6UOfLBERcT+b5sPMvvYrnI2x/1w1GZ6aC2/+CndXsLpCyeI0uERERNzLif328GQSICHe+efMx8Azp9UVSjZgaYDaunUr7dq1Izg4GJvN5rhUPikrVqygWbNmFCxYEH9/f+rVq8f69etd3ueVK1cYOHAgd999N76+vlSsWJHZs2en4SsTEZF0s2me/YxTYmw22Dg3Y+uRbMnSABUdHU21atWYMWNGstpv3bqVZs2asXbtWiIiImjSpAnt2rVj165dLu1z6NChrFu3jg8//JC9e/cyZMgQBg4cyGeffZbq1/RvGp8vVtLnT7KsM4dvc6N0Y18vks4sHQPVqlUrWrVqlez2N+cMumnChAmsXr2aNWvWUKNGjWTv87vvviMsLIzQ0FAA+vfvz7vvvssPP/xA+/btXXoNicmZ0376+OrVq/j6+qZ6fyIpcfXqVeB/n0eRLCOoxD9jnxJbabOvF0lnbj2IPCEhgcuXLxMYGOjSdvXr1+ezzz6jT58+BAcHEx4ezp9//smbb76Z5DYxMTHExMQ4nkdFRSXZ1tPTk7x583LmzBkAcuXKhS2p080iacwYw9WrVzlz5gx58+bF09PT6pJE0sbl8zD7cajZKukzUMbAA49lbF2SLbl1gJoyZQpXrlyhS5cuLm339ttv079/f+6++25y5MiBh4cH77//Po0bN05ym4kTJzJ27NhkH6Nw4cIAjhAlktHy5s3r+ByKuL1fNsLbj8KNaxAaZr/abuZj/4yFMsA/V+M9NReKlLa6WskG3DZALV68mLFjx7J69WqCglybJO3tt99mx44dfPbZZxQvXpytW7cyYMAAgoODadq0aaLbjBgxgqFDhzqeR0VFUbRo0SSPYbPZKFKkCEFBQcTGxrpUn0hq5cyZU2eeJGuIjYHFL8NnU6DKAzBo4f9uBFyhoX3A+M15oB54TOFJMoxbBqilS5fSt29fli9fnmTgScq1a9d48cUXWblyJW3atAGgatWq7N69mylTpiS5P29vb7y9Xb+Hkqenp77IRERSKi4Wdn0JYVPsk2P++9ZORUpDj4nW1SbZmtsFqCVLltCnTx+WLl3qCECuiI2NJTY29pb7q3l6epKQkJBWZYqISEoZA+tnQ7Vm9pA0ZRfk0MUQkrlYGqCuXLnCgQMHHM8PHTrE7t27CQwMpFixYowYMYLjx4+zaNEiwN5tFxYWxvTp06lbty6nTp0CwNfXl4CAgGTt09/fn5CQEIYPH46vry/Fixdny5YtLFq0iDfeeCMDX72IiNwi8gzM6AMRX0DvN6HtEIUnyZyMhTZv3mywj/5zeoSFhRljjAkLCzMhISGO9iEhIbdtn5x9GmPMyZMnTa9evUxwcLDx8fEx5cqVM1OnTjUJCQnJrj0yMtIAJjIyMpXvgoiIGGOM+fELY3oHGdOroDE711hdjWRRafX9bTNGs+2lRFrdzVlERLBPUfBECajQCAbOh7yFrK5Isqi0+v52uzFQIiKShRzZY7+CLk9+mPQD3FU+6du0iGQiupmwiIhkvIQEWPMmPFcbVk+xL7u7gsKTuA2dgRIRkYx14QS80wt+3mCfmuDBEVZXJOIyBSgREck4l8/Ds9XAMyeM+so+VYGIG1KAEhGR9BdzFbx87WOder4OtduCfwGrqxJJMY2BEhGR9HXgRxhWA9bNtD+/v5fCk7g9BSgREUkf8fGw4jV4sR745oGqrt16SyQzUxeeiIikvSsXYXIn+H0rdHoBuoyBnF5WVyWSZhSgREQk7eUKgALFYOxmqBRidTUiaU5deCIikjauRsE7veG3LeDhAYMXKTxJlqUAJSIiqbdvu32g+PZPIOqs1dWIpDsFKBERSbn4OFg2Fl5uZL9/3dSfod5DVlclku40BkpERFLuejSEL4L/GwmdXwJPfa1I9qBPuoiIuMYY2PKhfXxTwWLw5q/g7Wt1VSIZSl14IiKSfFcuwpsPw9uPwrcf25cpPEk2pDNQIiKSPL9tgbd62q+2G7oUGnS1uiIRyyhAiYjInV0+DxPaQKlaMPgDe9edSDamACUiIkk7sR/y322/CfC4LVCiOnh6Wl2ViOU0BkpERG5lDGx4H4ZVh9Wv25fdU0vhSeQfOgMlIiLOos7BrH7wwypo2g/aP2t1RSKZjgKUiIj8z+XzMLQqxN2A51ZA3U5WVySSKSlAiYgIxN6AHDntY50eHAH3dYbAYKurEsm0NAZKRCS7O/obPF8HNs23P289SOFJ5A4UoEREsitj4MsZ8Hxt+z3t7qlldUUibkNdeCIi2VF0JEx7BH5aC60GQs/JmlFcxAUKUCIi2ZGPH3jmhBe/gFqtra5GxO2oC09EJLuIuQZzBsGf34NnDnhhlcKTSAopQImIZAeHdsNztWDjHDh90OpqRNyeApSISFaWkACfTYUX7oUcXjA5Aho9YnVVIm5PY6BERLKy6Euw5g1oPRgeGQ85va2uSCRLUIASEcmKflgNZepCvsIw7XfwC7C6IpEsRV14IiJZybUr9vvYTeoImxfYlyk8iaQ5nYESEckqDuyENx+BSyfhqblwf2+rKxLJshSgRESygqhzMCoUilaCl9ZCcBmrKxLJ0hSgRETc2bljEFAI/AvAy+ug7H32mwKLSLrSGCgREXf1zVJ4pgp8NsX+vGIjhSeRDKIzUCIi7uZqFMwZCFs+gAbdoOVTVlckku0oQImIuJOoc/D8vXD5HAz+ABp3B5vN6qpEsh0FKBERdxAfD56e9rFOTftCw4ehUEmrqxLJtjQGSkQkszt1EF5uaB/zBND5RYUnEYspQImIZFbGwKYF8Gx1iDwDQSUsLkhEblIXnohIZnQ1Cmb2he3LoUkveOwt8M1jdVUi8g8FKBGRzCint32g+NCPoUEXq6sRkf9QgBIRySxib8CyMdCgK5SoBmM26go7kUxKAUpEJDP4+w+Y3h2O/AJFytoDlMKTSKalACUiYiVjYMN7MP8ZKFAMJu6Ae2pZXZWI3IEClIiIlS6fh8UvQeijEDYVfPysrkhEkkEBSkTECj9/DaVq2CfGnP47BARZXZGIuEDzQImIZKQb1+3ddeOawfrZ9mUKTyJuR2egREQyypE9MK07nNgHvd+E1oOtrkhEUkgBSkQkI0SdgxfrQVBJmLQTSlS1uiIRSQUFKBGR9BR5BnIH2sc6DfsEKoaAt6/VVYlIKmkMlIhIetm5BoZUgjVv2p/XaKnwJJJFKECJiKS1mKvw3lPwWnsoWw+ahFldkYikMXXhiYikpahz8HIjOHsE+s+C5o9rRnGRLEgBSkQkLRhjD0p58kOdDvazTndXsLoqEUkn6sITEUmt83/D2Kaw8zN7iOr5msKTSBanM1AiIqmx/ROY3R+8coGvv9XViEgGUYASEUmJ69EwdxBsmg/3dYYn3oM8gVZXJSIZRAFKRCQlbDY4+isMmAdNemmguEg2owAlIpJc8fGwejLc2wnuLg8Td4CHhpKKZEcKUCIiyXHmMLzVE/Z9B3kK2AOUwpNItqUAJSJyJ1s/gvefAr98MG4LVGhodUUiYjFL/3zaunUr7dq1Izg4GJvNxqpVq27bfsWKFTRr1oyCBQvi7+9PvXr1WL9+fYr2uXfvXtq3b09AQAB+fn7UqVOHo0ePptErE5EsI/KsPTzVbgdTf1Z4EhHA4gAVHR1NtWrVmDFjRrLab926lWbNmrF27VoiIiJo0qQJ7dq1Y9euXS7t8+DBgzRs2JDy5csTHh7OL7/8wsiRI/Hx8Un1axKRLOKP7yA6EgIKwht74OkPwS/A6qpEJJOwGWOM1UUA2Gw2Vq5cSceOHV3arlKlSnTt2pVRo0Yle5/dunUjZ86cfPDBBymuNyoqioCAACIjI/H319wvIllGXCwsHwcrJkDXcfDQS1ZXJCJpKK2+v916BGRCQgKXL18mMDD5c68kJCTwxRdfULZsWVq0aEFQUBB169a9Y/dhTEwMUVFRTg8RyWJOHoCXG8KKidB1LHR63uqKRCSTcusANWXKFK5cuUKXLl2Svc2ZM2e4cuUKr732Gi1btuSrr76iU6dOPPjgg2zZsiXJ7SZOnEhAQIDjUbRo0bR4CSKSWUSehedqweXzMP5beOhl8NR1NiKSOLf97bB48WLGjh3L6tWrCQoKSvZ2CQkJAHTo0IFnnnkGgOrVq/Pdd98xe/ZsQkJCEt1uxIgRDB061PE8KipKIUokK4i+ZL8FS0BBeHIO1GgJvnmsrkpEMjm3PAO1dOlS+vbty7Jly2jatKlL2xYoUIAcOXJQsWJFp+UVKlS47VV43t7e+Pv7Oz1ExM3t2QRDKsPat+3P6/+fwpOIJIvbBaglS5bQu3dvlixZQps2bVze3svLizp16rBv3z6n5X/++SfFixdPqzJFJDOLjYFFz8HYphBcFup1troiEXEzlnbhXblyhQMHDjieHzp0iN27dxMYGEixYsUYMWIEx48fZ9GiRYC92y4sLIzp06dTt25dTp06BYCvry8BAQHJ2ifA8OHD6dq1K40bN6ZJkyasW7eONWvWEB4enkGvXEQsE3UOxjWHY79Cj0nQ/lnNKC4irjMW2rx5swFueYSFhRljjAkLCzMhISGO9iEhIbdtn5x93jR37lxTunRp4+PjY6pVq2ZWrVrlUu2RkZEGMJGRkSl89SJiifh4Y9590piDP1ldiYhYIK2+vzPNPFDuRvNAibiRyDMwqx+0GgTVXBs3KSJZi+aBEhFJjl3rYGhV2LcdEuKtrkZEsgi3ncZAROS2blyHD56HtW/ZpyYYMB/yFba6KhHJIhSgRCRrirsBv3wNj70FrQaCzWZ1RSKShaQoQCUkJLBgwQJWrFjB4cOHsdlslCxZkoceeoiePXti0y8qEbFCQgKsmwG12kKhkvDGz5pNXETShctjoIwxtG/fnr59+3L8+HGqVKlCpUqVOHLkCL169aJTp07pUaeIyO1dPAmvtoK5g2HXl/ZlCk8ikk5c/u2yYMECtm7dysaNG2nSpInTuk2bNtGxY0cWLVrEo48+mmZFikj2dfzSNS5G30hyfT4/L+768yuY+Rh45oSX10GNFhlYoYhkRy5PY9C8eXPuv/9+XnjhhUTXT5gwgS1btrB+/fo0KTCz0jQGIunv+KVr3D8lnJi4hCTbeHva2HTsSe6qWN1+L7uAghlXoIi4HcumMfjll19o2bJlkutbtWrFzz//nOKCRERuuhh947bhCSAm3nBxyGfw/CqFJxHJMC534V24cIFChQolub5QoUJcvHgxVUW5leho8PS0ugqRLMl2NRrfG9fv3C5PQbh6NQMqEhG3Fx2dJrtxOUDFx8eTI0fSm3l6ehIXF5eqotxKcLDVFYhkWZWAvclp+GY6FyIi8h8uByhjDL169cLb2zvR9TExMakuSkRERCQzczlAhYWF3bFNtroC78QJ0CBykXTx24lIHpq1/Y7tPnmyHpWCAzKgIhFxe1FRadJ75HKAmj9/fqoPmqX4+dkfIpK2YmMw33zINa9Kd2xqcunfoYgkU3za3BMzzW4mfOTIEX7//XcSEm5/xYyIyB398R0MqwGb5lldiYhIolwOUPPmzeONN95wWta/f39KlSpFlSpVqFy5MseOHUuzAkUkm9mzGV5uCL7+5HthKd45bv9ryjuHB/n8vDKoOBERO5cn0rzvvvt4/PHH6d27NwDr1q2jXbt2LFiwgAoVKjBw4EAqVqzInDlz0qXgzEITaYqksaO/QrHK9tPr3y6FBt3A0zN5M5Hn9c3AQkXEnaXV97fLY6D2799P7dq1Hc9Xr15Nhw4d6N69O2CfifxmuBIRuaOLp+z3r9vxCbyxB4pVgsbdHavvyuurgCQimY7LXXjXrl1zSmzfffcdjRs3djwvVaoUp06dSpvqRCTrMgY2zoOnK8Bv4fD0R1C0otVViYgki8sBqnjx4kRERABw7tw5fvvtNxo0aOBYf+rUKQICdDmxiNzB6in2GwDX6QBv7YVGD4PNZnVVIiLJkqJ5oAYMGMBvv/3Gpk2bKF++PLVq1XKs/+6776hcuXKaFikiWURcLPz9O5SoBk37QskaUK2p1VWJiLjM5QD13HPPcfXqVVasWEHhwoVZvny50/pvv/2Whx9+OM0KFJEs4sCPMKsvnP8b3j0KufMpPImI23L5Kjyx01V4Isl0PRqWjoIvpkHxqvDkHLin1h03ExFJD5ZdhRcVFZXocj8/Pzw9PVNciIhkUe/0hog18MgEaDcUcuS0uiIRkVRz+QyUh4cHtkQGenp6elKyZEmGDRtGv3790qzAzEpnoERuI+ocRJ2FuyvA8X3g4QlFSltdlYiIdWegNm/enOjyS5cuERERwfDhw8mRI4fmghLJjoyBb5bAvKfhrvLw6ja4q5zVVYmIpDmXA1RISEiS6zp06ECJEiV4++23FaBEspszR+C9J2HXl1C/C/SZbnVFIiLpJs1uJnxTSEgIBw4cSOvdikhmFh8PY5vC0T3wwmfw7MeQr7DVVYmIpBuXz0DdSWRkpCbSFMkujuwB/wKQrwg8swSCy0IujQkUkawvTc9AxcbG8vrrr1O3bt203K2IZDY3rsPil2F4TVg12b6sdG2FJxHJNlw+A/Xggw8mujwyMpLffvsNm83Gtm3bUl2YiGRSv22F2f3gzCF46GXo9ILVFYmIZDiXA5S/v3+i0xgULVqUzp070717d3XhiWRVF0/CuGb2iTCfW6mb/4pItuXyPFBXr14lV65c6VWP29A8UJKt/PQlVLkfcnrD/h/gntrgkebXoIiIpLu0+v52+TdggQIFaNu2Le+99x6nT59O8YFFxA1cOAGTO8P41rDjU/uyMvcqPIlItufyb8G9e/fSokULli1bRvHixalbty7jx49nz5496VGfiFghIQG+eg+ergj7voVnl0FD3SRcROSmVN1MODIykrVr17J69WrWrVtHYGAg7du3p3379oSEhGTpe+OpC0+ytJ+/to91euAxePR1yJ3P6opERNJEWn1/pypA/VtsbCzh4eF89tlnfPbZZ1y+fJm3336b7t27p8XuMx0FKHF7J/bDpnlw5jAElYDGPeDv36H+/9lvyXL4ZyhZ3eIiRUTSVqYLUP9mjGH37t3ExcVRp06dtN59pqAAJW5t03yY2RdsNntYstkgId7+881fdXWdiGRZlg0iv5MVK1ZQrVo1atSokWXDk4hbO7HfHp5Mgj003fwJgA1yeFlanoiIO0hRgHr33Xd56KGHeOSRR/j+++8B2LRpEzVq1KBnz540aNAgTYsUkTS0aZ79TFNibDbYODdj6xERcUMuB6jXXnuNQYMGcfjwYT777DPuv/9+JkyYQPfu3enatSt///03s2bNSo9aRSQt/P27/axToox9TJSIiNyWyzORz58/n/fff5+wsDC2bdtGSEgI3333HQcOHMDPzy89ahSRtBAfB1++Y58UM8mhjzb7gHIREbktl89AHT16lPvvvx+ARo0akTNnTsaOHavwJJKZHdgJz98LC4ZC/S5gS+KfvjH2qQtEROS2XD4DFRMTg4+Pj+O5l5cXgYGBaVqUiKSxFRMBAxN32GcSr9oUZj72z1goA/xzNd5Tc6FIaYuLFRHJ/FwOUAAjR4503A/vxo0bvPrqq7fcQPiNN95IfXUikjLGwHfLwSc31GptD0a+ecDzn3/y9/eCCg3tA8ZvzgP1wGMKTyIiyeTyPFChoaHYkrqC5+ZObTY2bdqUqsIyO80DJZnWqb9gzgDYtQ5aPAn9Z1pdkYhIppFW398un4EKDw9P8cFEJB3F3oDPpsAnr4B/ELywGuq0t7oqEZEsKUVdeCKSGRn4Zgm0HAhdRoNvbqsLEhHJslwOUA8++GCiywMCAihbtix9+/alYMGCqS5MRJLh8nn48AVoMwSKVYLJEZBTM4mLiKQ3l6cxCAgISPRx6dIl3n//fcqVK8evv/6aHrWKyE3GwKYFMKgcbP8ETv9lX67wJCKSIdL0ZsIJCQn069ePM2fOsGbNmrTabaakQeRimdOHYEZv+G0LNHoEer0BeQtZXZWIiFuwbBD57Xh4eDB48GBatWqVlrsVkX/L4QXXLsOoDVCtqdXViIhkSym6mfDt+Pn5cfXq1bTerUj2tvsreLkRREdC/rtg8o8KTyIiFkrzALVhwwbKli2b1rsVyZ4unoI3HoZXWoBHDrgWZV9+h7nYREQkfbnchffZZ58lujwyMpKIiAjmzJnDnDlzUl2YSLb33XKY1Q9y5IRBiyCkh4KTiEgm4XKA6tixY6LL8+TJQ7ly5ZgzZw7dunVLbV0i2Vd8nP2WK/mKQP3/gx6TII/uNykikpm4HKASEhLSow4RuXYFPh4NB3bCuHD7veoqNLS6KhERSYTLY6Bat25NZGSk4/lrr73GpUuXHM/Pnz9PxYoV06Q4kWzj+1XwdAVYPwtqtgajP1RERDIzlwPUunXriImJcTyfMGECFy5ccDyPi4tj3759aVOdSHbwdhhM7gTFq8K03+DBF+xdeCIikmml+rd0Gs7DKZJ9xMdBbAz4+EG15lC7HdzXWYPERUTchP7MFclof34P7z4OZerCE+9C4+5WVyQiIi5yuQvPZrNh+89fyf99LiKJiL4E7z0FL9azd9E16291RSIikkIun4EyxtCrVy+8vb0BuH79Ok888QR+fn4ATuOjROQfV6Pg6Ypw/Qr0ngYtB4Cnp9VViYhICrkcoMLCwpye9+jR45Y2jz76aMorEnFHJ/bDpnlw5jAElYD7+0BwGfvz/EUhlz90Gwc1WtlvxSIiIu7NWGjLli2mbdu2pkiRIgYwK1euvG37Tz/91DRt2tQUKFDA5MmTx9x3331m3bp1qdrn448/bgDz5ptvulR7ZGSkAUxkZKRL20kWtHGeMZ09jHnI0/nnpE7GdPU2ZsMcqysUEZF/pNX3d5rfC88V0dHRVKtWjRkzZiSr/datW2nWrBlr164lIiKCJk2a0K5dO3bt2pWifa5cuZIdO3YQHByc4tcg2dyJ/TCzr33epoR455/fr4SQMGiomflFRLIaS6/Ca9WqFa1atUp2+2nTpjk9nzBhAqtXr2bNmjXUqFHDpX0eP36cQYMGsX79etq0aeNS3SIOm+bZpx5IbDYPD0/7LVh8/DK8LBERSV9uPY1BQkICly9fJjDQtfuEJSQk0LNnT4YPH06lSpWStU1MTIzTAPmoqCiXjilZ1JnDkORcaMa+XkREshxLu/BSa8qUKVy5coUuXbq4tN2kSZPIkSMHgwcPTvY2EydOJCAgwPEoWrSoq+VKVmMMxFy9zW1XbPYB5SIikuW4bYBavHgxY8eOZdmyZQQFBSV7u4iICKZPn86CBQtcmr9qxIgRREZGOh7Hjh1LSdmSVfzxHYyoBz9+lnQbY+CBxzKuJhERyTBuGaCWLl1K3759WbZsGU2bNnVp223btnHmzBmKFStGjhw5yJEjB0eOHOHZZ5+lRIkSSW7n7e2Nv7+/00Oyse3LIe4GjN0MA+aDzcM+5snjn582D3hqLhQpbXWlIiKSDtxuDNSSJUvo06cPS5cuTdHg7549e94Sulq0aEHPnj3p3bt3WpUpWU30JfhkPBQoCm0GwyMTIKe3PTABVGgIG+f+bx6oBx5TeBIRycIsDVBXrlzhwIEDjueHDh1i9+7dBAYGUqxYMUaMGMHx48dZtGgRYO+2CwsLY/r06dStW5dTp04B4OvrS0BAQLL2mT9/fvLnz+9UR86cOSlcuDDlypVL75cs7iYuFr56F5aNgdjr0O0V+3JvX+d2RUpDj4kZXp6IiFjD0i68H3/8kRo1ajimIBg6dCg1atRg1KhRAJw8eZKjR4862r/33nvExcUxYMAAihQp4ng8/fTTyd6nSLJdOg3PVIF5g+HejvDOfmj3jNVViYhIJmAzJslrsOU2oqKiCAgIIDIyUuOhsppTf0HhUvZB4Iueg5AeUKKa1VWJiEgaSKvvb7ccRC6SLi6cgBl9YGBp+G2rfYLMsNcVnkRE5BZuN4hcJM1dj4bPpsCqyeCdC/q+A+XqWV2ViIhkYgpQIp9Pg08nQJunofOL4JfX6opERCSTU4CS7GnPZjj9FzR9zD4tQaNHoFBJq6sSERE3oTFQkr0c3wevdYAx98M3S+wDxX3zKDyJiIhLdAZKsof4OFgwFNbPgsC7YOhSqN/FPlBcRETERQpQkrXF3oAcOcEzB0SehYdftY918vKxujIREXFj6sKTrMkY2P4JPF0BflxjXzZ0CXR6XuFJRERSTWegJOvZ/4O9u+6Pb6FGKyhSxuqKREQki1GAkqzlh9UwqSMUqwKjvoJqzayuSEREsiAFKHF/V6PsZ5tqtoLqLWDQQmjUHTw9ra5MRESyKAUocV/xcbBxHiwdCbEx8N4x+5QEoY9aXZmIiGRxGkQu7mnXeni2Orz7uP2s05t77OFJREQkA+gMlGROJ/bDpnlw5jAElYD7+0DwvwaDb5wLefLDpJ1QurZVVYqISDZlM8YYq4twR1FRUQQEBBAZGYm/v7/V5WQtm+bDzL72SS6N+d/Pio2gxZPQoKv9BsDeuTQRpoiIuCStvr/VhSeZy4n99vBkEiAh3vnnb1vgzBF7Ox8/hScREbGMApRkLpvmJR2MPDwh+mLG1iMiIpIIBSjJXM4ctnfXJcrY14uIiFhMAUoyj4QE+xkmk5BEA5t9QLmIiIjFdBWeZA4n9sPsfvZxTtiARM5CGQMPPJbRlYmIiNxCZ6DEej9+Ds9WhbNHYfTXMGAe2DzsY548/vlp84Cn5kKR0lZXKyIiojNQYqGYa+DtC6XrQJsh8NDL9qvrACo0tM/1dHMeqAceU3gSEZFMQ/NApZDmgUqF2Bj4dII9IE3dDf4FrK5IRESyibT6/tYZKMlYf34PMx+DE/ug0wjdfkVERNySApRknM+nw4JnoFRNmBwBJapaXZGIiEiKKEBJ+rtxHbx8oHx96DEJ2j0DnvroiYiI+9K3mKSf6EuwaDgc2g0Tt9sHi5euY3VVIiIiqaYAJelj52fw3pNw7TL0nGyfhkBERCSLUICStPfuk/DVbKjZGh6fDQWKWl2RiIhImlKAkrRhjH16Ai8fqBxqn8ep0SNJ3xhYRETEjSlASeqdOwbvPmGfz2nQQmjQ1eqKRERE0pUGpkjKJSTA+tkwpBIc3g11H7S6IhERkQyhM1CSMvFx8EoL2LMJmvaDRyeDX16rqxIREckQClDimvg4wGafx6lGK+j8ElS53+qqREREMpS68CT5Dv8CI+rBF9PszzsMU3gSEZFsSQFK7iw2BpaMgudqwY1rUL6h1RWJiIhYSl14cnuRZ2BUEzi1395d9+CLkNPL6qpEREQspQAliYu9YQ9K/gWhegu4fykUr2J1VSIiIpmCuvDkVr9shKcrwO6v7BNh9n5D4UlERORfFKDkf6Ivwax+MLYpFCgGhUpZXZGIiEimpC48sTv8M4xvbb/57+PvQtO+4KF8LSIikhgFqOwuLhZy5ITCpaFmG+gyCvLfbXVVIiIimZoCVHZwYj9smgdnDkNQCbi/DxQpDVs/gsUvwthwKFwKnnzP4kJFRETcgwJUVrdpPszsax8Mboz956rJUKwyHPkFGj4MvnmsrlJERMStKEBlZSf228OTSQDzz7KbP4/8Ao/PhuaPW1WdiIiI29Io4axs0zz7GafEeHjau/RERETEZQpQWdmZw/Zuu0QZBSgREZEUUoDKyoJKJH0GCpt9vYiIiLhMASora9QdEuITX2cMPPBYxtYjIiKSRWgQeVZlDHw8CjxzQELCP2eiDPDP1XhPzbVPZSAiIiIuU4DKqmw2uLcjPNAXgsvCxrn/mwfqgccUnkRERFLBZkySo4zlNqKioggICCAyMhJ/f3+ry/kfY2D3eqjR0upKREREMp20+v7WGKis5sMR8GorOLDT6kpERESyLAWorGTFRFg1CXq9AaXrWF2NiIhIlqUAlVV8OQM+ehG6joF2z1hdjYiISJamAJUVJCTAztXQ9hn4v1FWVyMiIpLl6So8d3fjOnj5wIjPIUfO20ycKSIiImlFZ6Dc2c8bYGAZ+02Dc3opPImIiGQQBSh39cd3MKkjFKsCBYtbXY2IiEi2ogDljv7aBeNbwz21Yfgn9rNPIiIikmEUoNxNXCxMeQiKlIERa8A7l9UViYiIZDsaRO5ucuSEoR/bb8mSKxPNgC4iIpKN6AyUu7h4ChY8C7E3oHRt8C9gdUUiIiLZlqUBauvWrbRr147g4GBsNhurVq26bfsVK1bQrFkzChYsiL+/P/Xq1WP9+vUu7TM2Npbnn3+eKlWq4OfnR3BwMI8++ignTpxI41eXhi5fgHHN4NulEHXG6mpERESyPUsDVHR0NNWqVWPGjBnJar9161aaNWvG2rVriYiIoEmTJrRr145du3Yle59Xr17lp59+YuTIkfz000+sWLGCffv20b59+zR5TWnu2mUY3wounYLRX0P+u62uSEREJNuzGWOM1UUA2Gw2Vq5cSceOHV3arlKlSnTt2pVRo26dgTu5+9y5cyf33nsvR44coVixYom2iYmJISYmxvE8KiqKokWLpvpuzrcVG2O/MfBfETB2M5SqmT7HERERySaioqIICAhI9fe3W4+BSkhI4PLlywQGBqZqP5GRkdhsNvLmzZtkm4kTJxIQEOB4FC1aNFXHTBbPnPapCkZ8rvAkIiKSibh1gJoyZQpXrlyhS5cuKd7H9evXef7553n44Ydvm0RHjBhBZGSk43Hs2LEUH/OO4uPhYAR4eMCjk6Fio/Q7loiIiLjMbacxWLx4MWPHjmX16tUEBQWlaB+xsbF06dIFYwyzZs26bVtvb2+8vb1TdByXGAPvPQlbP4CZf0G+Iul/TBEREXGJWwaopUuX0rdvX5YvX07Tpk1TtI+b4enIkSNs2rQp/cYxucIYWPQcfP0+DJiv8CQiIpJJuV2AWrJkCX369GHp0qW0adMmRfu4GZ7279/P5s2byZ8/fxpXmUKfjofPpkCf6XB/L6urERERkSRYGqCuXLnCgQMHHM8PHTrE7t27CQwMpFixYowYMYLjx4+zaNEiwN5tFxYWxvTp06lbty6nTp0CwNfXl4CAgGTtMzY2loceeoiffvqJzz//nPj4eMd+AgMD8fKy6L5y1y7DxnnQbRy0GWxNDSIiIpIslk5jEB4eTpMmTW5ZHhYWxoIFC+jVqxeHDx8mPDwcgNDQULZs2ZJk++Ts8/Dhw5QsWTLRejZv3kxoaGiyak+ryyAB+6BxT0+IjrTfnsVmS93+REREJFFp9f2daeaBcjdpFqC2fwqrJsGor8Avb5rVJyIiIrfSPFBZwa71MO1hKHQP+OSxuhoRERFJJgUoq+z9BiZ3gmotYPAiexeeiIiIuAUFKCtcPg8T2kLZ++DZZZAjp9UViYiIiAvcbhqDLCFPfhi4AKo+AN6+VlcjIiIiLtIZqIx0+hB8OcP+33U7gq/GPYmIiLgjnYHKKBdOwNim9ikKQh9VeBIREXFjClAZ4fJ5GNcc4m7Aq9sUnkRERNycAlR6uxoFr7SEyDPwylYIKmF1RSIiIpJKGgOV3mw2KFDUPlHm3eWtrkZERETSgM5ApZfYG3DxhP2M03MrrK5GRERE0pDOQKWH+Hh4qyeMbAw3rltdjYiIiKQxnYFKa8bAu4/Djk9h2HLw8rG6IhEREUljClBpyRhY8CxsnAuDFkLdTlZXJCIiIulAXXhp6fQh+Po96PuOfa4nERERyZJ0BiqtGAOFS8Hbf0JgsNXViIiISDpSgEqtj8dAYEE49qu9207hSUREJMtTgEqtz6dBDgOVm4CHp9XViIiISAbQGKjUMsb+87ctcOqgtbWIiIhIhlCASis2m/3qOxEREcnyFKDSjIEzh60uQkRERDKAAlSaselGwSIiItmEAlRaMQYeeMzqKkRERCQD6Cq81PLwABvw1FwoUtrqakRERCQDKEClVpunoe1TCk8iIiLZiAJUanUdA/7+VlchIiIiGUhjoERERERcpAAlIiIi4iIFKBEREREXKUCJiIiIuEgBSkRERMRFClAiIiIiLlKAEhEREXGRApSIiIiIixSgRERERFykACUiIiLiIgUoERERERcpQImIiIi4SAFKRERExEUKUCIiIiIuUoASERERcZEClIiIiIiLFKBEREREXKQAJSIiIuIiBSgRERERFylAiYiIiLhIAUpERETERQpQIiIiIi5SgBIRERFxkQKUiIiIiIsUoERERERcpAAlIiIi4iIFKBEREREXKUCJiIiIuEgBSkRERMRFClAiIiIiLlKAEhEREXGRApSIiIiIixSgRERERFykACUiIiLiIgUoERERERcpQImIiIi4SAFKRERExEWWBqitW7fSrl07goODsdlsrFq16rbtV6xYQbNmzShYsCD+/v7Uq1eP9evXu7xPYwyjRo2iSJEi+Pr60rRpU/bv35+Gr0xERESyMksDVHR0NNWqVWPGjBnJar9161aaNWvG2rVriYiIoEmTJrRr145du3a5tM/Jkyfz1ltvMXv2bL7//nv8/Pxo0aIF169fT/VrEhERkazPZowxVhcBYLPZWLlyJR07dnRpu0qVKtG1a1dGjRqVrH0aYwgODubZZ59l2LBhAERGRlKoUCEWLFhAt27dknXcqKgoAgICiIyMxN/f36WaRURExBpp9f2dIw1rynAJCQlcvnyZwMDAZG9z6NAhTp06RdOmTR3LAgICqFu3Ltu3b08yQMXExBATE+N4HhkZCdj/R4iIiIh7uPm9ndrzR24doKZMmcKVK1fo0qVLsrc5deoUAIUKFXJaXqhQIce6xEycOJGxY8fesrxo0aLJPraIiIhkDufPnycgICDF27ttgFq8eDFjx45l9erVBAUFpfvxRowYwdChQx3PL126RPHixTl69Giq/gdklKioKIoWLcqxY8fcpsvR3Wp2t3rB/Wp2t3ol/ekzIa6KjIykWLFiLvVeJcYtA9TSpUvp27cvy5cvd+qKS47ChQsDcPr0aYoUKeJYfvr0aapXr57kdt7e3nh7e9+yPCAgwK3+0fr7+7tVveB+NbtbveB+NbtbvZL+9JkQV3l4pO46OrebB2rJkiX07t2bJUuW0KZNG5e3L1myJIULF2bjxo2OZVFRUXz//ffUq1cvLUsVERGRLMrSM1BXrlzhwIEDjueHDh1i9+7dBAYGUqxYMUaMGMHx48dZtGgRYO+2CwsLY/r06dStW9cxZsnX19fRjXanfdpsNoYMGcKrr75KmTJlKFmyJCNHjiQ4ONjlKwBFREQkmzIW2rx5swFueYSFhRljjAkLCzMhISGO9iEhIbdtn5x9GmNMQkKCGTlypClUqJDx9vY2DzzwgNm3b59LtV+/ft2MHj3aXL9+PRXvQMZxt3qNcb+a3a1eY9yvZnerV9KfPhPiqrT6zGSaeaBERERE3IXbjYESERERsZoClIiIiIiLFKBEREREXKQAJSIiIuIiBSgRERERFylAiYiIiLjILW/lIrd3c+LRO3n00UfTuZKsS++xiIh7iI6Oxs/PL833q3mgsiAPDw9y585Njhw5SOp/r81m48KFCxlcWdLcLZDoPU5/48aNS1a7UaNGpXMlklnoMyEpcc8997Bw4UIaNmyYpvtVgEomd/qHW6lSJU6fPk2PHj3o06cPVatWtbqkO3K3QKL3OP15eHgQHBxMUFDQbev96aefMrgysYo+E5ISzz33HNOmTePpp59m/PjxeHl5pcl+FaCSyd3+4X7//ffMmzePjz/+mNKlS/PYY4/RvXv3THu3cncMJHqP01ebNm3YtGkTLVq0oE+fPrRt2zbVd08X96bPhKTUjh076NOnDx4eHnzwwQfUqFEj9TtN1Y1gspHWrVsbHx8f06FDB7N69WoTHx9vdUnJcvXqVbNw4UITGhpqcuXKZR555JFMe8+oHTt2mP79+5uAgABTq1YtM3PmTBMZGWl1WXek9zj9HD9+3EyYMMGULVvWFC5c2Dz33HPmjz/+sLossZA+E5JS169fN8OGDTM+Pj6mXbt2plOnTk4PV+kMlAtOnDjBwoULWbBgAVFRUTz66KP06dOHcuXKWV3aHW3dupXRo0ezdetWzp07R758+awuKUnXrl1j+fLlzJ8/nx9++IGOHTsyb948vL29rS7ttvQep6+tW7cyf/58Pv30U6pUqcLXX3+Nr6+v1WWJhfSZEFdERUUxaNAgli9fTufOncmRw/k6uvnz57u2wzSPeNnEli1bTK9evUyePHlM/fr1zdWrV60u6RZ///23GT9+vCldurQpUqSIGT58uNm7d6/VZSXbli1bTGhoqPHw8DAXLlywupxE6T3OODfP9N17773G19c3U585k4yhz4Qk11dffWXuvvtuU6dOHfP777+nyT4VoFIoM//D/fjjj03Lli2Nr6+v6dixo1m9erWJi4uzuqxkcZdAovc443z33Xemb9++xt/f39SuXdvMmDHDXLx40eqyxEL6TIgr+vfvb7y9vc3YsWPT9Pe0uvBctH37dubNm8eyZcsoW7YsvXv35pFHHiFv3rxWl+bg4eFBsWLF6N69O4UKFUqy3eDBgzOwqttbtmwZ8+fPZ8uWLbRo0YLevXvTpk0bPD09rS4tUXqP09/kyZNZsGAB586do3v37vTu3TvTD3yX9KXPhKRE5cqVWbRoETVr1kzT/SpAJZM7/cMtUaIENpvttm1sNht//fVXBlV0Z+4WSPQep7+b9bZt2/a2lx2/8cYbGViVWEmfCUmJGzdu3PbzcuzYMUaPHs28efNc2q8CVDLpH276csdAkpiEhIRMe1m1u73HoaGhyap306ZNGVSRWE2fCUkPP//8MzVr1iQ+Pt6l7RSgkik5/3ABNm/enAHVSGbl5eXFzz//TIUKFawuRUREgM8+++y26//66y+effZZBSixu3btGhEREQQGBlKxYkWnddevX2fZsmWZ5pYdN+3du5cdO3ZQv359ypUrxx9//MH06dOJiYmhR48e3H///VaX6DB06NBEl0+fPp0ePXqQP39+IHOfkYyOjmbZsmUcOHCA4OBgHn74YQIDA60uS+S2Tp48yaxZs/jmm284efIkHh4elCpVio4dO9KrV69MO6ZPrOPh4YHNZktyEmywn7l0NUBlzr4GN3Ts2DH69OljdRkA/Pnnn1SoUIHGjRtTpUoVQkJCOHnypGN9ZGQkvXv3trDCW61bt47q1aszbNgwqlevzrp162jcuDEHDhzgyJEjNG/ePFOdlp82bRqbN29m165dTg9jDHv37mXXrl3s3r3b6jKdVKxY0XGblmPHjlGpUiWeeeYZNmzYwKhRo6hQoQKHDh2yuMr/+emnn5zq+eCDD2jQoAFFixalYcOGLF261MLqxAo//vgjFSpUYO3atcTGxrJ//35q1aqFn58fw4YNo3Hjxly+fNnqMiWTKVKkCCtWrCAhISHRR4rvIJJm1/Nlc7t37zYeHh5Wl2GMMaZjx46mTZs25uzZs2b//v2mTZs2pmTJkubIkSPGGGNOnTqVaWq9qV69euall14yxhizZMkSky9fPvPiiy861r/wwgumWbNmVpV3i4kTJ5qSJUuajRs3Oi3PkSOH+e233yyq6vZsNps5ffq0McaY7t27m/r165tLly4ZY4y5fPmyadq0qXn44YetLNFJ1apVzYYNG4wxxrz//vvG19fXDB482MyaNcsMGTLE5M6d28ydO9fiKiUjNWjQwIwZM8bx/IMPPjB169Y1xhhz4cIFU716dTN48GCrypNMql27dmbkyJFJrt+9e7ex2Wwu71ddeMmUXn2o6aFQoUJ8/fXXVKlSBQBjDE899RRr165l8+bN+Pn5ERwcnClqvSkgIICIiAhKly5NQkIC3t7e/PDDD477Ff366680bdqUU6dOWVzp/+zcuZMePXrQrl07Jk6cSM6cOcmZMyc///zzLd2mmYGHhwenTp0iKCiIe+65h9mzZ9OsWTPH+u+++45u3bpx9OhRC6v8n1y5crF3716KFy9OzZo1efLJJ+nXr59j/eLFixk/fjy//fabhVVKRsqVKxe//vorpUqVAuwXbfj4+HDs2DEKFSrEhg0b6NWrF8ePH7e4UslMtm3bRnR0NC1btkx0fXR0ND/++CMhISEu7TfHnZsIQMeOHZPVh5oZXLt2zWmKepvNxqxZsxg4cCAhISEsXrzYwuqSdvP98/DwwMfHh4CAAMe6PHnyEBkZaVVpiapTpw4REREMGDCA2rVr89FHH2Waz0BSbtZ3/fp1ihQp4rTurrvu4uzZs1aUlahcuXJx7tw5ihcvzvHjx7n33nud1tetWzdTdTlK+gsKCuLkyZOOAHX69Gni4uIcN/AuU6aMo5ta5KZGjRrddr2fn5/L4Qk0BirZ0q0PNR2UL1+eH3/88Zbl77zzDh06dKB9+/YWVHV7JUqUYP/+/Y7n27dvp1ixYo7nR48eveULPzPInTs3CxcuZMSIETRt2jRTndVLzAMPPEDNmjWJiopi3759TuuOHDniGPyeGbRq1YpZs2YBEBISwieffOK0ftmyZZQuXdqK0sQiHTt25IknnmDdunVs3ryZ7t27ExIS4rj/3b59+7jrrrssrlKyC52BSqZatWoRERFBhw4dEl1/p7NTGalTp04sWbKEnj173rLunXfeISEhgdmzZ1tQWdKefPJJp/BRuXJlp/VffvllproK77+6detGw4YNiYiIoHjx4laXk6jRo0c7Pc+dO7fT8zVr1tzxL7WMNGnSJBo0aEBISAi1a9dm6tSphIeHU6FCBfbt28eOHTtYuXKl1WVKBnr11Vc5efIk7dq1Iz4+nnr16vHhhx861ttsNiZOnGhhhZKdaAxUMqVXH6qIJO3SpUu89tprrFmzhr/++ouEhASKFClCgwYNeOaZZ6hdu7bVJYoFrl+/Tlxc3C1/BIhkJAUoERERERdpDJSIiIiIixSgRERERFykACUiIiLiIgUoERERERcpQImIiIi4SAFKRERExEUKUCIiIiIu+n9mG6bClcJ8uAAAAABJRU5ErkJggg=="
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAlAAAAG4CAYAAACKHdk3AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8pXeV/AAAACXBIWXMAAA9hAAAPYQGoP6dpAABhX0lEQVR4nO3de3zO9f/H8ce12YnZHMfmNJJzOUROaXNYQqQUlWLRQQ6lSYhQOUWKUvrm51hfC6HyzSFhlMM3RAfkkIkcErEx7Pj+/XHl+na1Yddc22fXPO+323XbPp/P+/P+vK5r13a99n6/P++3zRhjEBEREZFs87I6ABERERFPowRKRERExEVKoERERERcpARKRERExEVKoERERERcpARKRERExEVKoERERERcpARKRERExEVKoERERERcpARKJJ+YM2cONpvtio+4uDhHWZvNRv/+/bOs55NPPslUPjo62qkuX19fbrrpJl544QUSExOvGFNMTAx169YFYPTo0dhsNk6dOpVl2Tp16hAZGem078iRI/Tt25dq1aoREBBAiRIluOWWW3jyySc5cuSIo9zlui8/ChcuTPny5Wnbti3vvPMO586du8arZ3e11/CFF17IVh2e6NChQ9hsNubMmZOt8gcPHqR///6On0vhwoWpXbs2I0aM4OjRo7kbrEgBUcjqAETE2ezZs6lRo0am/bVq1bquegMCAli7di0AZ8+e5ZNPPmHy5Mn88MMPfPnll1mes2TJEnr16pWj6/322280aNCAYsWKMWjQIKpXr05CQgK7d+9m4cKFHDx4kAoVKjids3LlSoKDg0lJSeHYsWOsWbOGF198kUmTJrFs2TJHMnctWb2GYWFhOXoeBc1//vMfHnroIUqVKkX//v2pX78+NpuNH3/8kVmzZvHFF1+wY8cOq8MUyfeUQInkM3Xq1KFhw4Zur9fLy4smTZo4tu+++24OHjzI6tWriY+Pp3Llyk7lt27dyq+//kqXLl1ydL0ZM2Zw6tQpvv32W6e6O3fuzEsvvURGRkamc2677TZKlSrl2H7ooYfo378/ERERdOrUiX379uHn53fNa+fWa3jhwgUKFy7s9nrz6trx8fE89NBDVKtWjXXr1hEcHOw41qpVK5599lmWLl16vaECkJqais1mo1AhfcxIwaQuPJEb2OUk4/fff890bPHixVSvXp3atWvnqO7Tp0/j5eVFSEhIlse9vLL356du3boMHz6cw4cPs2DBghzF8k+ff/45TZs2pXDhwhQtWpSoqCg2b97sVOZyt+J3333HAw88QPHixbnpppv44osvsNlsbN261VF28eLF2Gw2OnTo4FTHrbfe6pSAvvvuu9x5552EhIRQpEgRbrnlFiZOnEhqaqrTeZGRkdSpU4cNGzbQrFkzChcu7GgJPHbsGF27dqVo0aIEBwfTrVs3Tpw4ka3n/eabb5KUlMR7773nlDxdZrPZuP/++x3b4eHhREdHZyoXGRnp1F0bFxeHzWbjww8/ZNCgQZQrVw4/Pz927dqFzWZj5syZmepYsWIFNpuNzz//3LFv//79PPLII4SEhODn50fNmjV59913s/XcRPKaEiiRfCY9PZ20tDSnR3p6eq5cKz4+nkKFClGlSpVMxxYvXpzj1ieApk2bkpGRwf3338+qVauuOtbqWjp16gTAhg0bslU+q9fwsvnz53PvvfcSFBREbGwsM2fO5MyZM0RGRvLNN99kquv++++natWqLFq0iPfff5+IiAh8fHz46quvHGW++uorAgICWL9+vSMZOnnyJD/99BNt2rRxlPvll1945JFH+PDDD/nPf/5D7969mTRpEk8//XSm6x4/fpxHH32URx55hOXLl9O3b18uXrxImzZt+PLLLxk/fjyLFi2ibNmydOvWLVuvy5dffkmZMmWcWiLdadiwYRw+fJj333+fZcuWUaFCBerXr8/s2bMzlZ0zZw4hISG0b98egN27d9OoUSN++uknJk+ezH/+8x86dOjAs88+yyuvvJIr8YpcFyMi+cLs2bMNkOXD29vbqSxg+vXrl2U9ixYtMoBZt26dY1/Pnj1NkSJFTGpqqklNTTWnTp0y06dPN15eXuall17KVMfOnTsNYLZv3+7YN2rUKAOYP/74I8vr1q5d20RERDi2MzIyzNNPP228vLwMYGw2m6lZs6Z5/vnnTXx8vNO516r74sWLBjDt2rXL8vhlV3sNU1NTTXp6ugkLCzO33HKLSU9Pd5x37tw5ExISYpo1a5YpppEjR2a6zh133GFatWrl2K5ataoZPHiw8fLyMuvXrzfGGPPvf//bAGbfvn1Zxpqenm5SU1PNvHnzjLe3t/nzzz8dxyIiIgxg1qxZ43TO9OnTDWA+++wzp/1PPvmkAczs2bOv+vr4+/ubJk2aXLXM31WqVMn07Nkz0/6IiAinn/W6desMYO68885MZd9++20DmL179zr2/fnnn8bPz88MGjTIsa9t27amfPnyJiEhwen8/v37G39/f6fXRyQ/UAuUSD4zb948tm7d6vT473//e931JiUl4ePjg4+PD6VKleKZZ56hW7dujB07NlPZxYsXEx4eToMGDXJ8PZvNxvvvv8/Bgwd57733ePzxx0lNTeWtt96idu3arF+/Ptt1GWNcunZWr2GhQoXYu3cvx44d47HHHnPqQgwMDKRLly5s2bKFCxcuONWVVStc69at2bhxIxcvXuTXX3/lwIEDPPTQQ9SrV4/Vq1cD9lapihUrcvPNNzvO27FjB506daJkyZJ4e3vj4+NDjx49SE9PZ9++fU7XKF68OK1atXLat27dOooWLepokbvskUcecen1yS1ZvVbdu3fHz8/P6Q7B2NhYkpOTefzxxwG4dOkSa9as4b777qNw4cJOLYft27fn0qVLbNmyJa+ehki2aHSfSD5Ts2bNaw6A9vb2vmK33uXuKh8fH6f9AQEBji6wEydOMHnyZGJjY7n11lsZOnSoU9lPPvkk04fh5cHAV7vuP68JUKlSJZ555hnH9sKFC3n44YcZPHgw33777dWepsOvv/4KZP9Ouiu9hqdPnwYgNDQ007GwsDAyMjI4c+aM02DtrMq2adOGV155hW+++YZff/2VUqVKUb9+fdq0acNXX33Fa6+9xpo1a5y67w4fPkyLFi2oXr06U6dOJTw8HH9/f7799lv69evHxYsXna6R1XVPnz5NmTJlMu0vW7bsVV6N/6lYsSLx8fHZKpsTWcVcokQJOnXqxLx583jttdfw9vZmzpw53H777Y7xdadPnyYtLY133nmHd955J8u6rzR9hohVlECJeKAyZcpccb6ey/v/+UHr5eXllFRERUVx22238corr9C9e3fHlAJ79uxhz549mQb+Xq7v6NGjmeo2xnD8+PFs3fnWtWtXxo8fz08//XTNspddHmj8z3mmXFWyZEnAPr7on44dO4aXlxfFixd32m+z2TKVbdy4MYGBgXz11VccOnSI1q1bY7PZaN26NZMnT2br1q0cPnzYKYH69NNPSUpKYsmSJVSqVMmxf+fOnVnGmtV1S5YsmWXSmd1B5Jfn1dqyZUu2xkH5+/uTnJycaf+pU6ec7pa8WswAjz/+OIsWLWL16tVUrFiRrVu3Mn36dMfx4sWL4+3tzWOPPUa/fv2yrOOfd4mKWE1deCIeqE2bNqxbt44//vjDab8xhkWLFhEeHk7VqlWvWoefnx/vvvsuly5dYsyYMY79ixcvJiwsLNMHbKtWrbDZbFneCbdy5UoSExOdEoaskhSA8+fPc+TIkWy3Jn3//feMGzeO8PBwunbtmq1zrqR69eqUK1eO+fPnO3ULJiUlsXjxYsededfi4+PDnXfeyerVq1m7di1RUVEAtGjRgkKFCjFixAhHQnXZ5eTi79MwGGOYMWNGtuNv2bIl586dc7pzDewD47Pj+eefp0iRIvTt25eEhIRMx40xTtMYhIeH88MPPziV2bdvH3v37s12zAB33XUX5cqVY/bs2cyePRt/f38efvhhx/HChQvTsmVLduzYwa233krDhg0zPS4nvyL5hVqgRPKZn376yemusctuuukmSpcuDcDIkSNZtmwZjRs3ZujQodx8882cOHGCGTNmsHXrVhYuXJita0VERNC+fXtmz57N0KFDqVy5Mp988gn3339/ptaEm266if79+zNp0iTOnj1L+/btCQgIYOvWrUyYMIGGDRs6jcUZO3YsGzdupFu3btSrV4+AgADi4+OZNm0ap0+fZtKkSZni2b59O8HBwaSmpjom0vzwww8JCQlh2bJl+Pr6uvJSZuLl5cXEiRPp3r0799xzD08//TTJycmO5zRhwoRs19W6dWsGDRoE4EgcAwICaNasGV9++SW33nqr0xQOUVFR+Pr68vDDD/Piiy9y6dIlpk+fzpkzZ7J9zR49evDWW2/Ro0cPxo4dy80338zy5ctZtWpVts6vXLkyH3/8seNncnkiTbDfBTdr1iyMMdx3330APPbYYzz66KP07duXLl268OuvvzJx4kTH+zC7vL296dGjB2+++SZBQUHcf//9maZRmDp1KnfccQctWrTgmWeeITw8nHPnznHgwAGWLVvmmARWJN+wcAC7iPzN1e4gA8yMGTOcyu/fv988+uijJjQ01BQqVMgUK1bM3HXXXZnu3DLmf3fhZeXHH380Xl5e5vHHHzcHDhzIdAff32VkZJjp06ebhg0bmsKFCxtfX19z8803myFDhphz5845ld2yZYvp16+fqVu3rilRooTx9vY2pUuXNnfffbdZvny5U9nLd7xdfvj5+ZnQ0FBz1113malTp5rExESXXsOtW7detdynn35qGjdubPz9/U2RIkVM69atzcaNG7OM6Up3Bn7//fcGMDfffLPT/rFjxxrAxMTEZDpn2bJlpm7dusbf39+UK1fODB482KxYsSLTax4REWFq166d5XV/++0306VLFxMYGGiKFi1qunTpYjZt2pStu/Au++WXX0zfvn1N1apVjZ+fnwkICDC1atUyMTExTndIZmRkmIkTJ5oqVaoYf39/07BhQ7N27dor3oW3aNGiK15z3759jp/v6tWrsywTHx9vevXqZcqVK2d8fHxM6dKlTbNmzcyYMWOy9bxE8pLNGBdvbxGRAmvixIm88cYbHD9+HG9vb6vDERHJt5RAiYiIiLhIg8hFREREXKQESkRERMRFliZQGzZsoGPHjoSFhWGz2fj000+vWn7JkiVERUVRunRpgoKCaNq0aaa7T2bMmEGLFi0oXrw4xYsXp02bNlnOm/Lee+9RuXJl/P39ue222/j666/d+dRERESkALM0gUpKSqJu3bpMmzYtW+U3bNhAVFQUy5cvZ/v27bRs2ZKOHTuyY8cOR5m4uDgefvhh1q1bx+bNm6lYsSJ33XWX06SDCxYsYODAgQwfPpwdO3bQokUL2rVrx+HDh93+HEVERKTgyTeDyG02G0uXLqVz584unVe7dm26devGyJEjszyenp5O8eLFmTZtGj169ADsswg3aNDAaSbcmjVr0rlzZ8aPH5/j5yAiIiI3Bo+eSDMjI4Nz585RokSJK5a5cOECqampjjIpKSls374909pfd911F5s2bbpiPcnJyU5LGmRkZPDnn39SsmTJKy5fICIiIvmLMYZz584RFhbmtKi4qzw6gZo8eTJJSUlXXd5h6NChlCtXzjFT8KlTp0hPT8+0lleZMmWuup7U+PHjeeWVV9wTuIiIiFjqyJEjlC9fPsfne2wCFRsby+jRo/nss8+clkv4u4kTJxIbG0tcXBz+/v5Ox/7ZamSMuWpL0rBhw4iJiXFsJyQkULFiRY4cOUJQUNB1PBMREZF8aP+38PZjkJEBL30B5apZHZFbJCYmUqFCBYoWLXpd9XhkArVgwQJ69+7NokWLnBYv/bs33niDcePG8dVXX3Hrrbc69pcqVQpvb+9MrU0nT57M1Cr1d35+fk6LgF4WFBSkBEpERAoOY2D1BzBzAFS9HV5YBMVDrY7K7a53+I3HzQMVGxtLdHQ08+fPp0OHDlmWmTRpEq+99horV66kYcOGTsd8fX257bbbWL16tdP+1atX06xZs1yLW0RExCPs3QT/6gNRT8PotQUyeXIHS1ugzp8/z4EDBxzb8fHx7Ny5kxIlSlCxYkWGDRvG0aNHmTdvHmBPnnr06MHUqVNp0qSJoxUpICDAsbL3xIkTefnll5k/fz7h4eGOMoGBgQQGBgIQExPDY489RsOGDWnatCkffPABhw8fpk+fPnn59EVERPKP82cgsDjUaA7jt0C1xlZHlL9Zt47x/1bw/uejZ8+exhj7CvJ/X/E7IiLiquWNMaZSpUpZlhk1apTTtd99911TqVIl4+vraxo0aGDWr1/vUuwJCQkGMAkJCTl89iIiIvnED2uNiS5tzPqPrI4k17nr8zvfzAPlaRITEwkODiYhIeGqY6DS09NJTU3Nw8hEwMfHB29vb6vDEJH8zhhY9hZ8+CLUaQnPx0JQKaujylXZ/fy+Fo8cRO4JjDGcOHGCs2fPWh2K3KCKFStG2bJlNU+ZiGQt+QK82xs2fgydh8AjY8BbaUF26ZXKJZeTp5CQEAoXLqwPMckzxhguXLjAyZMnAQgN1QBQEcmClzecP22/y67pA1ZH43GUQOWC9PR0R/JUsmRJq8ORG1BAQABgn54jJCRE3Xki8j/bl0PxslClAby8CvQPfo543DQGnuDymKfChQtbHIncyC6//zQGT0QA+4SYC1+F8ffAV/9n36fkKcfUApWL1G0nVtL7T0QckhLss4pv/w889Crc/5LVEXk8JVAiIiIFmTH2VqfDP8Gw/8Bt7a2OqEBQF54UWKNHj6ZevXpWhyEiYp30NHs33WMTYeI2JU9upAQqvzu2Hz4aBm8+bP96bH+uXi46OhqbzZbp8fcZ40VEJJ9LT4MPh8D4jpCeDtWbQtmbrI6qQFEXXn62dja894T9vwdj7F8/nQh9Z0Kr6Fy77N13383s2bOd9pUuXdrlelJSUvD19XVXWFeUmpqKj49Prl9HRMQjJJ6CNx+CXXHQYxJ4qa0kN+hVza+O7bcnTyYDMtKdv77XG47nXouQn58fZcuWdXp4e3uzfv16br/9dvz8/AgNDWXo0KGkpaU5zouMjKR///7ExMRQqlQpoqKiGDRoEB07dnSUmTJlCjabjS+++MKxr3r16vzrX/8CYOvWrURFRVGqVCmCg4OJiIjgu+++c4rPZrPx/vvvc++991KkSBHGjBkDwIQJEyhTpgxFixald+/eXLp0yem8uLg4br/9dooUKUKxYsVo3rw5v/76q9tfPxERy/yyHQbfBr/+ACNXQ8fndaddLlECldfOHIeD3zk/fo+3H0u59L99S8Zd+U1vs8HisfZy5/6070v4I3O9Z467LeyjR4/Svn17GjVqxPfff8/06dOZOXOmI3m5bO7cuRQqVIiNGzfyr3/9i8jISL7++msyMjIAWL9+PaVKlWL9+vWAfcLRffv2ERERAcC5c+fo2bMnX3/9NVu2bOHmm2+mffv2nDt3zuk6o0aN4t577+XHH3+kV69eLFy4kFGjRjF27Fi2bdtGaGgo7733nqN8WloanTt3JiIigh9++IHNmzfz1FNP6U41ESlYdsVBsTIwaTvc0tLqaAo2N6zLd0O62mKEFy9eNLt37zYXL17MfOLHo4y5H+fHlO72Y8f2Zz52rUfch/Zzl0/LfOzjUS4/r549expvb29TpEgRx+OBBx4wL730kqlevbrJyMhwlH333XdNYGCgSU9PN8bYF3uuV6+eU31nz541Xl5eZtu2bSYjI8OULFnSjB8/3jRq1MgYY8z8+fNNmTJlrhhPWlqaKVq0qFm2bJljH2AGDhzoVK5p06amT58+TvsaN25s6tata4wx5vTp0wYwcXFxLr8mnuqq70MRKThSko3Z9h/79xkZxqRcsjaefM5diwlrDFReu+tpaNTJeV+R4vavJcvb/2sAWP4OrP/Q3m33T17eEPEYtB8ApcPt+5p1tQ8S/LviOVvCo2XLlkyfPv1/4RUpQr9+/WjatKlTi03z5s05f/48v/32GxUrVgSgYcOGTnUFBwdTr1494uLi8PHxwcvLi6effppRo0Zx7tw54uLiHK1PYJ85e+TIkaxdu5bff/+d9PR0Lly4wOHDh53q/ed19uzZQ58+fZz2NW3alHXr1gFQokQJoqOjadu2LVFRUbRp04auXbtqmRMR8Wx/HoM3HoSD22HafihVAXz8rI7qhqAEKq8VD71yYuPrb59aH+yTnMXNy7qcMdBlOIRW/d++4NL2hxsUKVKEqlWrOu0zxmTq7jLGAM4TNhYpUiRTfZGRkcTFxeHr60tERATFixendu3abNy4kbi4OAYOHOgoGx0dzR9//MGUKVOoVKkSfn5+NG3alJSUlEwxumr27Nk8++yzrFy5kgULFjBixAhWr15NkyZNXK5LRMRye76xJ09e3vBqnD15kjyjMVD5VdjN9rvtbF72Xw6vv77avOz7Q6teuw43qlWrFps2bXIkTQCbNm2iaNGilCtX7qrnXh4HtXbtWiIjIwGIiIjg448/dhr/BPD111/z7LPP0r59e2rXro2fnx+nTp26Znw1a9Zky5YtTvv+uQ1Qv359hg0bxqZNm6hTpw7z58+/Zt0iIvnOjpUwqiWEVbP3XFTTP4J5TQlUftYqGt7ZC/cOhqZd7V/f2ZurUxhcSd++fTly5AgDBgzg559/5rPPPmPUqFHExMTgdY1bZO+8807OnTvHsmXLHAlUZGQkH330EaVLl6ZWrVqOslWrVuXDDz9kz549/Pe//6V79+6OhXGv5rnnnmPWrFnMmjWLffv2MWrUKHbt2uU4Hh8fz7Bhw9i8eTO//vorX375Jfv27aNmzZo5e0FERKxUo7l9SZZRX9kHjUueUxdefhdaFR4db3UUlCtXjuXLlzN48GDq1q1LiRIl6N27NyNGjLjmucHBwdSvX5/Dhw87kqUWLVqQkZHh1PoEMGvWLJ566inq169PxYoVGTduHC+88MI1r9GtWzd++eUXhgwZwqVLl+jSpQvPPPMMq1atAuwL6/7888/MnTuX06dPExoaSv/+/Xn66adz8GqIiFjg5CH7NDZPvW/vpbh/mNUR3dBs5u99MpJtiYmJBAcHk5CQQFBQkNOxS5cuER8fT+XKlfH397coQrnR6X0oUoB8/xW89RAEBMHQz6DSLVZH5LGu9vntCnXhiYiI5FfG2FegGNMWbmpoX89OyVO+oC48ERGR/OrUEfhkDNw3DLq9At7eVkckf1ECJSIikt8c2w8lwqB0Rfv8Thoonu+oC09ERCQ/2fo5DGkIi161byt5ypeUQImIiOQH6ekQOxIm3Au3tIEHrn2Xs1hHXXgiIiJWS0+zJ047VkD3cXDf0CsvKC/5ghIoERERq3kXsq9n2v5ZqN/W6mgkG5RAiYiIWOXrWLiQAG37qMvOw2gMlIiISF5LT4PZMTDlETjwrX2+J/EoSqDyqaNnL/LT0YQrPo6evWh1iNdlzpw5FCtWzLE9evRo6tWrd111Hjp0CJvNxs6dO6+rHk8SHR1N586drQ5DRFyRcBJeiYIV70Dvt/9aOF7jnTyNuvDyoaNnL9LqjTiS0zKuWMavkBdrX4ikXLFrL7TriujoaM6ePcunn37q1nqv5YUXXmDAgAG5fp3IyEjWr1+faX9qaiqFCunXQUTywJwYOLoHRq2B2ndaHY3kkD4x8qEzSSlXTZ4AktMyOJOU4vYEyiqBgYEEBgbmybWefPJJXn31Vad9OU2eUlJS8PX1dUdYV5WamoqPj0+uX0dEclHCSQgOgei3IC0FSpazOiK5DurCk6uKjIxkwIABDBw4kOLFi1OmTBk++OADkpKSePzxxylatCg33XQTK1ascJwTFxeHzWbjiy++oG7duvj7+9O4cWN+/PHHK14nqy682bNnU7NmTfz9/alRowbvvfee0/Fvv/2W+vXr4+/vT8OGDdmxY0e2nlPhwoUpW7as0+OyxYsXU7t2bfz8/AgPD2fy5MlO54aHhzNmzBiio6MJDg7mySefpEuXLk6tZwMHDsRms7Fr1y4A0tLSKFq0KKtWrQJg5cqV3HHHHRQrVoySJUtyzz338MsvvzjOv9wVuXDhQiIjI/H39+ejjz4iPT2dmJgYx3kvvvgiWgtcxAOkJsP0pyCmLiQlQHBpJU8FgBIouaa5c+dSqlQpvv32WwYMGMAzzzzDgw8+SLNmzfjuu+9o27Ytjz32GBcuXHA6b/Dgwbzxxhts3bqVkJAQOnXqRGpqarauOWPGDIYPH87YsWPZs2cP48aN4+WXX2bu3LkAJCUlcc8991C9enW2b9/O6NGjeeGFF67reW7fvp2uXbvy0EMP8eOPPzJ69Ghefvll5syZ41Ru0qRJ1KlTh+3bt/Pyyy8TGRlJXFyc4/j69espVaqUo6tw69atXLp0iebNmztij4mJYevWraxZswYvLy/uu+8+MjKcWx2HDBnCs88+y549e2jbti2TJ09m1qxZzJw5k2+++YY///yTpUuXXtdzFpFcdvo3ePlOWD8PHhkLRYKtjkjcxUiOJCQkGMAkJCRkOnbx4kWze/duc/HixRzV/eNvZ02lIf+55uPH385e79PIpGfPnubee+91bEdERJg77rjDsZ2WlmaKFCliHnvsMce+48ePG8Bs3rzZGGPMunXrDGA+/vhjR5nTp0+bgIAAs2DBAmOMMbNnzzbBwcGO46NGjTJ169Z1bFeoUMHMnz/fKbbXXnvNNG3a1BhjzL/+9S9TokQJk5SU5Dg+ffp0A5gdO3Zc8flFREQYHx8fU6RIEccjJibGGGPMI488YqKiopzKDx482NSqVcuxXalSJdO5c2enMj/88IOx2Wzmjz/+MH/++afx8fExY8aMMQ8++KAxxphx48aZxo0bXzGmkydPGsD8+OOPxhhj4uPjDWCmTJniVC40NNRMmDDBsZ2ammrKly/v9PP6u+t9H4rIddr9tTGPhxjzVAVj9n9rdTTyl6t9frtCY6Dkmm699VbH997e3pQsWZJbbrnFsa9MGfs6TSdPnnQ6r2nTpo7vS5QoQfXq1dmzZ881r/fHH39w5MgRevfuzZNPPunYn5aWRnCw/b+3PXv2ULduXQoXLpzl9a6me/fuDB8+3LF9+W7APXv2cO+99zqVbd68OVOmTCE9PR3vv1ZBb9iwoVOZOnXqULJkSdavX4+Pjw9169alU6dOvP3224C9SzMiIsJR/pdffuHll19my5YtnDp1ytHydPjwYerUqeMo9/frJCQkcPz4cafnWKhQIRo2bKhuPJH8yrsQVGkAA+bZu+2kQFECJdf0z8HLNpvNaZ/tr9tv/9kFlRVbNm7VvVzPjBkzaNy4sdOxy0nM9SQNwcHBVK1aNdN+Y0ym+LK6TpEiRZy2bTYbd955J3Fxcfj6+hIZGUmdOnVIT0/nxx9/ZNOmTQwcONBRvmPHjlSoUIEZM2YQFhZGRkYGderUISUl5arXEREPkHwBlr0FnV+Eak1gxIprnyMeSWOgJNds2bLF8f2ZM2fYt28fNWrUuOZ5ZcqUoVy5chw8eJCqVas6PSpXrgxArVq1+P7777l48X/zYf39ejlRq1YtvvnmG6d9mzZtolq1ao7E7Uouj4OKi4sjMjISm81GixYteOONN7h48aJj/NPp06fZs2cPI0aMoHXr1tSsWZMzZ85cM7bg4GBCQ0OdnmNaWhrbt2/PwTMVkVxx4iAMawpLxsGvP1gdjeQytUDlQ8WL+OJXyOua80AVL5L7t89fj1dffZWSJUtSpkwZhg8fTqlSpbI96ePo0aN59tlnCQoKol27diQnJ7Nt2zbOnDlDTEwMjzzyCMOHD6d3796MGDGCQ4cO8cYbb1xXvIMGDaJRo0a89tprdOvWjc2bNzNt2rRMd/9lJTIykueee45ChQrRokULx75BgwbRoEEDgoKCAChevDglS5bkgw8+IDQ0lMOHDzN06NBsxffcc88xYcIEbr75ZmrWrMmbb77J2bNnc/x8RcSNvlthn1W8aEmY8F+oWOfa54hHUwKVD5UrFsDaFyI5k5RyxTLFi/jm+zmgJkyYwHPPPcf+/fupW7cun3/+ebbnTHriiScoXLgwkyZN4sUXX6RIkSLccsstjq6wwMBAli1bRp8+fahfvz61atXi9ddfp0uXLjmOt0GDBixcuJCRI0fy2muvERoayquvvkp0dPQ1z61Tpw6lSpWiUqVKjmQpIiKC9PR0p/FPXl5efPzxxzz77LPUqVOH6tWr8/bbbxMZGXnNawwaNIjjx48THR2Nl5cXvXr14r777iMhISGnT1lE3OHgdzCuAzRoD899BEWKWR2R5AGb0QjUHElMTCQ4OJiEhATHB+Zlly5dIj4+nsqVK+Pv729RhNaJi4ujZcuWnDlzxmm5FslbN/r7UCTXpSaDj599HbtvP4VG94KXRsbkd1f7/HaFftIiIiKuOrLbPjHmNx/b17FrfJ+SpxuMftoiIiKu2LwYhjb+a5qC26yORiyiMVDidpGRkZqbSEQKnvR0iB0BSydAs67QdyYE5M0anpL/KIESERHJjrQU+OEr6DEJOg2yd93JDUsJlIiIyNUc3AGFfKFibRi3CQr5XPscKfA0BkpERORK4j6E4c3gk9fs20qe5C9qgRIREfmn1BSYOwhWTINWj8OT155QV24sSqBERET+afKDsGOFPXFq20fjnSQTJVAiIiKXGWNPltr1h85DoEYzqyOSfEpjoCTXREZGOpZeAQgPD2fKlCmWxSMickXGwMrp8OZDkJEBdaOUPMlVKYESJydPnuTpp5+mYsWK+Pn5UbZsWdq2bcvmzZsBsNlsfPrpp9mqa8mSJbz22mu5GK2IiBukXIJ3e8GMvhAcAubKC7mLXKYuPHHSpUsXUlNTmTt3LlWqVOH3339nzZo1/Pnnn9muIzU1FR8fH0qUKJGLkYqIuMEfh2HS/XBkFwyYC5E9rI5IPIRaoPKKMZCUlPcPF2YEP3v2LN988w2vv/46LVu2pFKlStx+++0MGzaMDh06EB4eDsB9992HzWZzbI8ePZp69eoxa9YsqlSpgp+fH8aYTF14/zR79myCg4NZvXo1ALt376Z9+/YEBgZSpkwZHnvsMU6dOpXTV1xE5Nq+iYXEUzB2o5IncYkSqLxy4QIEBub948KFbIcYGBhIYGAgn376KcnJyZmOb926FbAnPsePH3dsAxw4cICFCxeyePFidu7cec1rvfHGG7zwwgusWrWKqKgojh8/TkREBPXq1WPbtm2sXLmS33//na5du2Y7fhGRbDEG9n9r//7ewfDGDqjSwNqYxOOoC08cChUqxJw5c3jyySd5//33adCgARERETz00EPceuutlC5dGoBixYpRtmxZp3NTUlL48MMPHWWuZtiwYcydO5e4uDhuueUWAKZPn06DBg0YN26co9ysWbOoUKEC+/bto1q1am58piJyw7p4Ht7rDVsWw9s/Q2hVCCxudVTigZRA5ZXCheH8eWuu64IuXbrQoUMHvv76azZv3szKlSuZOHEi//d//0d0dPQVz6tUqVK2kqfJkyeTlJTEtm3bqFKlimP/9u3bWbduHYGBmRfm/OWXX5RAicj1O7YfJt4Hf/wKMQvsyZNIDimByis2GxQpYnUU2eLv709UVBRRUVGMHDmSJ554glGjRl01gSqSzefWokULvvjiCxYuXMjQoUMd+zMyMujYsSOvv/56pnNCQ0Ndfg4iIk5+3gRj20GxsjDhv1ChltURiYdTAiXXVKtWLcfUBT4+PqSnp+e4rttvv50BAwbQtm1bvL29GTx4MAANGjRg8eLFhIeHU6iQ3pYi4mbla8Kdj8EjY6FIsNXRSAGgQeTicPr0aVq1asVHH33EDz/8QHx8PIsWLWLixInce++9gH0yzDVr1nDixAnOnDmTo+s0bdqUFStW8Oqrr/LWW28B0K9fP/78808efvhhvv32Ww4ePMiXX35Jr169rithE5EbWNJZeLsHnPzVPs7pyWlKnsRt9K++OAQGBtK4cWPeeustfvnlF1JTU6lQoQJPPvkkL730EmAfwxQTE8OMGTMoV64chw4dytG1mjdvzhdffEH79u3x9vbm2WefZePGjQwZMoS2bduSnJxMpUqVuPvuu/HyUp4vIi46/BO83hnOnYbWvSGkktURSQFjM8aFiYLEITExkeDgYBISEggKCnI6dunSJeLj46lcuTL+/v4WRSg3Or0P5Ya1cYF9ZvEyN8GQpVD2Jqsjknzkap/frlALlIiIeKZj+2HtLDh5CELCoVUvCCgK0x6H2zvDMzPA3zNu3hHPowRKREQ8z9rZ8N4T9jucjbF//XQi9J0Jk76DctXt+0RyiQaXiIiIZzm23548mQzISHf++l5v8C6k5ElynaUJ1IYNG+jYsSNhYWHYbDbHrfJXsmTJEqKioihdujRBQUE0bdqUVatWOZXZtWsXXbp0ITw8HJvNxpQpUzLVk5aWxogRI6hcuTIBAQFUqVKFV199lYwMrcAtIpLvrZ115QTJZoM1M/M2HrkhWZpAJSUlUbduXaZNm5at8hs2bCAqKorly5ezfft2WrZsSceOHdmxY4ejzIULF6hSpQoTJkzItNzIZa+//jrvv/8+06ZNY8+ePUycOJFJkybxzjvvuOV5Xabx+WIlvf+kwDp56CoLpRv7cZFcZukYqHbt2tGuXbtsl/9na9K4ceP47LPPWLZsGfXr1wegUaNGNGrUCMBppuu/27x5M/feey8dOnQA7HMbxcbGsm3bthw8i8x8fHwAezIXEBDgljpFXHXhr4WkL78fRQqMkPC/xj5lddBmPy6Syzx6EHlGRgbnzp2jRIkSLp13xx138P777zsWqf3+++/55ptvsuzuuyw5OZnk5GTHdmJi4hXLent7U6xYMU6ePAlA4cKFsak/XvKIMYYLFy5w8uRJihUrhre3t9UhibhH8gWY+wIUD71yC5Qx9nmfRHKZRydQlxem7dq1q0vnDRkyhISEBGrUqIG3tzfp6emMHTuWhx9++IrnjB8/nldeeSXb17jcfXg5iRLJa8WKFbtiN7aIxzm4A6Y8Yl8IuPc79rvt3uv911goA/x1N17fmVokWPKExyZQsbGxjB49ms8++4yQkBCXzl2wYAEfffQR8+fPp3bt2uzcuZOBAwcSFhZGz549szxn2LBhxMTEOLYTExOpUKHCFa9hs9kIDQ0lJCSE1NRUl+ITuV4+Pj5qeZKCISMDlr0J81+CCrVh0nb7unYANe+wDxi/PA9U695KniTPeGQCtWDBAnr37s2iRYto06aNy+cPHjyYoUOH8tBDDwFwyy238OuvvzJ+/PgrJlB+fn74+fm5fC1vb299kImI5JQxsG0ZdBgID78GPn/7OxxaFR4db1locmPzuAQqNjaWXr16ERsb6xgE7qoLFy5kWl/N29tb0xiIiOQXmz+B4mFQoxmM+goK6WYIyV8sTaDOnz/PgQMHHNvx8fHs3LmTEiVKULFiRYYNG8bRo0eZN28eYE+eevTowdSpU2nSpAknTpwAICAggOBg+wrbKSkp7N692/H90aNH2blzJ4GBgVStam/a7dixI2PHjqVixYrUrl2bHTt28Oabb9KrV6+8fPoiIvJPF8/BrOfsM413eM6eQCl5knzI0sWE4+LiaNmyZab9PXv2ZM6cOURHR3Po0CHi4uIAiIyMZP369VcsD3Do0CEqV66cqUxERISjnnPnzvHyyy+zdOlSTp48SVhYGA8//DAjR47E19c3W7G7azFCERH5y77/wtTucPaEfaB4y2jNKC5u567Pb0sTKE+mBEpExI3SUqH/zVCsDDz3bw0Gl1zjrs9vjxsDJSIiBcjJQ1DIF0qEwcgvIaSyuuzEI2gxYRERscaGf8OguvDvYfbtsGpKnsRjqAVKRETyVlICzOgLX8+HO7tDr7etjkjEZUqgREQk76SlwtDGcPY4PPeRPYES8UBKoEREJPelpdonxfTxhUfGwE0NteiveDSNgRIRkdx1/ACMuAPmD7dvN31AyZN4PCVQIiKSO4yxT4j5Qj04d9qeOIkUEOrCExER90tLhSmP2JdkadULek2BgKJWRyXiNkqgRETE/Qr5QIly8MIitTxJgaQESkRE3CM1BWJHQKVbIeJRe6uTSAGlMVAiInL9fvsZhjWBL6ZA0lmroxHJdWqBEhGRnDMGvvwXzImB0pVg/H+hSn2roxLJdUqgREQk59LTYM1MaBkNPd8Av8JWRySSJ5RAiYiI63ashOAQqNIAXtsAfgFWRySSpzQGSkREsi/5Isx8Dsa0s7c8gZInuSGpBUpERLLn1x/tczsd3w+9pkK7/lZHJGIZJVAiInJtqSkwrgMULgYTt0HFOlZHJGIpJVAiInJlZ46Dtw8ElYJh/4GwauDrb3VUIpbTGCgREcnat5/B87fAhy/at8NvVfIk8hclUCIi4uxSEvyrD7zeGWo0h0dftzoikXxHXXgiIvI/qSn2GcVP/AJPvw9RT4HNZnVUIvmOEigREYH0dMCAjy90egFubgzla1gdlUi+pS48EZEb3akj8EobWPiqfbtlTyVPItegBEpE5Ea2aREMqmuf26lOS6ujEfEY6sITEbkRpabAB31g7Wxo+qB9vFPRElZHJeIxlECJiNyICvnYv/abbe+y00BxEZcogRIRuVGkp8HicfZZxJvcD/1mWR2RiMfSGCgRkRvB7/HwcgQsegV+P2h1NCIeTy1QIiIFmTGw4d8woy8ULQmvbbBPjiki10UJlIhIQZaWCp++Drd3ht7vQJFgqyMSKRCUQImIFES7v7a3OFWoBWO+UeIk4mYaAyUiUpCkpcK/h8OoSFj+tn2fkicRt1MLlIhIQXFsP0ztDvE74OExcO+LVkckUmApgRIRKQhSU2B0K/ANgHGboGojqyMSKdCUQImIeLJzp8HLG4oUgxc+gQq1ISDQ6qhECjyNgRIR8VQ/rIGYW2HeX1111RoreRLJI0qgREQ8TWoyzB0Mr7SBcjWh6yirIxK54agLT0TEk6SmwPDm8OuP0PMNuOd58NL/wiJ5TQmUiIgnMMb+8PGFlo/bZxOvXM/qqERuWPq3RUQkv0s4CeM7wmeT7Nvt+il5ErGYEigRkfxs+3J4/hbY/y1UrGN1NCLyF3XhiYjkR6kpMHcQrJgG9dtB/9lQrIzVUYnIX5RAiYjkR4V84M9j9gWA2/UDm83qiETkb5RAiYjkFxkZ8MVUKF8T6t8Ngz9R4iSST2kMlIhIfvDnMXitLcyJgV+22fcpeRLJt9QCJSJitf8uhfeeAB8/GPkl1I2yOiIRuQYlUCIiVkpNgQ+HQK074ZkZEFTK6ohEJBuUQImIWOHANggsDmVvgrHfQFBpddmJeBCNgRIRyUvp6bBkPLzUFJZOsO8LDlHyJOJh1AIlIpJX/jgMbz8Ge76G+4ZC19FWRyQiOaQESkQkL6SmwIg77N+/sg5qR1gbj4hcFyVQIiK56UIi2LwgIBAGzIPwuvaxTyLi0TQGSkQkt+zdDIPqwUdD7Nt1IpU8iRQQSqBERNwtPQ0WvgIjWkDxstBxkNURiYibqQtPRMSdUlNgdCvYtxkeHAldhoO3/tSKFDT6rRYRcQdj7F99fOG2e+CxiVCjmbUxiUiuUReeiMj1On8G3noYVkyzb98/VMmTSAGnBEpE5Hr8FAeD6sKOlVCsrNXRiEgeUQIlIpITaanw0TD7eKcyVeDNH6DZg1ZHJSJ5RGOgRERywssbDn4Hj4yDeweDt7fVEYlIHlICJSKSXcbAV/8HYdXsM4mPWAFeasgXuRHpN19EJDsST8HE++H9p+CHNfZ9Sp5EblhqgRIRuZadX8K0aEhLgSGfwu33Wh2RiFjM0n+fNmzYQMeOHQkLC8Nms/Hpp59etfySJUuIioqidOnSBAUF0bRpU1atWuVUZteuXXTp0oXw8HBsNhtTpkzJsq6jR4/y6KOPUrJkSQoXLky9evXYvn27m56ZiBQYqcnwr6ehYh37QHElTyKCxQlUUlISdevWZdq0adkqv2HDBqKioli+fDnbt2+nZcuWdOzYkR07djjKXLhwgSpVqjBhwgTKls36luIzZ87QvHlzfHx8WLFiBbt372by5MkUK1bMHU9LRAqCw7vg1BHw8YPXNsCIlVAizOqoRCSfsBlzefpca9lsNpYuXUrnzp1dOq927dp069aNkSNHZjoWHh7OwIEDGThwoNP+oUOHsnHjRr7++uscx5uYmEhwcDAJCQkEBQXluB4RyWeMgRXvwoeD4c5H4ZkZVkckIm7krs9vjx4BmZGRwblz5yhRooRL533++ec0bNiQBx98kJCQEOrXr8+MGVf/I5mcnExiYqLTQ0QKmLO/w7h7YOYAaP0E9Hrb6ohEJJ/y6ARq8uTJJCUl0bVrV5fOO3jwINOnT+fmm29m1apV9OnTh2effZZ58+Zd8Zzx48cTHBzseFSoUOF6wxeR/CQ1GYY2hl+2wUtfwBPvgF+A1VGJSD7lsXfhxcbGMnr0aD777DNCQkJcOjcjI4OGDRsybtw4AOrXr8+uXbuYPn06PXr0yPKcYcOGERMT49hOTExUEiVSECRfAJsX+PrDk+/CTQ2hWBmroxKRfM4jW6AWLFhA7969WbhwIW3atHH5/NDQUGrVquW0r2bNmhw+fPiK5/j5+REUFOT0EBEPF78TXmwI/x5m376tg5InEckWj0ugYmNjiY6OZv78+XTo0CFHdTRv3py9e/c67du3bx+VKlVyR4gikt9lZMBnb8DQ26GQL7R50uqIRMTDWNqFd/78eQ4cOODYjo+PZ+fOnZQoUYKKFSsybNgwjh496hibFBsbS48ePZg6dSpNmjThxIkTAAQEBBAcHAxASkoKu3fvdnx/9OhRdu7cSWBgIFWrVgXg+eefp1mzZowbN46uXbvy7bff8sEHH/DBBx/k5dMXESukJsPYDvDjGuj0Ajwyxj5VgYiIK4yF1q1bZ4BMj549expjjOnZs6eJiIhwlI+IiLhqeWOMiY+Pz7LM3+sxxphly5aZOnXqGD8/P1OjRg3zwQcfuBR7QkKCAUxCQkIOn72IWOajl4zZudrqKETEAu76/M4380B5Gs0DJeJBLp6H2QOhejNo3cvqaETEQpoHSkQkOw5shRfqw8aPwdvH6mhEpIBQAiUiBVN6OiweBy81g8DiMGkHRD5mdVQiUkBc1yDyU6dOcejQIWw2G+Hh4ZQsWdJdcYmIXCcD3y2HzkOg6ygopNYnEXGfHCVQu3bt4plnnmHjxo1O+yMiIpg+fTrVq1d3S3AiIi77OhbK3gQ33w6vxoG3x84XLCL5mMt/WU6cOEFERASlS5fmzTffpEaNGhhj2L17NzNmzKBFixb89NNPLs8OLiJyXZIS4P/6w4aPoPOL9gRKyZOI5BKX78IbMmQIX331FRs3bsTf39/p2MWLF7njjju46667GD9+vFsDzW90F55I3jh69iJnklKueLx4EV/KnfgOpj4K507Dk+/Bnd3BZsvDKEXEU7jr89vlf89Wr17N0KFDMyVPYJ/QcvDgwUycOLHAJ1AikvuOnr1IqzfiSE7LuGIZv0JerD01hHIlwmD0WihTOQ8jFJEblcsJ1MGDB2nQoMEVjzds2JCDBw9eV1AiIgBnklKumjwBJKdlcKbPvyl3S0112YlInnH5r825c+eu2uRVtGhRzp8/f11BeZSkJPD2tjoKkQLJdiGJgJRL1y5XpCRcSgaScz8oEfFsSUluqSZH/66dO3cuyy48sPct3lCTm4eFWR2BSIFVG9iTnYJv5XIgIiL/4HICZYyhWrVqVz1u0+BNERERKcBcTqDWrVuXG3F4rmPHQHfhieSKXccSeGD65muW++SZptQOC86DiETE4yUmuqX3yOUEKiIi4rovWqAUKWJ/iIh7ZWRgdsznou+1/9CZwvo9FJFsSk93SzUuJ1AZGRlkZGRQqND/Tv399995//33SUpKolOnTtxxxx1uCU5EblCHd8H7T8Khk1BxqtXRiIhk4vJiwr1796Zv376O7XPnztGoUSPeffddVq1aRcuWLVm+fLlbgxSRG8ix/TC4Ppw/Q/HnZ+FX6Op/pvwKeVG8iG8eBSciYudyC9TGjRuZNm2aY3vevHmkpaWxf/9+goODGTJkCJMmTaJ9+/ZuDVRECrjDP0GF2hB2M/SfC43vo5yvP2tvzsZM5MUC8jBQEZEcJFBHjx7l5ptvdmyvWbOGLl26EBxsH8DZs2dPZs+e7b4IRaRgu5AIHw2FVdNh+HJo0A5aPOw4XK5YgBIkEcl3XO7C8/f35+LFi47tLVu20KRJE6fjN9REmiKSc1s/h+dqwfp50Gsq1L3L6ohERLLF5QSqbt26fPjhhwB8/fXX/P7777Rq1cpx/JdffiFMk0uKyLVsWgQT7oXwujBlN3R4VrP6i4jHcLkL7+WXX6Z9+/YsXLiQ48ePEx0dTWhoqOP40qVLad68uVuDFJECwhg4+B3cdBs0uheGfAqNOoEm3xURD+NyAtWyZUu2bdvGV199RdmyZXnwwQedjterV4/bb7/dbQGKSAFxbD/862nY8zVMj4eS5eH2e62OSkQkR2zmhlq4zn0SExMJDg4mISHhqosri9zw0lLh88mw6BUoFgp9/gV1o6yOSkRuUO76/Ha5BWrevHlZ7g8ODqZ69erUqFEjx8GISAE0fzgsmwz3xEC30eCvGcNFxPO53AJVvHjxLPefP3+ejIwM2rdvz/z58ylatKhbAsyv1AIlchWXkuDYXqjSAM6cgD+P2sc9iYhYzF2f3y7fhXfmzJksH8nJyWzZsoXDhw/zyiuv5DggEfFwO1bB83Vg4v2QngbFyyp5EpECx+UE6ooVeXnRqFEjJk+ezLJly9xVrYh4isRT8HYPGHM3lKkCo74Cb5dHCYiIeAS3/3WrWrUqv/32m7urFZH8bnJXOLQT+s2CltGamkBECjS3J1C//PIL5cuXd3e1IpIfnfwV0pIhrBo8MQ0CS9i77ERECji3deEZY/juu+8YNGgQHTt2dFe1IpIfpafDf6bC87XhwyH2fRVqKXkSkRuGyy1QxYsXx5ZF0/z58+dJT0/n7rvvZvTo0e6ITUTyo0M/wPtPwoGtcHc/eGSs1RGJiOQ5lxOoKVOmZLk/KCiIGjVqULNmzeuNSUTyq5RL8GoUFC0JY76BGs2sjkhExBIuJ1ChoaG0bNkSHx+f3IhHRPKj3V9DhdpQtASMWGH/3sfP6qhERCzj8hioPn36ULp0abp168b8+fM5e/ZsLoQlIvlC0ll4/2l4+U748n37vioNlDyJyA3P5QTq4MGDbNiwgVtuuYUpU6ZQtmxZWrduzdtvv82hQ4dyIUQRscR/l8JzteCbWHjyPbhvqNURiYjkG9e9mPCxY8f4/PPP+fzzz1m3bh3VqlXj3nvvpVOnTjRs2NBdceY7WspFCrSje+G5mnDbPfDUe1BSU5OISMHgrs/v606g/i4pKYkVK1bw+eefs3z5cmJiYnjppZfcVX2+ogRKPN6x/bB2Fpw8BCHh9skvD30PTbqAtzfE74TwupoQU0QKlHyZQF129OhRQkNDOX36NKVLl3Z39fmCEijxaGtnw3tP2JMjY+xfM9Ltx15eBfXusjY+EZFcYtliwldz4sQJBgwYQNWqVfHy8iqwyZOIRzu23548mQx70nT5K4DNy76OnYiIXJXLCdTZs2fp3r07pUuXJiwsjLfffpuMjAxGjhxJlSpV2LJlC7NmzcqNWEXEHdbOunK3nM0Ga2bmbTwiIh7I5XmgXnrpJTZs2EDPnj1ZuXIlzz//PCtXruTSpUusWLGCiIiI3IhTRNzl2D57q1OWjH1MlIiIXJXLCdQXX3zB7NmzadOmDX379qVq1apUq1btijOUi0g+YQxs+DfsWGH/Pks2+4ByERG5Kpe78I4dO0atWrUAqFKlCv7+/jzxxBNuD0xE3OjYPnilDbz9GNRpaR/rlBVjoHXvvI1NRMQDuZxAZWRkOC3j4u3tTZEiRdwalIi42ar37V1zI1bC8C+g70x7EuXlDV5/fbV52feHVrU6WhGRfM/laQy8vLxo164dfn72pRyWLVtGq1atMiVRS5YscV+U+ZCmMZB874c18OdRiOwBl5LsCZJfwP+OHz9gHzB+eR6o1r2VPIlIgeeuz2+Xx0D17NnTafvRRx/N8cVFJBec/R3mDrKPd6rfDiIeA/8sWolDq8Kj4/M+PhGRAsDlBGr27Nm5EYeIXK+MDPjq/+CjIfYuuX6z7LOLayZxERG3czmBEpF8ymaDTQvh9s7QYxIElbI6IhGRAsvlBKply5bYsviPNjg4mOrVq9OvXz8qVKjgluBE5BouJcGiV+HWKKjbBoYvBx9fq6MSESnwXE6g6tWrl+X+s2fPsnz5cqZNm8Y333xzxXIi4ibb/gP/1x8Sfoeyfw3+VvIkIpIn3L6YcL9+/YiPj2f58uXurDbf0V14YpnEU/D+0/DfJVD3LnjqPSh7k9VRiYh4BMvuwruWp59+mrZt27q7WhG5zMffPj1BzMfQrKsGiYuIWMDliTSvJSAggEuXLrm7WpEb24GtMKKFfc6mgEAYvxmad1PyJCJiEbcnUF9++SXVqlVzd7UiN6akBJjRH4Y2hkvn7Q9Q4iQiYjGXu/A+//zzLPcnJCSwdetWZs6cyZw5c643LhHZtR7eehguJkLPydB+AHhr5hERkfzA5b/GnTt3znJ/0aJFqVGjBnPmzOHBBx+83rhEblzpafZEqUQ5qNkCer4BpTQ1iIhIfuJyApWRkZEbcYhIagosm2xfguX1b+1LrQxaYHVUIiKSBZfHQLVv356EhATH9tixYzl79qxj+/Tp09SqVcstwYncMHZ/DS/Uh9iX7evXiYhIvuZyArVy5UqSk5Md26+//jp//vmnYzstLY29e/e6JzqRG0HsSHj5TigcBJO2Q89J4FfY6qhEROQqrntEqpvn4RS5MRgDF8/Zk6aad8BT0yHqKfBy+42xIiKSC3RLj0he++1n+OAZKOQLL6+EendZHZGIiLjI5X93bTZbpsWEs1pcWET+Ifmivbtu0K1w+je49wXN5yQi4qFcboEyxhAdHY2fnx8Aly5dok+fPhQpUgTAaXyUiPwlPR2GNYGjP8N9w+D+YeDrb3VUIiKSQy4nUD179nTafvTRRzOV6dGjR84jEvFEx/bD2ln2pVZCwqFVLwi7Gc6cgICi4F8EurwElepC+RpWRysiItfLWGj9+vXmnnvuMaGhoQYwS5cuvWr5xYsXmzZt2phSpUqZokWLmiZNmpiVK1c6lfnpp5/M/fffbypVqmQA89Zbb121znHjxhnAPPfccy7FnpCQYACTkJDg0nlSAK2ZZUwXL2Me8Hb+OrWHMY8GGzN/hNURiojIX9z1+W3pLT9JSUnUrVuXadOmZav8hg0biIqKYvny5Wzfvp2WLVvSsWNHduzY4Shz4cIFqlSpwoQJEyhbtuxV69u6dSsffPABt95663U9D7mBHdsP7z0BJgMy0p2/rp8Hde+CewZaHaWIiLiZpXfhtWvXjnbtsj9p4JQpU5y2x40bx2effcayZcuoX78+AI0aNaJRo0YADB069Ip1nT9/nu7duzNjxgzGjBnjevAiYO+2s9kgq9k8bF5Q9iYoWjLPwxIRkdzl0ZPOZGRkcO7cOUqUKOHyuf369aNDhw60adMmW+WTk5NJTEx0eohw8pB9Tqes2P46LiIiBY5HzwM1efJkkpKS6Nq1q0vnffzxx3z33Xds3bo12+eMHz+eV155xdUQpaAzGfZHlmz2AeUiIlLgeGwLVGxsLKNHj2bBggWEhIRk+7wjR47w3HPP8dFHH+Hvn/3byIcNG0ZCQoLjceTIkZyELQXF4V0wph1sWnjlMsZA6955F5OIiOQZj2yBWrBgAb1792bRokXZ7oK7bPv27Zw8eZLbbrvNsS89PZ0NGzYwbdo0kpOT8fb2znSen5+fY+4rEX74Co7vhxeXQNJZ+0Bymw37YCibPXnqOxNCq1ocqIiI5AaPS6BiY2Pp1asXsbGxdOjQweXzW7duzY8//ui07/HHH6dGjRoMGTIky+RJhOSL8MUUuJAIj46Hu/tC22fAx9d+vGYLWDPzf/NAte6t5ElEpACzNIE6f/48Bw4ccGzHx8ezc+dOSpQoQcWKFRk2bBhHjx5l3rx5gD156tGjB1OnTqVJkyacOHECgICAAIKDgwFISUlh9+7dju+PHj3Kzp07CQwMpGrVqhQtWpQ6deo4xVGkSBFKliyZab8IGRmw8WP4aBicOQYdBtpblwr5OJcLrWpPrERE5IZg6Riobdu2Ub9+fccUBDExMdSvX5+RI0cCcPz4cQ4fPuwo/69//Yu0tDT69etHaGio4/Hcc885yhw7dsxR5/Hjx3njjTeoX78+TzzxRN4+OfF8qckwvDlM6Q433QZTdkPPSVq/TkREsBlzpXuw5WoSExMJDg4mISGBoKAgq8MRdzp5CEpWAG9v+GSMvXuudoTVUYmIiBu46/PbY+/CE3G782dg7gswoBp8/W/7vgdGKHkSEZFMPG4QuYjbpaXCl+/DgtGQlgwPjoSmD1gdlYiI5GNKoEQ2LYRZz0GrXvDwa1A81OqIREQkn1MCJTemgzvgp3XQKQaaPwTh9aBibaujEhERD6ExUHJjOX0Upj0OL95mXwg4+aJ9sLiSJxERcYFaoOTG8ckYWDIe/ArDE+9C1JPgrV8BERFxnT49pGBLTweMPVE69ye06w/3vwRFgq2OTEREPJgSKCm4flwLcwdBy8ehw7Pw+JtWRyQiIgWExkBJwfPbzzC+E4xuDT7+cHNjqyMSEZECRi1QUrAc/A6G3A6lKkDMx9Csq5ZeERERt1MCJZ4vNRm+WwGNO0Pl+vDMDLjjYfD1tzoyEREpoNSFJ57LGNj8CTxbE954AH6Pt7c2tXpcyZOIiOQqJVDimfZ/CyNawBsPQoVa8NaPUKay1VGJiMgNQl14kj8d22+f6PLkIQgJty+zEnbz/45v/gQunoORq6FuG6uiFBGRG5TNGGOsDsITJSYmEhwcTEJCAkFBQVaHU7CsnQ3vPWHvjjPmf1/r3w23tLYvv5J8EQr52mcRFxERySZ3fX6rC0/yl2P77cmTyYCMdOev3y2Hs8ft5fwClDyJiIhllEBJ/rJ21pWnHfDyBi/1OouIiPWUQEn+cvKQvbsuS8Z+XERExGJKoCR/SU22d9dlyWYfUC4iImIxJVCSP5w5AZMegG+XXrmMMdC6d97FJCIicgUaUCLWO7ANXrvLPr4pZgEkJ/3vLjwM8NddeH1nQmhVq6MVERFRAiUWSr5ov5uuQm37PE/3DYWgUvZjNVvAmpn/mweqdW8lTyIikm9oHqgc0jxQ1yEjA1a+B4tegbEbIaya1RGJiMgNwl2f32qBkrx1dC+81xt+3ghtn4FiZa2OSERExGVKoCTvbP4Epj4KJSvAq3FQO8LqiERERHJECZTkvpRL4OsPVW+HjjHwwMv2sU8iIiIeStMYSO5JuQT/fgkG1oYLiVC6InQfp+RJREQ8nlqgJHf8vBHe7Q0n4+HBl8HH3+qIRERE3EYJlLjfkvEwfzjc3BheXAIValkdkYiIiFspgRL3uTzWqVpTiH4T2g0Ab2+roxIREXE7JVBy/c79CXNi4I9DMHot1Im0P0RERAooJVByfTYvhv/rZ2996jn5r+VXRERECjYlUJJz70RD3FxodC889R6UCLM6IhERkTyhBEpcYwykpYKPL9SOhNs6QNMH1PIkIiI3FCVQkn0nD8H7T0FYdXjiHWgVbXVEIiIiltBEmnJtGRmw/B14vg4c/RkatLc6IhEREUupBUquLjUZRre2T4x5dz94dDwEFLU6KhEREUspgZKspaWClzf4+EHdu6D7eKjVwuqoRERE8gV14UlmB3fA0NthzUz7dteRSp5ERET+RgmU/E/KJfhoGAxpZL/brkoDqyMSERHJl9SFJ3anf7OPdTp5CLq9Ap1fhEI+VkclIiKSLymButGlpdoTpWKhcGsb+0BxLf4rIiJyVUqgbhTH9sPaWfYWppBwaNULfj8IH/SB5/4NNZrBk+9aHaWIiIhHUAJ1I1g7G957wj5buDH2r0sn2I/d2gaKh1obn4iIiIdRAlXQHdtvT55MBpi/9l3+arPBk+9BmcpWRSciIuKRdBdeQbd21pXXqbN52Y+LiIiIS5RAFXQnD9m77bJk7MdFRETEJUqgCrrSFa+SQNnsA8pFRETEJUqgCrKMDDi6l/8NevoHY6B17zwNSUREpCBQAlWQzR0E2z6Htn3s4528vMHrr682L+g7E0KrWh2liIiIx9FdeAVZg/ZQ8RZo3Qs6DrKvbXd5HqjWvZU8iYiI5JDNmCsOkJGrSExMJDg4mISEBIKCgqwOx9nOL+3zO3mpgVFEROTv3PX5rU/YgmbldHitLfx3idWRiIiIFFhKoAqS9R/B//WD9s9Cky5WRyMiIlJgKYEqKL79DKZFQ8toePytK0+eKSIiItdNCVRBsW0ZNL4P+szQ2CcREZFcprvwPF3KJfD1hz4fQHoaeHtbHZGIiEiBp6YKT3boe+hXFX7eZG918vG1OiIREZEbghIoT3VsH7x6FxQrAxVqWx2NiIjIDUUJlCf64zC80gaKloSXV0GRYKsjEhERuaEogfI0xsDUR8GrEIxcDUGlrI5IRETkhqNB5J7GZrOvYeflBSXLWR2NiIjIDUktUJ7i4nmY+RxcSISwm6HsTVZHJCIicsOyNIHasGEDHTt2JCwsDJvNxqeffnrV8kuWLCEqKorSpUsTFBRE06ZNWbVqlVOZXbt20aVLF8LDw7HZbEyZMiVTPePHj6dRo0YULVqUkJAQOnfuzN69e934zNws5RK8fi+smw0n462ORkRE5IZnaQKVlJRE3bp1mTZtWrbKb9iwgaioKJYvX8727dtp2bIlHTt2ZMeOHY4yFy5coEqVKkyYMIGyZctmWc/69evp168fW7ZsYfXq1aSlpXHXXXeRlJTkluflVmmp8GY32LsJhv0HwutaHZGIiMgNz2aMMVYHAWCz2Vi6dCmdO3d26bzatWvTrVs3Ro4cmelYeHg4AwcOZODAgVet448//iAkJIT169dz5513ZlkmOTmZ5ORkx3ZiYiIVKlS47tWcr8oYePsx2LQQhnwGDdrlznVERERuEImJiQQHB1/357dHj4HKyMjg3LlzlChR4rrqSUhIALhqPePHjyc4ONjxqFChwnVdM1tsNqhcH577t5InERGRfMSjE6jJkyeTlJRE165dc1yHMYaYmBjuuOMO6tSpc8Vyw4YNIyEhwfE4cuRIjq+ZjaDgwFb7950GQbMHc+9aIiIi4jKPncYgNjaW0aNH89lnnxESEpLjevr3788PP/zAN998c9Vyfn5++Pn55fg6LlkyHuYPh0nfQZX6eXNNERERyTaPTKAWLFhA7969WbRoEW3atMlxPQMGDODzzz9nw4YNlC9f3o0RXofl0+zJU7fRSp5ERETyKY9LoGJjY+nVqxexsbF06NAhR3UYYxgwYABLly4lLi6OypUruznKHIqbBzMHwD3Pw4OZB8WLiIhI/mBpAnX+/HkOHDjg2I6Pj2fnzp2UKFGCihUrMmzYMI4ePcq8efMAe/LUo0cPpk6dSpMmTThx4gQAAQEBBAfb14NLSUlh9+7dju+PHj3Kzp07CQwMpGrVqgD069eP+fPn89lnn1G0aFFHPcHBwQQEBOTZ83eSng4r34PWvSF6sn0AuYiIiORLlk5jEBcXR8uWLTPt79mzJ3PmzCE6OppDhw4RFxcHQGRkJOvXr79ieYBDhw5l2aIUERHhqMd2heRk9uzZREdHZyt2d90GCdiTJ29vuHgOfAvbvxcRERG3c9fnd76ZB8rTuC2B+nkjTH8Khi+HkEruC1BEREQy0TxQBcHBHTC2AwSXhuCc30koIiIieUsJlFV++xleawth1WDo5+Bn0dgrERERcZkSKCukpsC4DvZWpxEroHAuLQUjIiIiucLjpjEoEHx8oc8HUKEWFC1pdTQiIiLiIrVA5aVzf8KSCZCRAbe2huKhVkckIiIiOaAEKq9cPAdj28GyyfDnUaujERERkeugLry8kHwRxneCoz/DK+ugVAWrIxIREZHroAQqt6WlwuQHYf9/YeSXUKWB1RGJiIjIdVIXXl4oWgpeXAo177A6EhEREXEDtUDlFmPgxC8QWhUGzLE6GhEREXEjtUDlBmNg3ovwQn04+7vV0YiIiIibqQUqNyweC5+/Ab3fhmJlrI5GRERE3EwtUO72n6kQ+zI8/Bq0H2B1NCIiIpILlEC5U1ICLB0PnV6ALsOtjkZERERyibrw3MUYKBIMb+yAYmXBZrM6IhEREcklaoG6XgtGw5qZMKYdXDxvX55FyZOIiEiBphao6/WfKVDIQHg98PGzOhoRERHJA2qBul7G2L/++gP88au1sYiIiEieUALlLjabvStPRERECjwlUG5j4OQhq4MQERGRPKAEym1sEBJudRAiIiKSB5RAuYsx0Lq31VGIiIhIHtBdeNfLywtsQN+Z9oWDRUREpMBTAnW9OjwH9/RV8iQiInIDUQJ1vbqNhqAgq6MQERGRPKQxUCIiIiIuUgIlIiIi4iIlUCIiIiIuUgIlIiIi4iIlUCIiIiIuUgIlIiIi4iIlUCIiIiIuUgIlIiIi4iIlUCIiIiIuUgIlIiIi4iIlUCIiIiIuUgIlIiIi4iIlUCIiIiIuUgIlIiIi4iIlUCIiIiIuUgIlIiIi4iIlUCIiIiIuUgIlIiIi4iIlUCIiIiIuUgIlIiIi4iIlUCIiIiIuUgIlIiIi4iIlUCIiIiIuUgIlIiIi4iIlUCIiIiIuUgIlIiIi4iIlUCIiIiIuUgIlIiIi4iIlUCIiIiIuUgIlIiIi4iIlUCIiIiIuUgIlIiIi4iIlUCIiIiIuUgIlIiIi4iIlUCIiIiIuUgIlIiIi4iIlUCIiIiIusjSB2rBhAx07diQsLAybzcann3561fJLliwhKiqK0qVLExQURNOmTVm1apVTmV27dtGlSxfCw8Ox2WxMmTIly7ree+89KleujL+/P7fddhtff/21m56ViIiIFHSWJlBJSUnUrVuXadOmZav8hg0biIqKYvny5Wzfvp2WLVvSsWNHduzY4Shz4cIFqlSpwoQJEyhbtmyW9SxYsICBAwcyfPhwduzYQYsWLWjXrh2HDx92y/MSERGRgs1mjDFWBwFgs9lYunQpnTt3dum82rVr061bN0aOHJnpWHh4OAMHDmTgwIFO+xs3bkyDBg2YPn26Y1/NmjXp3Lkz48ePz9Z1ExMTCQ4OJiEhgaCgIJdiFhEREWu46/O7kBtjynMZGRmcO3eOEiVKZPuclJQUtm/fztChQ53233XXXWzatOmK5yUnJ5OcnOzYTkhIAOw/CBEREfEMlz+3r7f9yKMTqMmTJ5OUlETXrl2zfc6pU6dIT0+nTJkyTvvLlCnDiRMnrnje+PHjeeWVVzLtr1ChQvYDFhERkXzh9OnTBAcH5/h8j02gYmNjGT16NJ999hkhISEun2+z2Zy2jTGZ9v3dsGHDiImJcWyfPXuWSpUqcfjw4ev6AeSlxMREKlSowJEjRzyi21Hx5j5Pi9nT4pXcp/eEuCohIYGKFSu61HuVFY9MoBYsWEDv3r1ZtGgRbdq0cencUqVK4e3tnam16eTJk5lapf7Oz88PPz+/TPuDg4M97pc2KCjIo2JWvLnP02L2tHgl9+k9Ia7y8rq+++g8bh6o2NhYoqOjmT9/Ph06dHD5fF9fX2677TZWr17ttH/16tU0a9bMXWGKiIhIAWZpC9T58+c5cOCAYzs+Pp6dO3dSokQJKlasyLBhwzh69Cjz5s0D7MlTjx49mDp1Kk2aNHG0IgUEBDi60VJSUti9e7fj+6NHj7Jz504CAwOpWrUqADExMTz22GM0bNiQpk2b8sEHH3D48GH69OmTl09fREREPJWx0Lp16wyQ6dGzZ09jjDE9e/Y0ERERjvIRERFXLW+MMfHx8VmW+Xs9xhjz7rvvmkqVKhlfX1/ToEEDs379epdiv3Tpkhk1apS5dOlSDp993vO0mBVv7vO0mD0tXsl9ek+Iq9z1nsk380CJiIiIeAqPGwMlIiIiYjUlUCIiIiIuUgIlIiIi4iIlUCIiIiIuUgIlIiIi4iIlUCIiIiIuUgIlIiIiBdb58+dzpV7NA1VAvfrqq9kqN3LkyFyOpGDS65v79BrLP+k9ITlRuXJl5s6dy5133unWepVAZZOn/eJ6eXkRFhZGSEgIV/oR22w2vvvuuzyOLGt6fXOfXmPxdHpPSE68+OKLTJkyhQEDBjBu3Dj8/PzcUq8SqGzytF/c9u3bs27dOtq2bUuvXr3o0KED3t7eVod1RXp9c59eY/F0ek9ITm3ZsoVevXphs9n48MMPadCgwXXXqQQqmzzxF/f48ePMmTOHOXPmkJiYSI8ePejVqxfVq1e3OrRM9PrmPr3GUhDoPSE5lZyczIgRI5g2bRpRUVEUKlTI6fiSJUtcqk+DyLNp+fLlHDx4kMaNGzN48GDKly/PkCFD2Lt3r9WhXVFoaCjDhg1j7969LFiwgJMnT9KoUSOaN2/OxYsXrQ7PiV7f3KfXWAoCvSckp5KTkzl58iQ2m43g4OBMD5dd11LEN7D169eb6OhoU7RoUdOsWTNz4cIFq0O6qgsXLpi5c+ea22+/3QQEBJiEhASrQ7oqvb65T6+xeDq9JyS7Vq1aZcqXL29uv/12s2fPHrfUqRaoHGrUqBEtW7akZs2a7Nixg9TUVKtDytLmzZt58sknKVu2LO+88w49e/bk2LFjBAUFWR3aVen1zX16jcVT6T0hrnj66afp1KkTTz75JJs2baJGjRruqdgtadgNZNOmTeaJJ54wQUFBpmHDhubdd981Z86csTqsTF5//XVTo0YNU7p0aTNw4EDzww8/WB1Stuj1zX16jcVT6T0hOVG7dm2zfft2t9erQeTZNHHiRGbPns3p06fp3r07vXr14pZbbrE6rCvy8vKiYsWK3HPPPfj6+l6x3JtvvpmHUV2ZXt/cp9dYPJ3eE5ITKSkpV32/HDlyhFGjRjFr1iyX6lUClU2e9osbGRmJzWa7ahmbzcbatWvzKKKr0+ub+/Qai6fTe0Jyw/fff0+DBg1IT0936TwlUNmUnV9cgHXr1uVBNAVPQfnDaIzJ1vvECgXlNRYRccXnn39+1eMHDx5k0KBBSqBErOTr68v3339PzZo1rQ5FpEA6fvw406dP55tvvuH48eN4e3tTuXJlOnfuTHR0dL6f20zynpeXFzab7YoTCIP9n0dXE6hC1y4i2ZHTPtTcdPHiRbZv306JEiWoVauW07FLly6xcOFCevToYVF0me3Zs4ctW7bQrFkzqlevzs8//8zUqVNJTk7m0UcfpVWrVlaH6BATE5Pl/vT0dCZMmEDJkiWB/NMdlpUzZ84wd+5c9u/fT1hYGD179qR8+fJWh+WwY8cOihUrRuXKlQH46KOPmD59OocPH6ZSpUr079+fhx56yOIoJS9t27aNNm3aULlyZQICAti3bx/du3cnJSWFF154gZkzZ7Jq1SqKFi1qdaiSj4SGhvLuu+/SuXPnLI/v3LmT2267zfWK3T4s/Qa1c+dO4+XlZXUYDnv37jWVKlUyNpvNeHl5mYiICHPs2DHH8RMnTuSreFesWGF8fX1NiRIljL+/v1mxYoUpXbq0adOmjWndurUpVKiQWbNmjdVhOthsNlOvXj0TGRnp9LDZbKZRo0YmMjLStGzZ0uownYSGhppTp04ZY4w5ePCgKVu2rClbtqyJiooy5cuXN8HBwW6bH8Ud6tevb9auXWuMMWbGjBkmICDAPPvss2b69Olm4MCBJjAw0MycOdPiKCUvNW/e3IwePdqx/eGHH5rGjRsbY4z5888/Tb169cyzzz5rVXiST3Xs2NG8/PLLVzy+c+dOY7PZXK5XXXjZlFt9qLnlvvvuIy0tjdmzZ3P27FliYmL46aefiIuLo2LFivz++++EhYXlm3ibNWtGq1atGDNmDB9//DF9+/blmWeeYezYsQAMHz6crVu38uWXX1ocqd348eOZMWMG//d//+fUMubj48P333+fqcUvP/Dy8uLEiROEhITw8MMPc+LECb744gsKFy5McnIyDzzwAP7+/ixatMjqUAEoUqQIe/bsoWLFijRo0IA+ffrw1FNPOY7Pnz+fsWPHsmvXLgujlLxUuHBhfvrpJ6pUqQJARkYG/v7+HDlyhDJlyrB69Wqio6M5evSoxZFKfvL111+TlJTE3XffneXxpKQktm3bRkREhGsV5zynu7Fcbsmx2WxXfOSnFp2QkJBMc6T07dvXVKxY0fzyyy/5rgUqKCjI7N+/3xhjTHp6uilUqJDTvB0//vijKVOmjFXhZenbb7811apVM4MGDTIpKSnGGGMKFSpkdu3aZXFkWbPZbOb33383xhhTuXLlTC16W7ZsMeXLl7citCyVLFnSbNu2zRhjfz/v3LnT6fiBAwdMQECAFaGJRSpVqmS++eYbx/axY8eMzWZzzKIfHx9v/P39rQpPbjCaiTybQkNDWbx4MRkZGVk+8ssK9pddvHgx00KJ7777Lp06dSIiIoJ9+/ZZFNm1eXl54e/vT7FixRz7ihYtSkJCgnVBZaFRo0Zs376dP/74g4YNG/Ljjz/m2zvwLrscX3JyMmXKlHE6VqZMGf744w8rwspSu3btmD59OgARERF88sknTscXLlxI1apVrQhNLNK5c2f69OnDypUrWbduHd27dyciIoKAgAAA9u7dS7ly5SyOUm4UGkSeTbfddhvffffdFQehXWuEf16rUaMG27Zty3Q32DvvvIMxhk6dOlkUWdbCw8M5cOCA4wNx8+bNVKxY0XH8yJEjhIaGWhXeFQUGBjJ37lw+/vhjoqKi8k2X6JW0bt2aQoUKkZiYyL59+6hdu7bj2OHDhylVqpSF0Tl7/fXXad68ORERETRs2JDJkycTFxdHzZo12bt3L1u2bGHp0qVWhyl5aMyYMRw/fpyOHTuSnp5O06ZN+eijjxzHbTYb48ePtzBCuZEogcqmwYMHk5SUdMXjVatWzVdzQN13333Exsby2GOPZTo2bdo0MjIyeP/99y2ILGvPPPOMU/JRp04dp+MrVqzIV3fh/dNDDz3EHXfcwfbt26lUqZLV4WRp1KhRTtuFCxd22l62bBktWrTIy5CuKiwsjB07djBhwgSWLVuGMYZvv/2WI0eO0Lx5czZu3EjDhg2tDlPyUGBgIAsWLODSpUukpaURGBjodPyuu+6yKDK5EWkQuYiIiIiLNAZKRERExEVKoERERERcpARKRERExEVKoERERERcpARKRERExEVKoERERERcpARKRERExEX/D1ShWlEkTla0AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -1195,23 +1419,74 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 22,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:22:24.059197300Z",
+     "start_time": "2024-07-01T14:22:23.101323300Z"
+    },
     "pycharm": {
      "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:12.774991Z",
-     "start_time": "2024-03-18T18:02:10.982756Z"
     }
    },
    "outputs": [
     {
      "data": {
-      "text/plain": "                   InstrumentName      ClientInternal  \\\n0  EUR/USD 6M FX Forward 20210720  FWD-EURUSD20210720   \n\n   Market Value (Portfolio Currency)  Forward Rate (Interpolated)  \\\n0                         4,748.9592                       1.2213   \n\n   FX Spot Rate  Holding/default/Units  PnL (1-day)  \n0        1.2164                 1.0000   4,748.9592  ",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>InstrumentName</th>\n      <th>ClientInternal</th>\n      <th>Market Value (Portfolio Currency)</th>\n      <th>Forward Rate (Interpolated)</th>\n      <th>FX Spot Rate</th>\n      <th>Holding/default/Units</th>\n      <th>PnL (1-day)</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>EUR/USD 6M FX Forward 20210720</td>\n      <td>FWD-EURUSD20210720</td>\n      <td>4,748.9592</td>\n      <td>1.2213</td>\n      <td>1.2164</td>\n      <td>1.0000</td>\n      <td>4,748.9592</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>InstrumentName</th>\n",
+       "      <th>ClientInternal</th>\n",
+       "      <th>Market Value (Portfolio Currency)</th>\n",
+       "      <th>Forward Rate (Interpolated)</th>\n",
+       "      <th>FX Spot Rate</th>\n",
+       "      <th>Holding/default/Units</th>\n",
+       "      <th>PnL (1-day)</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>EUR/USD 6M FX Forward 20210720</td>\n",
+       "      <td>FWD-EURUSD20210720</td>\n",
+       "      <td>4,748.9592</td>\n",
+       "      <td>1.2213</td>\n",
+       "      <td>1.2164</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>4,748.9592</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                   InstrumentName      ClientInternal  \\\n",
+       "0  EUR/USD 6M FX Forward 20210720  FWD-EURUSD20210720   \n",
+       "\n",
+       "   Market Value (Portfolio Currency)  Forward Rate (Interpolated)  \\\n",
+       "0                         4,748.9592                       1.2213   \n",
+       "\n",
+       "   FX Spot Rate  Holding/default/Units  PnL (1-day)  \n",
+       "0        1.2164                 1.0000   4,748.9592  "
+      ]
      },
-     "execution_count": 24,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1242,21 +1517,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 23,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:21:58.759021100Z",
+     "start_time": "2024-07-01T14:21:58.363020500Z"
+    },
     "pycharm": {
      "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:12.854334Z",
-     "start_time": "2024-03-18T18:02:12.775741Z"
     }
    },
    "outputs": [
     {
      "data": {
-      "text/plain": "<Figure size 640x480 with 1 Axes>",
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAlAAAAG6CAYAAADH1Xg8AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/SrBM8AAAACXBIWXMAAA9hAAAPYQGoP6dpAABej0lEQVR4nO3dd3gU1dvG8e8mkEIggQCBIF16ryJFEpQqBKL4AxU0oYiFIiL4ikqXogKCSlFpIlKVqggikAACChEUlC4I0mtCAoQkO+8fK6trEsimTcr9ua69ws6cmXl22bA3c86csRiGYSAiIiIiKeZidgEiIiIi2Y0ClIiIiIiTFKBEREREnKQAJSIiIuIkBSgRERERJylAiYiIiDhJAUpERETESQpQIiIiIk5SgBIRERFxkgKUiIiIiJMUoEREsrmRI0disVjMLkMkV1GAEski5s2bh8ViSfaxc+dOAE6cOIHFYmHixIlJ7mfixIlYLBZOnDhhXxYYGOiwL09PT2rVqsWUKVOwWq3J1tS5c2ceffRRAEJDQ8mfP3+ybfPnz09oaKjDshMnTtCjRw/uv/9+PDw8KF68OM2bN2fEiBEO7f5dn4uLC97e3lSuXJlnnnmGDRs23O1tcxAaGprs+7du3boU7yenCwsL4/HHH6d48eK4ubnh5+dHUFAQy5cvN7s0kWwjj9kFiIij0aNHU65cuUTLK1SokKb9lixZkvHjxwNw6dIlFi5cyCuvvMLFixcZO3ZsovZxcXFs2LDBvo2zjh49SsOGDfH09KRnz56ULVuWs2fP8vPPP/POO+8watSoZOuLiYnh6NGjLF++nAULFtClSxcWLFhA3rx573lcd3d3Zs2alWh57dq1U/U6cpoRI0YwevRoKlasyPPPP0+ZMmW4fPkya9eupXPnznzxxRc8/fTTZpcpkuUpQIlkMe3ataNBgwbpvl8fHx+6d+9uf/7CCy9QpUoVPvzwQ0aPHo2rq6tD+61bt3L9+nXat2+fquO9//77REdHs3fvXsqUKeOw7sKFC/esD2DChAkMGDCA6dOnU7ZsWd555517HjdPnjyJ9pNebty4Qb58+TJk33cTHx+P1WrFzc0tTfv58ssvGT16NE888QQLFy50CKRDhgxh/fr1xMXFpbVcwLz3SiSzqAtPJJfy8PCgYcOGXL9+PclA880331CtWjXKli2bqv0fO3aMkiVLJgpPAH5+finah6urKx988AHVqlXjo48+IjIyMlW1/Nf06dOpXr067u7ulChRgr59+3Lt2jWHNoGBgdSoUYOIiAiaN29Ovnz5eOONNxg0aBCFCxfGMAx72/79+2OxWPjggw/sy86fP4/FYmHGjBkA3L59m+HDh1O/fn18fHzw8vLioYceYvPmzQ7H/XcX7ZQpU7j//vtxd3fn999/B2Dbtm00bNgQDw8P7r//fj7++OMUv+5hw4bh6+vLnDlzkjyb16ZNGzp06AD806X8765gsHX/WSwWwsLC7vledejQgfLlyydZS+PGjRP9R2HBggXUr18fT09PfH19efLJJzl16lSKX59IZlKAEsliIiMjuXTpksPj8uXLGXKsO1/WBQsWTLRu7dq19vFPqVGmTBlOnTrFpk2b0lChLUQ99dRT3Lhxg23btqVom/++f/8OXiNHjqRv376UKFGCSZMm0blzZz7++GNat26d6OzL5cuXadeuHXXq1GHKlCm0aNGChx56iCtXrvDbb7/Z223duhUXFxe2bt3qsAygefPmAERFRTFr1iwCAwN55513GDlyJBcvXqRNmzbs3bs30WuYO3cuH374IX369GHSpEn4+vqyb98+WrduzYULFxg5ciQ9evRgxIgRrFix4p7vyZEjRzh48CDBwcEUKFAgRe+jM5J6r7p27crx48fZtWuXQ9s///yTnTt38uSTT9qXjR07lmeffZaKFSsyefJkBg4cyMaNG2nevHmicCuSFagLTySLadmyZaJl7u7u3Lp1K037TUhI4NKlS4Dty2727Nns3r2b9u3b4+np6dD2+PHjHDx40H72JDUGDBjA559/ziOPPEKdOnUICAigRYsWtGrVyumunRo1agC2s1r3EhMTQ9GiRR2WBQQEEBYWxsWLFxk/fjytW7fm22+/xcXF9n/IKlWq0K9fPxYsWECPHj3s2507d46ZM2fy/PPP25ddvHgRsAWkGjVqEBkZyb59++jcuTNbtmyxt9u6dSu+vr5Uq1YNgEKFCnHixAmHbrjnnnvO3o06e/Zsh5r/+usvjh496vBaHnvsMQzDYOvWrZQuXRqwDfSvWbPmPd+XAwcOAKSobWok9V5FRUXh7u7OkiVLaNiwoX350qVLsVgsdOnSBbAFqhEjRvD222/zxhtv2Ns9/vjj1K1bl+nTpzssF8kKdAZKJIuZNm0aGzZscHh8++23ad7vwYMHKVq0KEWLFqVKlSq89957dOzYkXnz5iVq+8033+Dj40OzZs1Sfbzq1auzd+9eunfvzokTJ5g6dSrBwcEUK1aMTz/91Kl93bn67/r16/ds6+Hhkej9mzRpEgDff/89t2/fZuDAgfbwBLYg4+3tzTfffOOwL3d3d4dABdjfvzth6YcffsDV1ZUhQ4Zw/vx5jhw5AtgCVLNmzezTC7i6utrDk9Vq5cqVK8THx9OgQQN+/vnnRK+jc+fODuEpISGB9evXExwcbA9PAFWrVqVNmzb3fF+ioqIAMuTsEyT9Xnl7e9OuXTuWLl3q0OW5ZMkSHnzwQfvrWL58OVarlS5dujicOSxevDgVK1ZM1M0pkhXoDJRIFvPAAw+kyyDy/84LVLZsWT799FOsVivHjh1j7NixXLx4EQ8Pj0TbfvPNN7Ru3Zo8eZz7J+K/x6xUqRKff/45CQkJ/P7773z99de8++679OnTh3LlyiV5ti0p0dHRQMq+/F1dXZPd759//glA5cqVHZa7ublRvnx5+/o77rvvviQHbj/00EOsXbsWsAWlBg0a0KBBA3x9fdm6dSvFihXjl19+SXQ122effcakSZM4ePCgQ3dhUldd/nfZxYsXuXnzJhUrVkzUtnLlyvZ6kuPt7Q2kLISmRnLvVdeuXVm5ciU7duygSZMmHDt2jIiICKZMmWJvc+TIEQzDSPK1ASm6+lIksylAiWQzdwLPzZs3k1x/48YNh3Z3eHl5OQSLpk2bUq9ePd544w2Hwc83btwgLCwsUfedh4cHsbGxGIaRKCgZhsGtW7eSDGNgCzU1a9akZs2aNG7cmBYtWvDFF1+kOEDt378fSPtUDs76b9fmHc2aNePTTz/ljz/+YOvWrTz00ENYLBaaNWvG1q1bKVGiBFarlYceesi+zYIFCwgNDSU4OJghQ4bg5+eHq6sr48ePT7JrMrljp1aVKlUA2LdvX4raJzcxZ0JCQpLLk6s3KCiIfPnysXTpUpo0acLSpUtxcXHhf//7n72N1WrFYrHw7bffJroaFLjr/GMiZlEXnkg2U7RoUfLly8ehQ4eSXH/o0CHy5ctHkSJF7rqfWrVq0b17dz7++GNOnjxpX75p0yZiY2Np166dQ/syZcoQHx+f5Jf90aNHSUhISPKKu/+6c3bt7Nmz92wLti/shQsXki9fvjR1KQL2+v773t2+fZvjx4+nqH7AHow2bNjArl277M+bN2/O1q1b2bp1K15eXtSvX9++zZdffkn58uVZvnw5zzzzDG3atKFly5YpHttWtGhRPD097V2E/5bcZ+HfKlWqROXKlVm1apX9jN7dFCpUCCDRAO7/nqW7Fy8vLzp06MCyZcuwWq0sWbKEhx56iBIlStjb3H///RiGYT8r+d/Hgw8+6NQxRTKDApRINuPq6krr1q1Zs2aNQ/ABOHnyJGvWrKF169ZJ/k/+v1577TXi4uKYPHmyfdnatWtp0KABxYoVc2h7J1B99NFHifYzbdo0hzZg69pKak6hO11N/+1GS0pCQgIDBgzgwIEDDBgwwN4NlVotW7bEzc2NDz74wGFMzuzZs4mMjEzxnFflypXjvvvu4/333ycuLo6mTZsCtmB17NgxvvzySx588EGHLtA7fx//Pu6PP/7Ijh07UnRMV1dX2rRpw8qVKx3+3g8cOMD69etTtI9Ro0Zx+fJlevfuTXx8fKL13333HV9//TVgCzWAw8D4hIQEPvnkkxQd69+6du3KmTNnmDVrFr/88gtdu3Z1WP/444/j6urKqFGjHN4fsL1fGXUVqkhaqAtPJIv59ttvOXjwYKLlTZo0sc+pM27cOB588EHq1atHnz59KFu2LCdOnOCTTz7BYrEwbty4FB2rWrVqPProo8yaNYthw4ZRuHBh1q5dm2gwMECdOnXo3bs3U6dO5ciRI7Rq1QqwnYVZu3YtvXv3dpjt+5133iEiIoLHH3+cWrVqAfDzzz8zf/58fH19GThwoMP+IyMjWbBgAWDrRrwzE/mxY8d48sknGTNmTIpe090ULVqUoUOHMmrUKNq2bUvHjh05dOgQ06dPp2HDhk5NwPnQQw+xePFiatasaT9bU69ePby8vDh8+HCi8U8dOnRg+fLlPPbYY7Rv357jx48zc+ZMqlWrlqIzQmALQOvWreOhhx7ipZdeIj4+ng8//JDq1avz66+/3nP7rl27sm/fPsaOHcuePXt46qmn7DORr1u3jo0bN7Jw4ULAdhHAgw8+yNChQ7ly5Qq+vr4sXrw4yeB1L48++igFChRg8ODBuLq60rlzZ4f1999/P2+//TZDhw7lxIkT9qkWjh8/zooVK+jTpw+DBw92+rgiGcoQkSxh7ty5BpDsY+7cuQ7tDxw4YHTt2tXw8/Mz8uTJY/j5+RlPPvmkceDAgUT7DggIMKpXr57kccPCwgzAGDFihLF//34DMH766ack2yYkJBhTp041ateubXh4eBgeHh5G7dq1jQ8++MBISEhwaPvDDz8Yffv2NWrUqGH4+PgYefPmNUqXLm2EhoYax44dS1Tfv19r/vz5jYoVKxrdu3c3vvvuuxS/hyEhIYaXl9c923300UdGlSpVjLx58xrFihUzXnzxRePq1auJakruPTMMw5g2bZoBGC+++KLD8pYtWxqAsXHjRoflVqvVGDdunFGmTBnD3d3dqFu3rvH1118bISEhRpkyZeztjh8/bgDGe++9l+Rxw8PDjfr16xtubm5G+fLljZkzZxojRowwnPnnfOPGjUanTp3sn52iRYsaQUFBxqpVqxzaHTt2zGjZsqXh7u5uFCtWzHjjjTeMDRs2GICxefNme7t7vVeGYRjdunUzAKNly5bJtvnqq6+MZs2aGV5eXoaXl5dRpUoVo2/fvsahQ4dS/NpEMovFMP5zvlREcq13332XyZMnc/bs2WQHEYuIiMZAici/lC1blvfff1/hSUTkHnQGSkRERMRJOgMlIiIi4iQFKBEREREnKUCJiIiIOEnzQKWS1WrlzJkzFChQQANuRUREsgnDMLh+/TolSpRwuKm4sxSgUunMmTOUKlXK7DJEREQkFU6dOkXJkiVTvb0CVCrduSv8qVOn0nx7CRERyeViIuG1BlC/PTzzDuR1N7uiHCsqKopSpUrZv8dTSwEqle5023l7eytAiYhI6lz+C/K4g38p+Ggf+PiZXVGukdbhNxpELiIiYobftsCQ+jBvkO25wlO2ogAlIiKSmQwDvvkARj0CJatB6CSzK5JUUBeeiIhIZjEMmNYTNs+Djq9C9wngqq/i7Eh/axksISGBuLg4s8uQXCZv3ry4urqaXYaI/JfFAhUegDptoNmTZlcjaaAAlUEMw+DcuXNcu3bN7FIklypYsCDFixfXPGUiWcGedfDHz9D5DWj7otnVSDpQgMogd8KTn58f+fLl05eYZBrDMLhx4wYXLlwAwN/f3+SKRHIxqxVWTIBFb0HddpAQry67HEJ/ixkgISHBHp4KFy5sdjmSC3l6egJw4cIF/Pz81J0nYoYbUfBhCPy0Ev43HLqMgDTMfC1ZiwJUBrgz5ilfvnwmVyK52Z3PX1xcnAKUiBmWjYH9m+D11dAwyOxqJJ0pQGUgdduJmfT5EzFJ5AXbnE5dR0KrPlCiotkVSQbQuUQREZH0kJAAX7wB/SrCpVPg4aXwlIMpQEmONXLkSOrUqWN2GSKSG1y/DGPbwcp3oPNbUDj1N6mV7EEBKis7cwQWDIXJT9l+njmS4YcMDQ3FYrEkehw9ejTDjy0iki2d+NV2I+A/foa31kPwENt8T5KjaQxUVrVpLkzvbfslNAzbz5Xvwkuz4eHQDD1027ZtmTt3rsOyokWLOr2f27dv4+bmll5lJSsuLo68efNm+HFERJLk5gnFysNLc8CvjNnVSCbRGais6MwRW3gyrGBNcPw5vReczdizQe7u7hQvXtzh4erqSnh4OA888ADu7u74+/vz+uuvEx8fb98uMDCQfv36MXDgQIoUKUKbNm0YPHgwHTp0sLeZMmUKFouFdevW2ZdVqFCBWbNmAbBr1y5atWpFkSJF8PHxISAggJ9//tmhPovFwowZM+jYsSNeXl6MHTsWgAkTJlCsWDEKFChAr169uHXrlsN2YWFhPPDAA3h5eVGwYEGaNm3Kn3/+me7vn4jkAvFx8NU4uBltG+c0cqPCUy6jAJXZrp61neb99+P8cdu627dsz5ePS/70r8UCX439Z9vrV2zLIy8m3u/Vs+lW9unTp3n00Udp2LAhv/zyCzNmzGD27Nm8/fbbDu0+++wz3Nzc+OGHH5g5cyYBAQFs27aNhIQEAMLDwylSpAhhYWH2/R47dozAwEAArl+/TkhICNu2bWPnzp1UrFiRRx99lOvXrzscZ+TIkTz22GPs27ePnj17snTpUkaOHMm4cePYvXs3/v7+TJ8+3d4+Pj6e4OBgAgIC+PXXX9mxYwd9+vTRlWoi4ryr52DkI7BkBBz8wexqxCyGpEpkZKQBGJGRkYnW3bx50/j999+NmzdvJt5w8QjDeBzHx5RutnVnjiRed69H2Oe2bdd+lHjd4hFOv66QkBDD1dXV8PLysj+eeOIJ44033jAqV65sWK1We9tp06YZ+fPnNxISEgzDMIyAgACjbt26Dvu7evWq4eLiYuzatcuwWq2Gr6+vMX78eKNRo0aGYRjGggULjPvuuy/ZehISEowCBQoYa9assS8DjIEDBzq0a9y4sfHSSy85LGvUqJFRu3ZtwzAM4/LlywZghIWFOf2eZFd3/RyKSOoc3G4YvUsYRs/ihnFgm9nVSCrc7fvbGRoDldlaPw8NOzou8ypk+1m4JLwXAWs/hPDPbd12/+XiCgHPwKP9bc+LlrX9bNIFKjd2bFsodbfwaNGiBTNmzPinPC8v+vbtS+PGjR3O2DRt2pTo6Gj++usvSpcuDUD9+vUd9lWwYEFq165NWFgYbm5uuLm50adPH0aMGEF0dDTh4eEEBATY258/f5633nqLsLAwLly4QEJCAjdu3ODkyZMO+23QoIHD8wMHDvDCCy84LGvcuDGbN28GwNfXl9DQUNq0aUOrVq1o2bIlXbp00W1ORCTlLp6E4YFQoSEMXpbqf2MlZ1CAymyF/JP/pXPzgPL14PE3IGx+0m0MAzq/Cf4VHJf7FLU90oGXlxcVKlS4d8Nktv2vwMBAwsLCcHd3JyAgAF9fX6pWrcq2bdsIDw/n1VdftbcNCQnh8uXLTJ06lTJlyuDu7k7jxo25ffv2PY9zL3PnzmXAgAGsW7eOJUuW8NZbb7FhwwYefPBB51+oiOQecbGQxw2KloYhX0Ht1pA34y+QkaxNY6CyohIVbVfbWVxsZ5xc/v5pcbEt/294ygRVq1Zlx44dGIZhX/bDDz9QoEABSpa8+3wnd8ZBbdy40T7WKTAwkEWLFnH48GH7sjv7HDBgAI8++ijVq1fH3d2dS5cupai+H3/80WHZzp07E7WrW7cuQ4cOZfv27dSoUYOFCxfec98ikotdPAlvNoOvp9ieN+ig8CSAAlTW9XAofHgIOg2Bxl1sPz88lOFTGCTnpZde4tSpU/Tv35+DBw+yatUqRowYwaBBg3C5x80xmzdvzvXr1/n6668dAtQXX3yBv78/lSpVsretWLEin3/+OQcOHODHH3+kW7du9hvj3s3LL7/MnDlzmDt3LocPH2bEiBH89ttv9vXHjx9n6NCh7Nixgz///JPvvvuOI0eOULVq1dS9ISKS8+3bBK/Vh6iLUD3g3u0lV1EXXlbmXwG6jze7CgDuu+8+1q5dy5AhQ6hduza+vr706tWLt956657bFipUiJo1a3L+/HmqVKkC2EKV1Wp1GP8EMHv2bPr06UO9evUoVaoU48aNY/Dgwfc8RteuXTl27BivvfYat27donPnzrz44ousX78esN1Y9+DBg3z22WdcvnwZf39/+vbty/PPP5+Kd0NEcjTDgNWTYMH/QY2H4ZVF4F3E7Koki7EY/+6TkRSLiorCx8eHyMhIvL29HdbdunWL48ePU65cOTw8PEyqUHI7fQ5FUikhAcY+CuXqwtNjwdXV7IokHd3t+9sZOgMlIiICtkmKr1+CSg/Cm9+Aq74iJXkaAyUiIhLxje1+dvOH2LrwFJ7kHhSgREQk97JaYekoGNfBNlB86Ne6EbCkiCK2iIjkXp++BBs+gafG2Obgu8dVxSJ3KECJiEjuYxi2M00tn4MGHaH+o2ZXJNmMoraIiOQuPyyFMW0h7jbcX1/hSVJFAUpERHKHhHj4bAhM7gr5fcEab3ZFko2pC09ERHK+yIvw/pPwWziEToYOAzVYXNLE1DNQW7ZsISgoiBIlSmCxWFi5cuVd2y9fvpxWrVpRtGhRvL29ady4sX2m6TvGjx9Pw4YNKVCgAH5+fgQHB3Po0KEk92cYBu3atUvRsUVEJBvbux7+3AcjvoegVxSeJM1MDVAxMTHUrl2badOmpaj9li1baNWqFWvXriUiIoIWLVoQFBTEnj177G3Cw8Pp27cvO3fuZMOGDcTFxdG6dWtiYmIS7W/KlClYsuAv0elrN9l/OjLZx+lrN80uMU3mzZtHwYIF7c9HjhxJnTp10rTPEydOYLFY2Lt3b5r2k52EhoYSHBxsdhkiWdvhv28yHtAdPjgINQJNLUdyDlO78Nq1a0e7du1S3H7KlCkOz8eNG8eqVatYs2YNdevWBWDdunUObebNm4efnx8RERE0b97cvnzv3r1MmjSJ3bt34+/vn/oXkc5OX7vJwxPDiI23JtvGPY8LmwYHcl/Be99k1xmhoaFcu3Yt08/GDR48mP79+2f4cQIDAwkPD0+0PC4ujjx51JstkqPE3Ya5A2H9DBj7A1RpAgV8za5KcpBs/a1htVq5fv06vr7J/1JERkYCOLS5ceMGTz/9NNOmTaN48eIpOlZsbCyxsbH251FRUams+u6uxty+a3gCiI23cjXmdroHKLPkz5+f/PnzZ8qxnnvuOUaPHu2wLLXh6fbt27i5uaVHWXcVFxdH3rx5M/w4IjnGlTMw8Qk4thue/9gWnkTSWba+Cm/ixIlER0fTpUuXJNdbrVYGDhxI06ZNqVGjhn35K6+8QpMmTejUqVOKjzV+/Hh8fHzsj1KlSqW5/qwuMDCQ/v37M3DgQAoVKkSxYsX49NNPiYmJoUePHhQoUIAKFSrw7bff2rcJCwvDYrHwzTffUKtWLTw8PHjwwQfZv39/ssdJqgtv1qxZVK1aFQ8PD6pUqcL06dMd1v/000/UrVsXDw8PGjRo4NCNezf58uWjePHiDo87vvrqK6pXr467uztly5Zl0qRJDtuWLVuWMWPG8Oyzz+Lt7U2fPn144okn6Nevn73NwIEDsVgsHDx4ELCFLC8vL77//nvAdoa0WbNmFCxYkMKFC9OhQweOHTtm3/5OV+SSJUsICAjAw8ODL774goSEBAYNGmTf7rXXXkP3AZdc78wRWDAUJj9l+3nmCPx1AIbUg4snYcwWaN3H7Colh8q2AWrhwoWMGjWKpUuX4ufnl2Sbvn37sn//fhYvXmxftnr1ajZt2pSoO/Behg4dSmRkpP1x6tSptJSfbXz22WcUKVKEn376if79+/Piiy/yv//9jyZNmvDzzz/TunVrnnnmGW7cuOGw3ZAhQ5g0aRK7du2iaNGiBAUFERcXl6JjfvHFFwwfPpyxY8dy4MABxo0bx7Bhw/jss88AiI6OpkOHDlSrVo2IiAhGjhzJ4MGD0/Q6IyIi6NKlC08++ST79u1j5MiRDBs2jHnz5jm0mzhxIrVr12bPnj0MGzaMgIAAwsLC7OvDw8MpUqSIfdmuXbuIi4ujSRPb/4BjYmIYNGgQu3fvZuPGjbi4uPDYY49htTqedXz99dd5+eWXOXDgAG3atGHSpEnMmzePOXPmsG3bNq5cucKKFSvS9JpFsrVNc2FAFVj1Hmxfavs5oAoc2AaN/wfvRdhuCiySUYwsAjBWrFiRoraLFi0yPD09ja+//jrZNn379jVKlixp/PHHHw7LX375ZcNisRiurq72B2C4uLgYAQEBKa43MjLSAIzIyMhE627evGn8/vvvxs2bN1O8vzv2/XXNKPN/X9/zse+va07v+15CQkKMTp062Z8HBAQYzZo1sz+Pj483vLy8jGeeeca+7OzZswZg7NixwzAMw9i8ebMBGIsXL7a3uXz5suHp6WksWbLEMAzDmDt3ruHj42NfP2LECKN27dr25/fff7+xcOFCh9rGjBljNG7c2DAMw/j444+NwoULO7y/M2bMMABjz549yb6+gIAAI2/evIaXl5f9MWjQIMMwDOPpp582WrVq5dB+yJAhRrVq1ezPy5QpYwQHBzu0+fXXXw2LxWJcuHDBuHLliuHm5maMGTPG6Nq1q2EYhvH2228bTZo0SbamixcvGoCxb98+wzAM4/jx4wZgTJkyxaGdv7+/8e6779qfx8XFGSVLlnT4+/qvtHwORbK004cNo7OLYTxO4kdnF8M4c8TsCiULu9v3tzOy3RioRYsW0bNnTxYvXkz79u0TrTcMg/79+7NixQrCwsIoV66cw/rXX3+d3r17OyyrWbMm77//PkFBQRlae3ZUq1Yt+59dXV0pXLgwNWvWtC8rVqwYABcuXHDYrnHjxvY/+/r6UrlyZQ4cOHDP48XExHDs2DF69erFc889Z18eHx+Pj48PAAcOHLB3DyZ1vLvp1q0bb775pv35nasBDxw4kKhLt2nTpkyZMoWEhARcXV0BaNCggUObGjVq4OvrS3h4OG5ubtStW5cOHTrYrywNDw8nMDDQ3v7IkSMMHz6cH3/8kUuXLtnPPJ08edKhm/nfx4mMjOTs2bM0atTIvixPnjw0aNBA3XiSO22aY5uGIKmPv8UCG2dD9/GZXpbkLqYGqOjoaI4ePWp/fvz4cfbu3Yuvry+lS5dm6NChnD59mvnz5wO2bruQkBCmTp1Ko0aNOHfuHACenp72L9e+ffuycOFCVq1aRYECBextfHx88PT0TDTu5Y7SpUsnCltCosHLFovFYdmdaSD+2wWVWtHR0QB8+umnDoEBsIeYtPDx8aFChQqp3t7Ly8vhucVioXnz5oSFheHu7k5gYCC1atUiNjaW/fv3s337dofuxaCgIMqUKcOnn35KiRIlsFqt1KhRg9u3b9/1OCLyLxdO2O5llyTDtl4kg5k6Bmr37t3UrVvXPgXBoEGDqFu3LsOHDwfg7NmznDx50t7+k08+IT4+nr59++Lv729/vPzyy/Y2M2bMIDIyksDAQIc2S5YsydwXl8vt3LnT/uerV69y+PBhqlates/tihUrRokSJfjjjz+oUKGCw+NOwK1atSq//vort27dSvJ4qVG1alV++OEHh2U//PADlSpVumdwuzMOKiwsjMDAQFxcXGjevDnvvfcesbGxNG3aFIDLly9z6NAh3nrrLR555BGqVq3K1atX71mbj48P/v7+/Pjjj/Zl8fHxREREpOKViuQAfmXvMhGmxbZeJIOZegYqMDDwrl0Q/x3A++/BuslJTZdGVuoGKeTlhnsel3vOA1XIK+Mvn0+L0aNHU7hwYYoVK8abb75JkSJFUjzp46hRoxgwYAA+Pj60bduW2NhYdu/ezdWrVxk0aBBPP/00b775Js899xxDhw7lxIkTTJw4MU31vvrqqzRs2JAxY8bQtWtXduzYwUcffZTo6r+kBAYG8sorr+Dm5kazZs3sywYPHkzDhg3tZ5MKFSpE4cKF+eSTT/D39+fkyZO8/vrrKarv5ZdfZsKECVSsWJEqVaowefJkrl27lurXK5Jt/RYOjR6Dle8mvd4w4JFemVuT5ErZbgxUTndfQU82DQ7kasztZNsU8nLL8nNATZgwgZdffpkjR45Qp04d1qxZk+I5k3r37k2+fPl47733GDJkCF5eXtSsWZOBAwcCtnmj1qxZwwsvvEDdunWpVq0a77zzDp07d051vfXq1WPp0qUMHz6cMWPG4O/vz+jRowkNDb3ntjVr1qRgwYJUqlTJPp9VYGAgCQkJDuOfXFxcWLx4MQMGDKBGjRpUrlyZDz74wKFNcl599VXOnj1LSEgILi4u9OzZk8cee8w+z5lIjhd3GxYPh1XvQpcR8NJsmN7r7zNRBmCxhaeXZoN/6rvpRVLKYmSl0y/ZSFRUFD4+PkRGRuLt7e2w7tatWxw/fpxy5co5DHTODcLCwmjRogVXr151uF2LZL7c/DmUHOavgzC1G5zcB0+9DUGvgqsrnD1qGzB+4YSt2+6RXgpPck93+/52hs5AiYhI1nX9Crz+ABQqAeN2wP31/1nnX0FX24lpFKBERCTruX4Z8vnY7l/3yiKoHggeujpVso5sOxO5ZE13LgxQ952IpNqe9TCwBqz6++KQ+u0VniTLUYASEZGs4fYtmPsKvN0WytSCFiFmVySSLHXhiYiI+a5fgeGBcOYQ9JgCj/YHF/0fX7IuBSgRETGPYdimIshfCOq0gZcXQNla995OxGSK9yIiYo6r52Dso/DTKluICnlP4UmyDZ2BEhGRzLdrDUzvCS6u4J7P7GpEnKYAJSIimSf2JswbBN/NhAZBtpnDfYqaXZWI09SFJxkmMDDQfvsVgLJlyzJlyhTT6hGRrMCAY7ugzwx4fZXCk2RbClDi4OLFi7z44ouULl0ad3d3ihcvTps2bfjhhx8AsFgsrFy5MkX7Wr58OWPGjMnAakUkW7BaYeV7tluyuOeDCT9Bmxf+vo+dSPakLjxx0LlzZ27fvs1nn31G+fLlOX/+PBs3buTy5csp3sft27dxc3PD19c3AysVkWzh8l/wwbPwW5htMsySVTQ9geQI+hRnFsOAmJjMfzhxr+hr166xdetW3nnnHVq0aEGZMmV44IEHGDp0KB07dqRs2bIAPPbYY1gsFvvzkSNHUqdOHWbNmuVw49r/duH916xZsyhYsCAbN24EYP/+/bRr1478+fNTrFgxnnnmGS5dupSqt1tEsoAdX8KgWnDmMIz4Htq+ZHZFIulGASqz3LgB+fNn/uPGjRSXmD9/fvLnz8/KlSuJjY1NtH7Xrl0AzJ07l7Nnz9qfAxw9epSvvvqK5cuXs3fv3nse69133+X111/nu+++45FHHuHatWs8/PDD1K1bl927d7Nu3TrOnz9Ply5dUly/iGQh1y/D9N5Q42GY/CvUfNjsikTSlbrwxC5PnjzMmzeP5557jpkzZ1KvXj0CAgJ48sknqVWrFkWL2gZ7FixYkOLFiztse/v2bebPn29vczf/93//x+eff054eDjVq1cH4KOPPqJu3bqMGzfO3m7OnDmUKlWKw4cPU6lSpXR8pSKSYY7uAv9KUKAwTNwDfmU11klyJAWozJIvH0RHm3NcJ3Tu3Jn27duzdetWdu7cybfffsu7777LrFmzCA0NTXa7MmXKpCg8TZo0iZiYGHbv3k358uXty3/55Rc2b95M/vz5E21z7NgxBSiRrC4hAVaMhyUj4Ym3oOtIKFbO7KpEMowCVGaxWMAre9xN3MPDg1atWtGqVSuGDRtG7969GTFixF0DlFcKX9tDDz3EN998w9KlS3n99dfty6OjowkKCuKdd95JtI2/v7/Tr0FEMtGFP+GD7nBoOzz+JnR+0+yKRDKcApTcU7Vq1exTF+TNm5eEhIRU7+uBBx6gX79+tG3bljx58jB48GAA6tWrx1dffUXZsmXJk0cfS5Fs4/plGFIX8vnA6HCo2szsikQyhQaRi93ly5d5+OGHWbBgAb/++ivHjx9n2bJlvPvuu3Tq1AmwTYa5ceNGzp07x9WrV1N1nCZNmrB27VpGjRpln1izb9++XLlyhaeeeopdu3Zx7Ngx1q9fT48ePdIU2EQkg9yIss3vVKAw9JkJE/cqPEmuogAldvnz56dRo0a8//77NG/enBo1ajBs2DCee+45PvroI8A2hmnDhg2UKlWKunXrpvpYzZo145tvvuGtt97iww8/pESJEvzwww8kJCTQunVratasycCBAylYsCAumjNGJGs5sM02PcE3U23Pm3YBLx9zaxLJZBbDcGKiILGLiorCx8eHyMhIvL29HdbdunWL48ePO8yJJJLZ9DmUdBcfB8tGw/JxULkJDPjcdpWdSDZyt+9vZ2iwiYiI3Nv1KzC2HRyLgK6j4bHXwdXV7KpETKMAJSIi9+ZVEMrVhZ4fQKVGZlcjYjoNLhERkaRdvwwT/we/bLDdv+75mQpPIn9TgBIRkcR+3WgbKL5vI8QlvrWTSG6nAJWBND5fzKTPn6RKXCzMfw1Gt4L7qtjuY9egg9lViWQ5GgOVAfLmzQvAjRs38PT0NLkaya1u/H0j6TufR5EUib8NEV/DM+9C0CBb152IJKIAlQFcXV0pWLAgFy5cACBfvnxYdDNNySSGYXDjxg0uXLhAwYIFcdWVUnIvhgEbPoFaraB4edukmHndzK5KJEtTgMogxYsXB7CHKJHMVrBgQfvnUCRZkRdgem/YvQZ6TIEOLys8iaSAAlQGsVgs+Pv74+fnR1xcnNnlSC6TN29enXmSe/v5W5jWw3ZLlqFrNNZJxAkKUBnM1dVVX2QikvVcvwyTutjuX9d3LhTS2UoRZyhAiYjkJif3g185202AJ/wIJauCxmiKOE2XV4iI5AZWK3w9BYbUh9UTbctKVVN4EkklnYESEcnprp6FD0Phl++gw0AI/j+zKxLJ9hSgRERysqhLthnFXfLAW+ugbhuzKxLJERSgRERyotib4OYB3kWg23ho2Al8ippdlUiOoTFQIiI5zbEIGFwHvvvY9rxlb4UnkXSmACUiklMkJMCKd2Dog+BZAGq0MLsikRxLXXgiIjlB9FV493H4Pdw2SLzrKM0oLpKBFKBERHICT28o5A8jNkJNnXkSyWjqwhMRya5uRMG0nnBgG7i6wisLFZ5EMokClIhIdnRoBwyuC9uXwbXzZlcjkusoQImIZCcJ8bB0NLz1EPj4waS90Liz2VWJ5DoaAyUikp3ciobNc+GJt2wPV/0zLmIG/eaJiGR1hgHbFkG15lC4JEz5DdzzmV2VSK6mLjwRkaws5hq8/zRM6QbbFtuWKTyJmE5noEREsqrftsAHz8CNSBi4EB56yuyKRORvClAiIllR1CUY2w7ubwD954NfGbMrEpF/UYASEclKzh61jXPyLgKjw6BcPdscTyKSpWgMlIhIVmAY8P1seLU2rJ5oW1ahocKTSBalM1AiIma7fhlmPAc/roCWvaH9QLMrEpF7UIASETFT1CXbWafbt2DIV/Dg42ZXJCIpoAAlImKG+DjbJJjeRaDTEGj8Pyh8n9lViUgKaQyUiEhmO/U7/F9DCP/c9rzDQIUnkWxGAUpEJLMYBnw7DV6rD/G3oUwtsysSkVRSF56ISGaIuWabTfzntdCuHzzzLrh7ml2ViKSSApSISGZw9wKLC7zxNdRvb3Y1IpJG6sITEckosTdh9stwdDfkyQtvrFF4EskhFKBERDLCiV/gtQbw/Sdw9rDZ1YhIOlOAEhFJT1YrrJ4M//eA7azTuxHw0NNmVyUi6UxjoERE0lPMVVj1HjzaH54eC3ndza5IRDKAqWegtmzZQlBQECVKlMBisbBy5cq7tl++fDmtWrWiaNGieHt707hxY9avX+/QZvz48TRs2JACBQrg5+dHcHAwhw4dsq+/cuUK/fv3p3Llynh6elK6dGkGDBhAZGRkRrxEEcktdq2GyAtQoDB8cABCJio8ieRgpgaomJgYateuzbRp01LUfsuWLbRq1Yq1a9cSERFBixYtCAoKYs+ePfY24eHh9O3bl507d7Jhwwbi4uJo3bo1MTExAJw5c4YzZ84wceJE9u/fz7x581i3bh29evXKkNcoIjncrRiY0QcmdIKNc2zLvAqaWpKIZDyLYRiG2UUAWCwWVqxYQXBwsFPbVa9ena5duzJ8+PAk11+8eBE/Pz/Cw8Np3rx5km2WLVtG9+7diYmJIU+elPVqRkVF4ePjQ2RkJN7e3k7VLCI5xNHdMLUbXP4Lekyx3QjYYjG7KhG5i/T6/s7WY6CsVivXr1/H19c32TZ3uubu1cbb2/uu4Sk2NpbY2Fj786ioqFRULCI5RuRFGNYcSlWDiXugRCWzKxKRTJStr8KbOHEi0dHRdOnSJcn1VquVgQMH0rRpU2rUqJFkm0uXLjFmzBj69Olz12ONHz8eHx8f+6NUqVJprl9EsqHLf9luBOxTFN5cC2O3KzyJ5ELZNkAtXLiQUaNGsXTpUvz8/JJs07dvX/bv38/ixYuTXB8VFUX79u2pVq0aI0eOvOvxhg4dSmRkpP1x6tSptL4EEcluflgCA2vA6km25zUCIa+bqSWJiDmyZRfe4sWL6d27N8uWLaNly5ZJtunXrx9ff/01W7ZsoWTJkonWX79+nbZt21KgQAFWrFhB3rx573pMd3d33N11RY1IrnQjCmb1g/DPoWlXaP282RWJiMmyXYBatGgRPXv2ZPHixbRvn/iWCIZh0L9/f1asWEFYWBjlypVL1CYqKoo2bdrg7u7O6tWr8fDwyIzSRSQ7irwIrzeC65eg/3wI6K6B4iJiboCKjo7m6NGj9ufHjx9n7969+Pr6Urp0aYYOHcrp06eZP38+YOu2CwkJYerUqTRq1Ihz584B4OnpiY+PD2Drtlu4cCGrVq2iQIEC9jY+Pj54enoSFRVF69atuXHjBgsWLCAqKso+ILxo0aK4urpm5lsgIlmV1QouLuBdBFqEQvPuULy82VWJSBZh6jQGYWFhtGjRItHykJAQ5s2bR2hoKCdOnCAsLAyAwMBAwsPDk20PtukQkjJ37lxCQ0OTPSbYAlzZsmVTVLumMRDJwc79YZueoOOr0PgJs6sRkXSUXt/fWWYeqOxGAUokBzIM2zinT/uCd1F4ZSFUetDsqkQkHWkeKBGR9HQjCmb2sV1pFxgCvT6AfPrPkYgkTQFKRAQgjxtcOweDFtuutBMRuQsFKBHJveJuw9JR8NBTULoGjNqsK+xEJEUUoEQkdzp9yDZQ/MQv4F/RFqAUnkQkhRSgRCR3MQz4fhbMHQiFS8K4HVChgdlViUg2owAlIrlL1CVY8LptXqfQyeDhZXZFIpINKUCJSO7w60YoX892E+Cpv0PBYmZXJCLZWLa9mbCISIrcvgVzB8GolvDdTNsyhScRSSOdgRKRnOvkbzDlaTh9EHq8D48OMLsiEckhFKBEJGeKvAhDG0HRsvDOLihby+yKRCQHUYASkZwl8iLk97WNdRq0BGo8DO6eZlclIjmMxkCJSM6x+2sYWB2+mWJ7Xr+9wpOIZAgFKBHJ/mJv2G4APD4IKjaCgGfMrkhEcjh14YlI9hZ5EYYHwIXj8Nx0aPOCZhQXkQynACUiWdbpaze5GnPb9uTiSdi1Cq6cBV9/aNiRQmUrcp9PEajXHh7uAaWqmVuwiOQaFsMwDLOLyI6ioqLw8fEhMjISb29vs8sRyXFOX7vJwxPDiI23JtvG3ZLApv9rxX0FNc5JRFImvb6/NQZKRLKkqzG37xqeAGINV67+eSyTKhIR+YcClIhkbz+tNLsCEcmFFKBEJHu7ctbsCkQkF1KAEpHszdff7ApEJBdSgBKRrCchAbYtSlnbB4IztBQRkaQoQIlI1nLmCLzZFFZNTFn7IqUyth4RkSQoQIlI1pLXHQwr9J1tdiUiIslSgBIR8/2+FUa3hpvXoWhpmPAjhao/gHueu/8T5Z7HhUJebplUpIjIPzQTuYiYJyYSFvwffPcxVG4M0VfBswBYLNxX0JNNgwP/mYk8CYW83DSJpoiYQgFKRMyx9zv4KNR21qn3R9DmRXBxPON0X0FPBSQRyZIUoETEHK554f4G8Nw0DQQXkWxHAUpEMofVChtnQ8Q38NpyqNnC9hARyYY0iFxEMt6ZwzDyYZjZBwoUhrhYsysSEUkTnYESkYz19RRY8DoULgkjvodaj5hdkYhImilAiUjGMAywWGxjndq/DF1GgHs+s6sSEUkXClAikr5uRsPiYbYA1XMKtOtrdkUiIulOY6BEJP3sWQev1LDN66Qr60QkB9MZKBFJu4QE25xOWxZArZYwchMUL292VSIiGUYBSkRSzzBsP11doWBx6P8ZBDxjG/skIpKDKUCJSOqcPw4fPw+N/wetnoOQ98yuSEQk02gMlIg4JyEeVk+2jXU6fVBjnUQkV9IZKBFJuWvnYVwH+CMC2vWDp8fabv4rIpLLKECJyL0lJNjGORUoAqVrQO8PodKDZlclImIadeGJyN3t2wwDq8GhHbYQ1W+uwpOI5HqpClBWq5U5c+bQoUMHatSoQc2aNenYsSPz58/HuHNVjohkb9FXYcZztnvY+fhBfl+zKxIRyTKc7sIzDIOOHTuydu1aateuTc2aNTEMgwMHDhAaGsry5ctZuXJlBpQqIpnm6C4Y3xFu34DnZ0LL58BFJ6xFRO5wOkDNmzePLVu2sHHjRlq0aOGwbtOmTQQHBzN//nyeffbZdCtSRDLAmSOwaQ5cOAF+ZeHhnrafefJC8QpQrx08OQYK32dyoSIiWY/FcLLPrXXr1jz88MO8/vrrSa4fN24c4eHhrF+/Pl0KzKqioqLw8fEhMjISb29vs8sRcc6muTC9t23Cyzs3/TWs4FUI3t8HviXMrlBEJEOk1/e30+fkf/31V9q2bZvs+nbt2vHLL7+kuiARyWBnjtjCk2EFa8K/fhq2cU/XzpldoYhIlud0gLpy5QrFihVLdn2xYsW4evVqmooSkQy0aU7yt1pxcYHtyzK3HhGRbMjpAJWQkECePMkPnXJ1dSU+Pj5NRYlIBrpw4p972CVi2NaLiMhdpeoqvNDQUNzd3ZNcHxsbm+aiRCSDRF6EU/tt3XZJstgGkouIyF05HaBCQkLu2UZX4IlkMVarbeD456+BNf6fweP/ZRjwSK/Mr09EJJtxOkDNnTs3I+oQkYz0/lOwfSkEPAMhEyFiLUzv9fdYKAP4O1C9NBv8K5hdrYhIluf0NAbJ+fPPP4mJiaFKlSq45IIJ9zSNgWR5sTdsD+8i8PO3kNcdaj78z/qzR2Hj7H/mgXqkl8KTiOR46fX97XSAmjNnDteuXWPQoEH2ZX369GH27NkAVK5cmfXr11OqVKlUF5UdKEBJlvbzt/BpX6j4AAxabHY1IiJZhmnzQH3yyScUKlTI/nzdunXMnTuX+fPns2vXLgoWLMioUaNSXZCIpMGVMzCxC4x9FIqVt80kLiIi6c7pMVBHjhyhQYMG9uerVq2iU6dOdOvWDbDNRN6jR4/0q1BEUuZmNLxaGywuMPALaPZU8vM9iYhImjgdoG7evOlwymv79u306vXPVTvly5fn3DnNZCySaY7vhZJVwTO/bRB41Ycgf6F7biYiIqnndBdemTJliIiIAODSpUv89ttvNG3a1L7+3Llz+Pj4pF+FIpK0m9dhzkB4rT5s+NS2rGFHhScRkUyQqnmg+vbty2+//camTZuoUqUK9evXt6/fvn07NWrUSNciReRfDAN2Loc5L0PMVej+DrR+3uyqRERyFacD1GuvvcaNGzdYvnw5xYsXZ9kyx/tm/fDDDzz11FPpVqCI/Meh7TDxCWgQBL0+BL8yZlckIpLrpNs8ULmNpjGQTBUfB7tWQeMnbGegDm2Hyk00SFxExEnp9f3t9BmoqKioJJd7eXnh6uqa6kJEJBkHt8PHL8Bfv8GkX6B0DajS9N7biYhIhnF6EHnBggUpVKhQooenpyeVK1fm008/zYg6RXKf6Ksw83l4sym4ecA7u23hSURETOf0GajNmzcnufzatWtEREQwZMgQ8uTJo7mgRNLqu4/hh8XQ+yNo/QLoDK+ISJaR7mOg5syZw0cffcTPP/+cnrvNcjQGSjLEmcNweCcEPgu3b0H0FfAtYXZVIiI5hmm3crmXgIAAjh49mqK2W7ZsISgoiBIlSmCxWFi5cuVd2y9fvpxWrVpRtGhRvL29ady4MevXr3doM378eBo2bEiBAgXw8/MjODiYQ4cOObS5desWffv2pXDhwuTPn5/OnTtz/vx5p16nSLq6fQuWjIRXasLy8RB329Ztp/AkIpIlpXuAioyMTPFEmjExMdSuXZtp06alqP2WLVto1aoVa9euJSIighYtWhAUFMSePXvsbcLDw+nbty87d+5kw4YNxMXF0bp1a2JiYuxtXnnlFdasWcOyZcsIDw/nzJkzPP744869UJH0sm8TDKoFy8dBx8HwXgTkdTO7KhERuYt07cKLi4vj2WefJS4uji+//NK5QiwWVqxYQXBwsFPbVa9ena5duzJ8+PAk11+8eBE/Pz/Cw8Np3rw5kZGRFC1alIULF/LEE08AcPDgQapWrcqOHTt48MEHU3RcdeFJunm3M0RdhOdnQqlqZlcjIpKjmTaNQXJnaiIjI/ntt9+wWCxs3bo11QU5w2q1cv36dXx9fZNtExkZCWBvExERQVxcHC1btrS3qVKlCqVLl75rgIqNjSU2Ntb+PLnpHETuyWqFjbOhYDHbrVf6zwN3L3BJ9xPCIiKSQZwOUN7e3liSmLyvVKlSdO7cmW7dumXavfAmTpxIdHQ0Xbp0SXK91Wpl4MCBNG3a1H57mXPnzuHm5kbBggUd2hYrVuyuN0EeP348o0aNSrfaJZf6c59tTqdD2yH4NVuA8ixgdlUiIuIkpwPU9OnTyZcvX0bU4pSFCxcyatQoVq1ahZ+fX5Jt+vbty/79+9m2bVuajzd06FAGDRpkfx4VFUWpUqXSvF/JJWJvwtKRsGYy+FeE0WFQPcDsqkREJJWcDlBFihTh4YcfpmPHjnTq1IlixYplRF13tXjxYnr37s2yZcscuuL+rV+/fnz99dds2bKFkiVL2pcXL16c27dvc+3aNYezUOfPn6d48eLJHtPd3R13d/d0ew2Sy7i4wq/fQ5eR0GmIBomLiGRzTg+6OHDgAG3atGHp0qWUKVOGRo0aMXbsWPbt25cR9SWyaNEievTowaJFi2jfvn2i9YZh0K9fP1asWMGmTZsoV66cw/r69euTN29eNm7caF926NAhTp48SePGjTO8fsmhzhyBBUNh8lO2n2eOwOW/YFJXOLnfFpgm/ARPvKnwJCKSA6TpKrzIyEjWrl3LqlWrWLduHb6+vnTs2JGOHTsSEBBwz3vjRUdH2+eMqlu3LpMnT6ZFixb4+vpSunRphg4dyunTp5k/fz5g67YLCQlh6tSpDoPZPT097eOuXnrpJRYuXMiqVauoXLmyvY2Pjw+enp4AvPjii6xdu5Z58+bh7e1N//79Adi+fXuKX7uuwhO7TXNhem/bjX0N4++fVnB1g/wFYcACqJ30mVIREclc6fX9nW7TGMTFxREWFsbq1atZvXo1169f58MPP6Rbt27JbhMWFkaLFi0SLQ8JCWHevHmEhoZy4sQJwsLCAAgMDCQ8PDzZ9kCSA9wB5s6dS2hoKGCbSPPVV19l0aJFxMbG0qZNG6ZPn37XLrz/UoASwHamaUAVW2BKxALv7Yby9TK9LBERSVqWC1D/ZhgGe/fuJT4+noYNG6b37rMEBSgBbN11q94Da0LidS6utvFO3cdnfl0iIpKkLHsrl+XLl1O7dm3q1q2bY8OTiN25Y7Z5nZJkwIUTmVmNiIhkklQFqI8//pgnnniCp59+mh9//BGATZs2UbduXZ555hmaNm2arkWKZDlWK2z5AvauA5I7iWsBv7KZWJSIiGQWpwPUhAkT6N+/PydOnGD16tU8/PDDjBs3jm7dutG1a1f++usvZsyYkRG1imQdM/vA1O5Q6UGwJPNrZBjwSK/MrUtERDKF0/NAzZ07l08//ZSQkBC2bt1KQEAA27dv5+jRo3h5eWVEjSJZw7ljEBdru19d6+ch4BnbZJib5sH0Xrar7zCAv6/Ge2k2+FcwuWgREckITg8i9/T05PDhw/ZZuN3d3dm+fTv169fPkAKzKg0iz0Wir8KXb8O3H0KDjjAkiRtlnz1qu7/dhRO2brtHeik8iYhkQabdTDg2NhYPDw/7czc3t7vezFck24qPg/UzYOkoiI+F/w2HoEFJt/WvoKvtRERyEacDFMCwYcPs98O7ffs2b7/9dqIbCE+ePDnt1YmY6eZ1+HIMPNgZnhwNhVI+T5iIiORsTgeo5s2bc+jQIfvzJk2a8Mcffzi0SW4yS5Es74+fYclI6DsHvIvAR0fBy+eem4mISO7idIC6Myu4SI5y+TQsfBPC58N9VeDKGVuAUngSEZEkpKoLTyRHCZsPH78AHvmh9zRo9Ry46ldDRESS5/S3xL9v4vtvPj4+VKpUid69e1O0aNE0FyaSoRISIPI8+JaAktXg0QHw+FCdcRIRkRRxeiJNHx+fJB/Xrl3j008/pXLlyuzfvz8jahVJH79uhNfqw7j2tvmaKjSAZyYoPImISIql682ErVYrzz33HBcuXGDNmjXptdssSfNAZUN/HYT5QyDia6jcGEIn22YSFxGRXMO0eaDuxsXFhQEDBtCuXbv03K1I2iXEw+hWtrFNg5ZAk//9PXO4iIiI89J9pKyXlxc3btxI792KOC8uFr79CJo+CYXvgze+hhKVwc3j3tuKiIjcRboHqA0bNlCpUqX03q1IyhkG7PgSPv8/uHQSfIpBQHcoW9vsykREJIdwOkCtXr06yeWRkZFEREQwa9YsZs2alebCRFLlz322KQkObYf6HeDNb6BkVbOrEhGRHMbpABUcHJzk8gIFClC5cmVmzZrFk08+mda6RJyTEG8b32RxgbhbMOJ7qPWI2VWJiEgO5XSAslqtGVGHSOrERMLy8bB3HbyzC0pXh3d3a4C4iIhkKKfngXr00UeJjIy0P58wYQLXrl2zP798+TLVqlVLl+JEkpUQD+tnQr+KsPYDaNgJrAm2dQpPIiKSwZyeB8rFxYVz587h5+cHgLe3N3v37qV8+fIAnD9/nhIlSpCQkJD+1WYhmgfKZGPbw55vIeBZePptKFzS7IpERCQbyDLzQKXjPJwi/zhzBDbNgQsnwK8sPNzTNrbJ0xv8ykDHV+GpMVC+ntmViohILqQ7pkrWs2kuTO9t64ozDNvPFe+ABWjXD3p9ADUfNrtKERHJxZwOUBaLBct/xpj897lIqp05YgtPhhXunNy0n+S0QOsXTCpMRETkH04HKMMwCA0Nxd3dHYBbt27xwgsv4OXlBUBsbGz6Vii5y6Y5f595SmKdxQXCP4fu4zO9LBERkX9zOkCFhIQ4PO/evXuiNs8++2zqK5Lc7cxhSHaqDMM2JkpERMRkTgeouXPnZkQdIrDjK9t8TkmefgKw2AaUi4iImMzpeaBE0t3Vc/DeEzDxCajU2NZVlxTDgEd6ZW5tIiIiSVCAEvP9EQG/b4FBS2DEBnhpti1EubiCy98/LS625f4VzK5WRETE+Yk0xUYTaabRhRMQ9hn8b7ht0PjNaPDM/8/6s0dh4+x/5oF6pJfCk4iIpFmWmUhTxClWK6ybBl8MBa9C0PI58C3hGJ7AFpZ0tZ2IiGRRClCSef46CDN6w8EfoM2L0H0C5NPZOxERyX4UoCTz/LQSIi/A6HCo3tzsakRERFJNg8glY/2xB9bNsP2546sw6ReFJxERyfYUoCRj3L4FX7wB/9cQNs6C+DjIkxfcPc2uTEREJM3UhSfp7+APMK0XXDgOXUdCp9ds4UlERCSHUICS9PftNMhfCF5bDqWqmV2NiIhIulOAkvSxZz3E3YIHOsELn4CbJ7i6ml2ViIhIhtAYKEmb61fgw1B4uy1sW2Rb5plf4UlERHI0nYGS1NvxFczqaxsw/tJseLiH2RWJiIhkCgUoSZ2EePhyDFR8EPpMt80mLiIikksoQEnKGQaEzYeytaFcHRgdBvl8bPeyExERyUU0BkpS5sIJGNMWPgqF3Wtsy7wKKjyJiEiupDNQcnf/vvlvfl94cy3Ua2d2VSIiIqZSgJK7i74Cy0ZDYAh0G6+b/4qIiKAAJUmJj4NvpkKLUPAuAh8cggK+ZlclIiKSZShAiaM/9sD0XvDnr1CkNDTtovAkIiLyHxpELjb/vvmvYYUJP9rCk4iIiCSiM1Bi89fv8PUU281/g/9PN/8VERG5CwWo3OxmtO0Ku46vQvl68PFJ25gnERERuSsFqNzgzBHYNMc2l5NfWXi4J5z/A2b2geuXoFZLuL++wpOIiEgKKUDldJvmwvTetgkvDcP2c8UE27paLeGFMChWztQSRUREshsFqJzszBFbeDKsYPy97M5PiwWem67wJCIikgq6Ci8n2zQn+VutWFxs60VERMRpClA52YUTtm67JBm29SIiIuI0BaiczK/sXVZa7rFeREREkqMAlZMVLmkb/5QUw4BHemVuPSIiIjmEAlROZRiwaxVUaGgb7+TiCi5//7S4wEuzwb+C2VWKiIhkS7oKLydKSABXV/i/leCSBy6dhI2z/5kH6pFeCk8iIiJpoACV0/yxB6Y8Da+tgJJVbMv8K0D38ebWJSIikoOoCy8n+esgjGkDHvnBt4TZ1YiIiORYClA5xYU/YXQr8C4Kw9ZBPm+zKxIREcmxFKByAqsVJnSEPG4wYgMUKGx2RSIiIjmaqQFqy5YtBAUFUaJECSwWCytXrrxr++XLl9OqVSuKFi2Kt7c3jRs3Zv369U7vMzo6mn79+lGyZEk8PT2pVq0aM2fOTMdXlslcXKDPdBjxvbruREREMoGpASomJobatWszbdq0FLXfsmULrVq1Yu3atURERNCiRQuCgoLYs2ePU/scNGgQ69atY8GCBRw4cICBAwfSr18/Vq9enebXlKluXocv34aEeKjSVPe1ExERySQWw0j2Xh+ZymKxsGLFCoKDg53arnr16nTt2pXhw4eneJ81atSga9euDBs2zL6sfv36tGvXjrfffjtFx42KisLHx4fIyEi8vU0Yb3T7Fox9FP6IgAk/wX2VM78GERGRbCa9vr+z9Rgoq9XK9evX8fX1dWq7Jk2asHr1ak6fPo1hGGzevJnDhw/TunXrZLeJjY0lKirK4WGa+DiY+D84vBPe+EbhSUREJJNl6wA1ceJEoqOj6dKli1Pbffjhh1SrVo2SJUvi5uZG27ZtmTZtGs2bN092m/Hjx+Pj42N/lCpVKq3lp05CAnzwLPyy3jbXU9Vm5tQhIiKSi2XbALVw4UJGjRrF0qVL8fPzc2rbDz/8kJ07d7J69WoiIiKYNGkSffv25fvvv092m6FDhxIZGWl/nDp1Kq0vIfXyF4KBC6FuG/NqEBERycWy5Uzkixcvpnfv3ixbtoyWLVs6te3Nmzd54403WLFiBe3btwegVq1a7N27l4kTJya7P3d3d9zd3dNce6oZBpw9CiUq2q64ExEREdNkuzNQixYtokePHixatMgegJwRFxdHXFwcLi6OL93V1RWr1ZpeZaa/r8bCKzXg3B9mVyIiIpLrmXoGKjo6mqNHj9qfHz9+nL179+Lr60vp0qUZOnQop0+fZv78+YCt2y4kJISpU6fSqFEjzp07B4Cnpyc+Pj4p2qe3tzcBAQEMGTIET09PypQpQ3h4OPPnz2fy5MmZ+Oqd8M0HsGgYPDUGipc3uxoRERExTLR582YDSPQICQkxDMMwQkJCjICAAHv7gICAu7ZPyT4NwzDOnj1rhIaGGiVKlDA8PDyMypUrG5MmTTKsVmuKa4+MjDQAIzIyMo3vwj1snGsYj2MY8wYbhhP1iYiISGLp9f2dZeaBym4yZR6o27fg5apQuzU8PxMslow5joiISC6RXt/f2XIQea5gGODmAeN3QoEiCk8iIiJZSLYbRJ4rHNgGIx+B6KtQsBi4uppdkYiIiPyLAlRW88fPMO7vqwvzephbi4iIiCRJASor+esAjGkD91WB11eBu6fZFYmIiEgSFKCyipvXYVQrKFgc3vwWPAuYXZGIiIgkQ4PIswrPAtB9AtR6BAo4d3NkERERyVw6A2W265chzDZRKAHdoZC/ufWIiIjIPekMlJluRMGYtnDxT6jfQWeeREREsgkFKLPE3oTxQXD2CIwOU3gSERHJRhSgzBB3GyY+Acd2w/ANUK6O2RWJiIiIEzQGygxxt2yP/1sJVZqYXY2IiIg4SWegMpNhQOQF2+ziI77X7VlERESyKZ2ByiyGAfNehSH1bXM+KTyJiIhkWwpQmWXZaPj6fXh8qCbJFBERyeYUoDLD11NgyUh4eiy062t2NSIiIpJGClAZ7coZ+OINCH7NdvZJREREsj0NIs9oviVg4h4oUUnjnkRERHIInYHKKD9/CzP6QEI83FdZ4UlERCQHUYDKCL9tgfceh8jztqvvREREJEdRgEpvR3fD+A5QuSkMWgJ58ppdkYiIiKQzBaj0dOEEvN0WSlW3zTLu5mF2RSIiIpIBNIg8PRUuBe1fhnb9wDO/2dWIiIhIBtEZqPRw+bRt3JOrK/xvGOQvZHZFIiIikoF0Biqt5r8Gv38PLi4w9Xdw1VsqIiKS0+nbPq2++xjyAt3GKzyJiIjkEurCSy8L34SzR82uQkRERDKBAlR6sVhg42yzqxAREZFMoACVbgzbNAYiIiKS4ylApRsL+JU1uwgRERHJBApQ6cUw4JFeZlchIiIimUCXjaWViwtYgJdmg38Fs6sRERGRTKAAlVbtX4YOLyk8iYiI5CIKUGnVdSR4e5tdhYiIiGQijYESERERcZIClIiIiIiTFKBEREREnKQAJSIiIuIkBSgRERERJylAiYiIiDhJAUpERETESQpQIiIiIk5SgBIRERFxkgKUiIiIiJMUoEREREScpAAlIiIi4iQFKBEREREnKUCJiIiIOEkBSkRERMRJClAiIiIiTlKAEhEREXGSApSIiIiIkxSgRERERJykACUiIiLiJAUoEREREScpQImIiIg4SQFKRERExEkKUCIiIiJOUoASERERcZIClIiIiIiTFKBEREREnKQAJSIiIuIkBSgRERERJ5kaoLZs2UJQUBAlSpTAYrGwcuXKu7Zfvnw5rVq1omjRonh7e9O4cWPWr1+fqn0eOHCAjh074uPjg5eXFw0bNuTkyZPp9MpEREQkJzM1QMXExFC7dm2mTZuWovZbtmyhVatWrF27loiICFq0aEFQUBB79uxxap/Hjh2jWbNmVKlShbCwMH799VeGDRuGh4dHml+TiIiI5HwWwzAMs4sAsFgsrFixguDgYKe2q169Ol27dmX48OEp3ueTTz5J3rx5+fzzz1Ndb1RUFD4+PkRGRuLt7Z3q/YiIiEjmSa/v72w9BspqtXL9+nV8fX2d2uabb76hUqVKtGnTBj8/Pxo1anTP7sPY2FiioqIcHiIiIpI7ZesANXHiRKKjo+nSpUuKt7lw4QLR0dFMmDCBtm3b8t133/HYY4/x+OOPEx4enux248ePx8fHx/4oVapUerwEERERyYaybYBauHAho0aNYunSpfj5+aV4O6vVCkCnTp145ZVXqFOnDq+//jodOnRg5syZyW43dOhQIiMj7Y9Tp06l+TWIiIhI9pTH7AJSY/HixfTu3Ztly5bRsmVLp7YtUqQIefLkoVq1ag7Lq1atyrZt25Ldzt3dHXd391TVKyIiIjlLtjsDtWjRInr06MGiRYto376909u7ubnRsGFDDh065LD88OHDlClTJr3KFBERkRzM1DNQ0dHRHD161P78+PHj7N27F19fX0qXLs3QoUM5ffo08+fPB2zddiEhIUydOpVGjRpx7tw5ADw9PfHx8UnRPgGGDBlC165dad68OS1atGDdunWsWbOGsLCwTHrlIiIikq0ZJtq8ebMBJHqEhIQYhmEYISEhRkBAgL19QEDAXdunZJ93zJ4926hQoYLh4eFh1K5d21i5cqVTtUdGRhqAERkZmcpXLyIiIpktvb6/s8w8UNmN5oESERHJfjQPlIiIiIhJFKBEREREnKQAJSIiIuIkBSgRERERJylAiYiIiDhJAUpERETESQpQIiIiIk5SgBIRERFxkgKUiIiIiJNMvRdejhATA66uZlchIiIiKRETky67UYBKqxIlzK5AREREMpm68EREREScpDNQaXXmDOhmwiIiItlDVFS69B4pQKWVl5ftISIiIllfQkK67EZdeCIiIiJOUoASERERcZIClIiIiIiTFKBEREREnKQAJSIiIuIkBSgRERERJylAiYiIiDhJAUpERETESQpQIiIiIk5SgBIRERFxkgKUiIiIiJMUoEREREScpAAlIiIi4iQFKBEREREnKUCJiIiIOCmP2QVkV4ZhABAVFWVyJSIiIpJSd76373yPp5YCVCpdvnwZgFKlSplciYiIiDjr8uXL+Pj4pHp7BahU8vX1BeDkyZNp+gvILFFRUZQqVYpTp07h7e1tdjkpkt1qzm71QvarObvVKxlPnwlxVmRkJKVLl7Z/j6eWAlQqubjYho/5+Phkq19ab2/vbFUvZL+as1u9kP1qzm71SsbTZ0Kcded7PNXbp1MdIiIiIrmGApSIiIiIkxSgUsnd3Z0RI0bg7u5udikpkt3qhexXc3arF7JfzdmtXsl4+kyIs9LrM2Mx0nodn4iIiEguozNQIiIiIk5SgBIRERFxkgKUiIiIiJMUoEREREScpAAlIiIi4iQFKBEREREn6VYuOdD8+fNT1O7ZZ5/N4EpyLr3HIiLZQ0xMDF5eXum+X80DlQO5uLiQP39+8uTJQ3J/vRaLhStXrmRyZcnLboFE73HGGz16dIraDR8+PIMrkaxCnwlJjfvvv5/PPvuMZs2apet+FaBSKDv94lavXp3z58/TvXt3evbsSa1atcwu6Z6yWyDRe5zxXFxcKFGiBH5+fnet9+eff87kysQs+kxIarz22mtMmTKFl19+mbFjx+Lm5pYu+1WASqHs9ov7448/MmfOHJYsWUKFChXo1asX3bp1y7J3K8+OgUTvccZq3749mzZtok2bNvTs2ZMOHTqk+e7pkr3pMyGptXPnTnr27ImLiwuff/45devWTftODUmRRx991PDw8DA6depkrFq1ykhISDC7pBS5ceOG8dlnnxmBgYFGvnz5jKefftq4deuW2WUlaefOnUafPn0MHx8fo379+sb06dONyMhIs8u6J73HGef06dPGuHHjjEqVKhnFixc3XnvtNePgwYNmlyUm0mdCUuvWrVvG4MGDDQ8PDyMoKMh47LHHHB7O0hkoJ5w5c4bPPvuMefPmERUVxbPPPkvPnj2pXLmy2aXd05YtWxgxYgRbtmzh0qVLFCpUyOySknXz5k2WLVvG3Llz+emnnwgODmbOnDlZ/maheo8z1pYtW5g7dy5fffUVNWvW5Pvvv8fT09PsssRE+kyIM6Kioujfvz/Lli2jc+fO5MnjeB3d3Llzndthuke8XCI8PNwIDQ01ChQoYDRp0sS4ceOG2SUl8tdffxljx441KlSoYPj7+xtDhgwxDhw4YHZZKRYeHm4EBgYaLi4uxpUrV8wuJ0l6jzPPnTN9DzzwgOHp6Zmlz5xJ5tBnQlLqu+++M0qWLGk0bNjQ+P3339NlnwpQqZSVf3GXLFlitG3b1vD09DSCg4ONVatWGfHx8WaXlSLZJZDoPc4827dvN3r37m14e3sbDRo0MKZNm2ZcvXrV7LLERPpMiDP69OljuLu7G6NGjUrXf6fVheekHTt2MGfOHJYuXUqlSpXo0aMHTz/9NAULFjS7NDsXFxdKly5Nt27dKFasWLLtBgwYkIlV3d3SpUuZO3cu4eHhtGnThh49etC+fXtcXV3NLi1Jeo8z3rvvvsu8efO4dOkS3bp1o0ePHll+4LtkLH0mJDVq1KjB/PnzqVevXrruVwEqhbLTL27ZsmWxWCx3bWOxWPjjjz8yqaJ7y26BRO9xxrtTb4cOHe562fHkyZMzsSoxkz4Tkhq3b9++6+fl1KlTjBgxgjlz5ji1XwWoFNIvbsbKjoEkKVarNcteVp3d3uPAwMAU1btp06ZMqkjMps+EZIRffvmFevXqkZCQ4NR2ClAplJJfXIDNmzdnQjWSVbm5ufHLL79QtWpVs0sRERFg9erVd13/xx9/8OqrrypAic3NmzeJiIjA19eXatWqOay7desWS5cuzTK37LjjwIED7Ny5kyZNmlC5cmUOHjzI1KlTiY2NpXv37jz88MNml2g3aNCgJJdPnTqV7t27U7hwYSBrn5GMiYlh6dKlHD16lBIlSvDUU0/h6+trdlkid3X27FlmzJjBtm3bOHv2LC4uLpQvX57g4GBCQ0Oz7Jg+MY+LiwsWiyXZSbDBdubS2QCVNfsasqFTp07Rs2dPs8sA4PDhw1StWpXmzZtTs2ZNAgICOHv2rH19ZGQkPXr0MLHCxNatW0edOnUYPHgwderUYd26dTRv3pyjR4/y559/0rp16yx1Wn7KlCls3ryZPXv2ODwMw+DAgQPs2bOHvXv3ml2mg2rVqtlv03Lq1CmqV6/OK6+8woYNGxg+fDhVq1bl+PHjJlf5j59//tmhns8//5ymTZtSqlQpmjVrxuLFi02sTsywe/duqlatytq1a4mLi+PIkSPUr18fLy8vBg8eTPPmzbl+/brZZUoW4+/vz/Lly7FarUk+Un0HkXS7ni+X27t3r+Hi4mJ2GYZhGEZwcLDRvn174+LFi8aRI0eM9u3bG+XKlTP+/PNPwzAM49y5c1mm1jsaN25svPnmm4ZhGMaiRYuMQoUKGW+88YZ9/euvv260atXKrPISGT9+vFGuXDlj48aNDsvz5Mlj/PbbbyZVdXcWi8U4f/68YRiG0a1bN6NJkybGtWvXDMMwjOvXrxstW7Y0nnrqKTNLdFCrVi1jw4YNhmEYxqeffmp4enoaAwYMMGbMmGEMHDjQyJ8/vzF79myTq5TM1LRpU2PkyJH2559//rnRqFEjwzAM48qVK0adOnWMAQMGmFWeZFFBQUHGsGHDkl2/d+9ew2KxOL1fdeGlUEb1oWaEYsWK8f3331OzZk0ADMPgpZdeYu3atWzevBkvLy9KlCiRJWq9w8fHh4iICCpUqIDVasXd3Z2ffvrJfr+i/fv307JlS86dO2dypf/YtWsX3bt3JygoiPHjx5M3b17y5s3LL7/8kqjbNCtwcXHh3Llz+Pn5cf/99zNz5kxatWplX799+3aefPJJTp48aWKV/8iXLx8HDhygTJky1KtXjxdffJHnnnvOvn7hwoWMHTuW3377zcQqJTPly5eP/fv3U758ecB20YaHhwenTp2iWLFibNiwgdDQUE6fPm1ypZKVbN26lZiYGNq2bZvk+piYGHbv3k1AQIBT+81z7yYCEBwcnKI+1Kzg5s2bDlPUWywWZsyYQb9+/QgICGDhwoUmVpe8O++fi4sLHh4e+Pj42NcVKFCAyMhIs0pLUsOGDYmIiKBv3740aNCAL774Ist8BpJzp75bt27h7+/vsO6+++7j4sWLZpSVpHz58nHp0iXKlCnD6dOneeCBBxzWN2rUKEt1OUrG8/Pz4+zZs/YAdf78eeLj4+038K5YsaK9m1rkjoceeuiu6728vJwOT6AxUCmWYX2oGaBKlSrs3r070fKPPvqITp060bFjRxOquruyZcty5MgR+/MdO3ZQunRp+/OTJ08m+sLPCvLnz89nn33G0KFDadmyZZY6q5eURx55hHr16hEVFcWhQ4cc1v3555/2we9ZQbt27ZgxYwYAAQEBfPnllw7rly5dSoUKFcwoTUwSHBzMCy+8wLp169i8eTPdunUjICDAfv+7Q4cOcd9995lcpeQWOgOVQvXr1yciIoJOnToluf5eZ6cy02OPPcaiRYt45plnEq376KOPsFqtzJw504TKkvfiiy86hI8aNWo4rP/222+z1FV4//Xkk0/SrFkzIiIiKFOmjNnlJGnEiBEOz/Pnz+/wfM2aNff8n1pmeuedd2jatCkBAQE0aNCASZMmERYWRtWqVTl06BA7d+5kxYoVZpcpmejtt9/m7NmzBAUFkZCQQOPGjVmwYIF9vcViYfz48SZWKLmJxkClUEb1oYpI8q5du8aECRNYs2YNf/zxB1arFX9/f5o2bcorr7xCgwYNzC5RTHDr1i3i4+MT/SdAJDMpQImIiIg4SWOgRERERJykACUiIiLiJAUoEREREScpQImIiIg4SQFKRERExEkKUCIiIiJOUoASERERcdL/A/qV8dwcNKwmAAAAAElFTkSuQmCC"
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAlAAAAG4CAYAAACKHdk3AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8pXeV/AAAACXBIWXMAAA9hAAAPYQGoP6dpAABeIElEQVR4nO3deZyNdf/H8deZMWbGbGYwjGUMKfsaSWjGMhSRUiTFRG6y5SZFWcuWpVRK5cdQ3SYUokTC0MJtiVa3fcuSbDMMxizf3x/ndrpPM8OcMTPXLO/n43Ee41zX97qu9zlzOB/f63t9L5sxxiAiIiIimeZmdQARERGR/EYFlIiIiIiLVECJiIiIuEgFlIiIiIiLVECJiIiIuEgFlIiIiIiLVECJiIiIuEgFlIiIiIiLVECJiIiIuEgFlEgeMX/+fGw2W4aP2NhYR1ubzcbAgQPT3c8nn3ySpn1UVJTTvooWLcptt93Gc889R3x8fIaZhg4dSt26dQEYN24cNpuNM2fOpNu2Vq1aREREOC07duwY/fv354477sDb25ugoCBq165Nnz59OHbsmKPd9X1ffxQrVozy5cvTtm1b3nrrLS5evHiTd8/uRu/hc889l6l95EeHDx/GZrMxf/78TLU/ePAgAwcOdPxeihUrRs2aNRk1ahTHjx/P2bAiBUQRqwOIiLPo6GiqVauWZnmNGjVuab/e3t6sX78egAsXLvDJJ58wY8YMfvrpJ7766qt0t1m6dCm9evXK0vF+//13GjRoQPHixRk2bBhVq1YlLi6O3377jcWLF3Pw4EEqVKjgtM3q1asJCAjg2rVrnDhxgnXr1vH8888zbdo0Vq5c6Sjmbia997Bs2bJZeh0Fzeeff85jjz1GyZIlGThwIPXr18dms/Hzzz8zb948vvjiC3bu3Gl1TJE8TwWUSB5Tq1YtGjZsmO37dXNz4+6773Y8v++++zh48CBr167l0KFDVKpUyan9tm3bOHLkCJ07d87S8ebMmcOZM2fYunWr0747derEiy++SGpqappt7rzzTkqWLOl4/thjjzFw4EDCw8Pp2LEje/fuxdPT86bHzqn38PLlyxQrVizb95tbxz506BCPPfYYd9xxBxs2bCAgIMCxrmXLlgwePJhly5bdalQAkpKSsNlsFCmirxkpmHQKT6QQu15k/PHHH2nWffrpp1StWpWaNWtmad9nz57Fzc2N4ODgdNe7uWXun5+6devy0ksvcfToURYtWpSlLH+3YsUKmjRpQrFixfDz8yMyMpLNmzc7tbl+WvGHH37gkUceITAwkNtuu40vvvgCm83Gtm3bHG0//fRTbDYb7du3d9pHnTp1nArQt99+m3vvvZfg4GB8fHyoXbs2U6dOJSkpyWm7iIgIatWqxaZNm7jnnnsoVqyYoyfwxIkTdOnSBT8/PwICAujatSunTp3K1Ot+7bXXSEhI4J133nEqnq6z2Ww8/PDDjudhYWFERUWlaRcREeF0ujY2NhabzcaHH37IsGHDKFeuHJ6envz666/YbDbmzp2bZh9ffvklNpuNFStWOJbt27ePxx9/nODgYDw9PalevTpvv/12pl6bSG5TASWSx6SkpJCcnOz0SElJyZFjHTp0iCJFilC5cuU06z799NMs9z4BNGnShNTUVB5++GHWrFlzw7FWN9OxY0cANm3alKn26b2H1y1cuJAHH3wQf39/YmJimDt3LufPnyciIoJvv/02zb4efvhhqlSpwpIlS3j33XcJDw/Hw8ODr7/+2tHm66+/xtvbm40bNzqKodOnT/PLL7/QunVrR7sDBw7w+OOP8+GHH/L555/Tu3dvpk2bRt++fdMc9+TJkzzxxBM8/vjjrFq1iv79+3PlyhVat27NV199xeTJk1myZAllypSha9eumXpfvvrqK0qXLu3UE5mdRo4cydGjR3n33XdZuXIlFSpUoH79+kRHR6dpO3/+fIKDg2nXrh0Av/32G40aNeKXX35hxowZfP7557Rv357Bgwczfvz4HMkrckuMiOQJ0dHRBkj34e7u7tQWMAMGDEh3P0uWLDGA2bBhg2NZz549jY+Pj0lKSjJJSUnmzJkzZvbs2cbNzc28+OKLafaxa9cuA5gdO3Y4lo0dO9YA5s8//0z3uDVr1jTh4eGO56mpqaZv377Gzc3NAMZms5nq1aubf/7zn+bQoUNO295s31euXDGAuf/++9Ndf92N3sOkpCSTkpJiypYta2rXrm1SUlIc2128eNEEBwebe+65J02mMWPGpDlOs2bNTMuWLR3Pq1SpYoYPH27c3NzMxo0bjTHG/Otf/zKA2bt3b7pZU1JSTFJSkvnggw+Mu7u7OXfunGNdeHi4Acy6deuctpk9e7YBzGeffea0vE+fPgYw0dHRN3x/vLy8zN13333DNv+rYsWKpmfPnmmWh4eHO/2uN2zYYABz7733pmn75ptvGsDs2bPHsezcuXPG09PTDBs2zLGsbdu2pnz58iYuLs5p+4EDBxovLy+n90ckL1APlEge88EHH7Bt2zanx7///e9b3m9CQgIeHh54eHhQsmRJnnnmGbp27crEiRPTtP30008JCwujQYMGWT6ezWbj3Xff5eDBg7zzzjs89dRTJCUl8frrr1OzZk02btyY6X0ZY1w6dnrvYZEiRdizZw8nTpzgySefdDqF6OvrS+fOndmyZQuXL1922ld6vXCtWrXiu+++48qVKxw5coT9+/fz2GOPUa9ePdauXQvYe6VCQ0O5/fbbHdvt3LmTjh07UqJECdzd3fHw8KBHjx6kpKSwd+9ep2MEBgbSsmVLp2UbNmzAz8/P0SN33eOPP+7S+5NT0nuvunfvjqenp9MVgjExMSQmJvLUU08BcPXqVdatW8dDDz1EsWLFnHoO27Vrx9WrV9myZUtuvQyRTNHoPpE8pnr16jcdAO3u7p7hab3rp6s8PDyclnt7eztOgZ06dYoZM2YQExNDnTp1GDFihFPbTz75JM2X4fXBwDc67t+PCVCxYkWeeeYZx/PFixfTrVs3hg8fztatW2/0Mh2OHDkCZP5Kuozew7NnzwIQEhKSZl3ZsmVJTU3l/PnzToO102vbunVrxo8fz7fffsuRI0coWbIk9evXp3Xr1nz99de88sorrFu3zun03dGjR2nevDlVq1bljTfeICwsDC8vL7Zu3cqAAQO4cuWK0zHSO+7Zs2cpXbp0muVlypS5wbvxl9DQUA4dOpSptlmRXuagoCA6duzIBx98wCuvvIK7uzvz58/nrrvucoyvO3v2LMnJybz11lu89dZb6e47o+kzRKyiAkokHypdunSG8/VcX/73L1o3NzenoiIyMpI777yT8ePH0717d8eUArt372b37t1pBv5e39/x48fT7NsYw8mTJzN15VuXLl2YPHkyv/zyy03bXnd9oPHf55lyVYkSJQD7+KK/O3HiBG5ubgQGBjott9lsado2btwYX19fvv76aw4fPkyrVq2w2Wy0atWKGTNmsG3bNo4ePepUQC1fvpyEhASWLl1KxYoVHct37dqVbtb0jluiRIl0i87MDiK/Pq/Wli1bMjUOysvLi8TExDTLz5w543S15I0yAzz11FMsWbKEtWvXEhoayrZt25g9e7ZjfWBgIO7u7jz55JMMGDAg3X38/SpREavpFJ5IPtS6dWs2bNjAn3/+6bTcGMOSJUsICwujSpUqN9yHp6cnb7/9NlevXmXChAmO5Z9++illy5ZN8wXbsmVLbDZbulfCrV69mvj4eKeCIb0iBeDSpUscO3Ys071JP/74I5MmTSIsLIwuXbpkapuMVK1alXLlyrFw4UKn04IJCQl8+umnjivzbsbDw4N7772XtWvXsn79eiIjIwFo3rw5RYoUYdSoUY6C6rrrxcX/TsNgjGHOnDmZzt+iRQsuXrzodOUa2AfGZ8Y///lPfHx86N+/P3FxcWnWG2OcpjEICwvjp59+cmqzd+9e9uzZk+nMAG3atKFcuXJER0cTHR2Nl5cX3bp1c6wvVqwYLVq0YOfOndSpU4eGDRumeVwvfkXyCvVAieQxv/zyi9NVY9fddtttlCpVCoAxY8awcuVKGjduzIgRI7j99ts5deoUc+bMYdu2bSxevDhTxwoPD6ddu3ZER0czYsQIKlWqxCeffMLDDz+cpjfhtttuY+DAgUybNo0LFy7Qrl07vL292bZtG1OmTKFhw4ZOY3EmTpzId999R9euXalXrx7e3t4cOnSIWbNmcfbsWaZNm5Ymz44dOwgICCApKckxkeaHH35IcHAwK1eupGjRoq68lWm4ubkxdepUunfvzgMPPEDfvn1JTEx0vKYpU6Zkel+tWrVi2LBhAI7C0dvbm3vuuYevvvqKOnXqOE3hEBkZSdGiRenWrRvPP/88V69eZfbs2Zw/fz7Tx+zRowevv/46PXr0YOLEidx+++2sWrWKNWvWZGr7SpUq8fHHHzt+J9cn0gT7VXDz5s3DGMNDDz0EwJNPPskTTzxB//796dy5M0eOHGHq1KmOz2Fmubu706NHD1577TX8/f15+OGH00yj8MYbb9CsWTOaN2/OM888Q1hYGBcvXmT//v2sXLnSMQmsSJ5h4QB2EfkfN7qCDDBz5sxxar9v3z7zxBNPmJCQEFOkSBFTvHhx06ZNmzRXbhnz11V46fn555+Nm5ubeeqpp8z+/fvTXMH3v1JTU83s2bNNw4YNTbFixUzRokXN7bffbl544QVz8eJFp7ZbtmwxAwYMMHXr1jVBQUHG3d3dlCpVytx3331m1apVTm2vX/F2/eHp6WlCQkJMmzZtzBtvvGHi4+Ndeg+3bdt2w3bLly83jRs3Nl5eXsbHx8e0atXKfPfdd+lmyujKwB9//NEA5vbbb3daPnHiRAOYoUOHptlm5cqVpm7dusbLy8uUK1fODB8+3Hz55Zdp3vPw8HBTs2bNdI/7+++/m86dOxtfX1/j5+dnOnfubL7//vtMXYV33YEDB0z//v1NlSpVjKenp/H29jY1atQwQ4cOdbpCMjU11UydOtVUrlzZeHl5mYYNG5r169dneBXekiVLMjzm3r17Hb/ftWvXptvm0KFDplevXqZcuXLGw8PDlCpVytxzzz1mwoQJmXpdIrnJZoyLl7eISIE1depUpk+fzsmTJ3F3d7c6johInqUCSkRERMRFGkQuIiIi4iIVUCIiIiIuUgElIiIi4iIVUCIiIiIuUgElIiIi4iJNpJlFqampnDhxAj8/vwxvXyAiIiJ5izGGixcvUrZsWaebirtKBVQWnThxwnHvMBEREclfjh07Rvny5bO8vQqoLPLz8wPsvwB/f3+L04iISL6WkgwvNYfgitD3PfAJuPk2kiXx8fFUqFDB8T2eVSqgsuj6aTt/f38VUCIikjUJF+yP4DCYHAt+JeAWTitJ5t3q8Bv9lkRERKxw9Bd4vhG8+SQYAwGlVDzlI/pNiYiI5LbvFsPIu6GoNwycD7oYKd9RASUiIpKbFo+H17pCw44weTOUuc3qRJIFGgOVw1JSUkhKSrI6hhQyHh4euLu7Wx1DRNJTsS5EvQYPDFHPUz6mAiqHGGM4deoUFy5csDqKFFLFixenTJkymqdMJC/Yvx2+WQhRM6BxJ6vTSDZQAZVDrhdPwcHBFCtWTF9ikmuMMVy+fJnTp08DEBISYnEikUJufTS8/wxUrANXLkIxXbldEKiAygEpKSmO4qlEiRJWx5FCyNvbG4DTp08THBys03kiVki6BvOeha/ehdZPQ++3oKiX1akkm6iAygHXxzwVK1bM4iRSmF3//CUlJamAErHC13Ng/Tzo9z5E9rE6jWQzFVA5SKftxEr6/IlYJO40BARDm35QMxxCa1mdSHKApjEQERHJDsbAqregX5h90Li7u4qnAkwFlBRY48aNo169elbHEJHCIPEyvNUT5g6GNn0hrK7ViSSHqYDK607sg49Gwmvd7D9P7MvRw0VFRWGz2dI89u/fn6PHFRHJt/48Ci81hc2fwJB/wVOvQxEPq1NJDtMYqLxsfTS887R9ojVj7D+XT4X+c6FlVI4d9r777iM6OtppWalSpVzez7Vr1yhatGh2xcpQUlISHh76x0pELFLUG4oVt88qrp6nQkM9UHnViX324smkQmqK8893esPJnOsR8vT0pEyZMk4Pd3d3Nm7cyF133YWnpychISGMGDGC5ORkx3YREREMHDiQoUOHUrJkSSIjIxk2bBgdOnRwtJk5cyY2m40vvvjCsaxq1aq89957AGzbto3IyEhKlixJQEAA4eHh/PDDD075bDYb7777Lg8++CA+Pj5MmDABgClTplC6dGn8/Pzo3bs3V69eddouNjaWu+66Cx8fH4oXL07Tpk05cuRItr9/IlIIGAOfz4RzJ+w3AX55g4qnQkYFVG47fxIO/uD8+OOQfd21q38tWzop4yn+bTb4dKK93cVz9mVxf6bd7/mT2Rb7+PHjtGvXjkaNGvHjjz8ye/Zs5s6d6yherluwYAFFihThu+++47333iMiIoJvvvmG1NRUADZu3EjJkiXZuHEjYJ9wdO/evYSHhwNw8eJFevbsyTfffMOWLVu4/fbbadeuHRcvXnQ6ztixY3nwwQf5+eef6dWrF4sXL2bs2LFMnDiR7du3ExISwjvvvONon5ycTKdOnQgPD+enn35i8+bN/OMf/9CVaiLiuisXYdojEP1P+OFLq9OIVYxkSVxcnAFMXFxcmnVXrlwxv/32m7ly5UraDT8ea8zDOD9mdrevO7Ev7bqbPWI/tG+7albadR+Pdfl19ezZ07i7uxsfHx/H45FHHjEvvviiqVq1qklNTXW0ffvtt42vr69JSUkxxhgTHh5u6tWr57S/CxcuGDc3N7N9+3aTmppqSpQoYSZPnmwaNWpkjDFm4cKFpnTp0hnmSU5ONn5+fmblypWOZYAZMmSIU7smTZqYfv36OS1r3LixqVu3rjHGmLNnzxrAxMbGuvye5Fc3/ByKSNYc223MoGrGdPczZssyq9NIFtzo+9sVGgOV29r0hUYdnZf5BNp/ligP03bY/7zqLdj4of203d+5uUP4k9BuEJQKsy+7pwtUbeLcLjBrt/Bo0aIFs2fP/iuejw8DBgygSZMmTj02TZs25dKlS/z++++EhoYC0LBhQ6d9BQQEUK9ePWJjY/Hw8MDNzY2+ffsyduxYLl68SGxsrKP3CewzZ48ZM4b169fzxx9/kJKSwuXLlzl69KjTfv9+nN27d9OvXz+nZU2aNGHDhg0ABAUFERUVRdu2bYmMjKR169Z06dJFtzkRkcy7cglGNwf/UvDqNihX1epEYiEVULktMCTjwqaoF1RuYP/zwy9C7AfptzMGOr8EIVX+WhZQyv7IBj4+PlSpUsVpmTEmzekuYwzgPGGjj49Pmv1FREQQGxtL0aJFCQ8PJzAwkJo1a/Ldd98RGxvLkCFDHG2joqL4888/mTlzJhUrVsTT05MmTZpw7dq1NBldFR0dzeDBg1m9ejWLFi1i1KhRrF27lrvvvtvlfYlIIZLy3/Gn3r4wZCHccTd4+1mdSiymMVB5Vdnb7Vfb2dzsPU5u//1pc7MvD6ly831koxo1avD99987iiaA77//Hj8/P8qVK3fDba+Pg1q/fj0REREAhIeH8/HHHzuNfwL45ptvGDx4MO3ataNmzZp4enpy5syZm+arXr06W7ZscVr29+cA9evXZ+TIkXz//ffUqlWLhQsX3nTfIlKIXTwHkx+ABc/Zn9eNVPEkgAqovK1lFLy1Bx4cDk262H++tSdHpzDISP/+/Tl27BiDBg3iP//5D5999hljx45l6NChuLnd+GN07733cvHiRVauXOkooCIiIvjoo48oVaoUNWrUcLStUqUKH374Ibt37+bf//433bt3d9wY90aeffZZ5s2bx7x589i7dy9jx47l119/daw/dOgQI0eOZPPmzRw5coSvvvqKvXv3Ur169ay9ISJS8B3+EZ5vCPu2wp3trU4jeYxO4eV1IVXgiclWp6BcuXKsWrWK4cOHU7duXYKCgujduzejRo266bYBAQHUr1+fo0ePOoql5s2bk5qa6tT7BDBv3jz+8Y9/UL9+fUJDQ5k0aRLPPffcTY/RtWtXDhw4wAsvvMDVq1fp3LkzzzzzDGvWrAHsN9b9z3/+w4IFCzh79iwhISEMHDiQvn37ZuHdEJECb9O/YHYfKFcNxq+H4DCrE0keYzP/e05GMi0+Pp6AgADi4uLw9/d3Wnf16lUOHTpEpUqV8PLysiihFHb6HIrcgneehuRr0Pc98Lx5L7jkHzf6/naFeqBEREQALvxhP21Xrw30ffe/4041V5ykTwWUiIjI3n/DtM7g4Qlv7AaPnL8NleRvGkQuIiKF21fvw+h7oVQoTPhGxZNkigooEREpvJZOgff6QqveMD4WgspanUjyCZ3CExGRwscY+/imZt3sRVNED6sTST6jHigRESlcfomFl5pBwgUIrqjiSbJEBZSIiBQOxsCK12B8a/uts1KSrU4k+ZhO4YmISMF3NcE+t9N3H9vv6tB9ErjrK1CyztIeqE2bNtGhQwfKli2LzWZj+fLlN2y/dOlSIiMjKVWqFP7+/jRp0sQx0/R1c+bMoXnz5gQGBhIYGEjr1q3ZunVrhvucPHkyNpvN6Ya2IiJSwBzYDj98AUMXQY+pKp7klllaQCUkJFC3bl1mzZqVqfabNm0iMjKSVatWsWPHDlq0aEGHDh3YuXOno01sbCzdunVjw4YNbN68mdDQUNq0acPx48fT7G/btm28//771KlTJ9teU3Y5fuEKvxyPy/Bx/MIVqyPekvnz51O8eHHH83HjxlGvXr1b2ufhw4ex2Wzs2rXrlvaTn0RFRdGpUyerY4jkXfu2Qmoq1AyH2YehaRerE0kBYWkJfv/993P//fdnuv3MmTOdnk+aNInPPvuMlStXUr9+fQD+9a9/ObWZM2cOn3zyCevWraNHj78GCl66dInu3bszZ84cJkyYkPUXkQOOX7hCy+mxJCanZtjGs4gb65+LoFzx7L3FQFRUFBcuXLhpb2B2e+655xg0aFCOHyciIoKNGzemWZ6UlESRIvofqUiBkZoKn06ERWPh2Y+g+ePgF2R1KilA8vUg8tTUVC5evEhQUMZ/KS5fvkxSUlKaNgMGDKB9+/a0bt06U8dKTEwkPj7e6ZFTzidcu2HxBJCYnMr5hGs5liG3+fr6UqJEiVw5Vp8+fTh58qTTI6vF07VrufM7SEpKypXjiBQICXEw9SH4eAx0GQtNH7M6kRRA+bqAmjFjBgkJCXTpknGX7IgRIyhXrpxTofTxxx/zww8/MHny5Ewfa/LkyQQEBDgeFSpUuKXs+UVERASDBg1iyJAhBAYGUrp0ad5//30SEhJ46qmn8PPz47bbbuPLL790bBMbG4vNZuOLL76gbt26eHl50bhxY37++ecMj5PeKbzo6GiqV6+Ol5cX1apV45133nFav3XrVurXr4+XlxcNGzZ0OpV7I8WKFaNMmTJOj+s+/fRTatasiaenJ2FhYcyYMcNp27CwMCZMmEBUVBQBAQH06dOHzp07O/WeDRkyBJvNxq+//gpAcnIyfn5+jvF6q1evplmzZhQvXpwSJUrwwAMPcODAAcf2109FLl68mIiICLy8vPjoo49ISUlh6NChju2ef/55dC9wKdRO7IOPRsJr3ew/T+yz38/uhUbw60YYudJeQLnl6686yaPy7acqJiaGcePGsWjRIoKDg9NtM3XqVGJiYli6dKnjbvTHjh3j2Wef5aOPPnLpDvUjR44kLi7O8Th27Fi2vI78YMGCBZQsWZKtW7cyaNAgnnnmGR599FHuuecefvjhB9q2bcuTTz7J5cuXnbYbPnw406dPZ9u2bQQHB9OxY8dM96TMmTOHl156iYkTJ7J7924mTZrE6NGjWbBgAWAfP/fAAw9QtWpVduzYwbhx43juuedu6XXu2LGDLl268Nhjj/Hzzz8zbtw4Ro8ezfz5853aTZs2jVq1arFjxw5Gjx5NREQEsbGxjvUbN26kZMmSjlOF27Zt4+rVqzRt2tSRfejQoWzbto1169bh5ubGQw89RGqqc6/jCy+8wODBg9m9ezdt27ZlxowZzJs3j7lz5/Ltt99y7tw5li1bdkuvWSTfWh8Ng6vBZ9Pg+8X2n4OrwY4voFFHeHUbNHzA6pRSkJk8AjDLli3LVNuPP/7YeHt7m88//zzDNtOmTTMBAQFm27ZtTsuXLVtmAOPu7u54AMZmsxl3d3eTnJycqQxxcXEGMHFxcWnWXblyxfz222/mypUrmdrX3/38+wVT8YXPb/r4+fcLWdr/jfTs2dM8+OCDjufh4eGmWbNmjufJycnGx8fHPPnkk45lJ0+eNIDZvHmzMcaYDRs2GMB8/PHHjjZnz5413t7eZtGiRcYYY6Kjo01AQIBj/dixY03dunUdzytUqGAWLlzolO2VV14xTZo0McYY895775mgoCCTkJDgWD979mwDmJ07d2b4+sLDw42Hh4fx8fFxPIYOHWqMMebxxx83kZGRTu2HDx9uatSo4XhesWJF06lTJ6c2P/30k7HZbObPP/80586dMx4eHmbChAnm0UcfNcYYM2nSJNO4ceMMM50+fdoA5ueffzbGGHPo0CEDmJkzZzq1CwkJMVOmTHE8T0pKMuXLl3f6ff2vW/0ciuRZx/ca09nNmIdJ++jsZsyJfVYnlDzsRt/frsh3o2ZjYmLo1asXMTExtG/fPt0206ZNY8KECaxZs4aGDRs6rWvVqlWaU0lPPfUU1apV44UXXsDd3T3HsudX/3uVoru7OyVKlKB27dqOZaVLlwbg9OnTTts1adLE8eegoCCqVq3K7t27b3q8P//8k2PHjtG7d2/69OnjWJ6cnExAQAAAu3fvpm7duhQrVizd491I9+7deemllxzPr18NuHv3bh588EGntk2bNmXmzJmkpKQ4Pht//0zVqlWLEiVKsHHjRjw8PKhbty4dO3bkzTffBOynNMPDwx3tDxw4wOjRo9myZQtnzpxx9DwdPXqUWrVqOdr973Hi4uI4efKk02ssUqQIDRs21Gk8KXzWz7PfhiW9j77NBuvmwhOZH6IhkhWWFlCXLl1i//79jueHDh1i165dBAUFERoaysiRIzl+/DgffPABYC+eevTowRtvvMHdd9/NqVOnAPD29nZ8sU6dOpXRo0ezcOFCwsLCHG18fX3x9fXFz8/P6UsKwMfHhxIlSqRZLnYeHh5Oz202m9Mym80GkOYUVHqut72R6/uZM2cOjRs3dlp3vYi5laIhICCAKlWqpFlujEmTL73j+Pj4OD232Wzce++9xMbGUrRoUSIiIqhVqxYpKSn8/PPPfP/9907zjHXo0IEKFSowZ84cypYtS2pqKrVq1UozIP3vxxGR/zp92D6reLqMfb1IDrN0DNT27dupX7++YwqCoUOHUr9+fcaMGQPAyZMnOXr0qKP9e++9R3JyMgMGDCAkJMTxePbZZx1t3nnnHa5du8Yjjzzi1Gb69Om5++KELVu2OP58/vx59u7dS7Vq1W66XenSpSlXrhwHDx6kSpUqTo9KlSoBUKNGDX788UeuXPlrPqz/PV5W1KhRg2+//dZp2ffff88dd9xx057J6+OgYmNjiYiIwGaz0bx5c6ZPn86VK1cc45/Onj3L7t27GTVqFK1ataJ69eqcP3/+ptkCAgIICQlxeo3Jycns2LEjC69UJJ8LDrP3NKXLZl8vksMs7YGKiIi4YU/C3wfv/u9A3YwcPnzY5RyZ2W9uCvQpimcRt5vOAxXoUzQXU7nu5ZdfpkSJEpQuXZqXXnqJkiVLZnrSx3HjxjF48GD8/f25//77SUxMZPv27Zw/f56hQ4fy+OOP89JLL9G7d29GjRrF4cOHb7lIHjZsGI0aNeKVV16ha9eubN68mVmzZqW5+i89ERERPPvssxQpUoTmzZs7lg0bNowGDRrg7+8PQGBgICVKlOD9998nJCSEo0ePMmLEiEzle/bZZ5kyZQq333471atX57XXXuPChQtZfr0i+dLhH6FOa1g+Nf31xkCr3rmbSQqlfDcGqjAoV9yb9c9F3HCep0Cfotk+iWZ2mzJlCs8++yz79u2jbt26rFixgqJFM1f0Pf300xQrVoxp06bx/PPP4+PjQ+3atR2nwnx9fVm5ciX9+vWjfv361KhRg1dffZXOnTtnOW+DBg1YvHgxY8aM4ZVXXiEkJISXX36ZqKiom25bq1YtSpYsScWKFR3FUnh4OCkpKU7jn9zc3Pj4448ZPHgwtWrVomrVqrz55ptERETc9BjDhg3j5MmTREVF4ebmRq9evXjooYeIi4vL6ksWyT9SU+HzmfCvkfZJMfvPhXd6/7cnygA2e/HUfy6EpD1FL5LdbEYjULMkPj6egIAA4uLiHF+Y1129epVDhw5RqVIll6ZKKChiY2Np0aIF58+fd7pdi+Suwv45lALk3Al4qyf89DV0HAaPTwQPTzi53z5g/PRh+2m7Vr1VPMlN3ej72xXqgRIRkbwrOQleagpJiTDmK6gb+de6kCq62k4sowJKRETynqsJ9lNy3r7203IV64B/SatTiTjk25nIJe+6fnGATt+JSJbs3w7DG8AH/727QO2WKp4kz1EBJSIieUNKCiydDC82AW8/6DDU6kQiGdIpPBERsV5yErzcBn7bCA+NgC7jwCNvT9UihZsKKBERsZYxUMTDPkC86zioGX7TTUSspgJKRESscTke5g6CyndC+8HQ+UWrE4lkmsZAiYhI7vvP9zCsHvx7GfiVsDqNiMtUQImISO5JSYZF42B0cwgsA9N3wb3drU4l4jIVUJJjIiIiHLdeAQgLC2PmzJmW5RGRPMDmBns2w6Nj4JVNUKay1YlEskQFlDg5ffo0ffv2JTQ0FE9PT8qUKUPbtm3ZvHkzADabjeXLl2dqX0uXLuWVV17JwbQiki8YAxsWwK8bwc0NRn0JXcaCu4bhSv6lT6846dy5M0lJSSxYsIDKlSvzxx9/sG7dOs6dO5fpfSQlJeHh4UFQUFAOJhWRfOHSeXivH3y/GDo9b7/Czk3/d5f8T5/i3GIMJCTk/sOFe0VfuHCBb7/9lldffZUWLVpQsWJF7rrrLkaOHEn79u0JCwsD4KGHHsJmszmejxs3jnr16jFv3jwqV66Mp6cnxpg0p/D+Ljo6moCAANauXQvAb7/9Rrt27fD19aV06dI8+eSTnDlzJqvvuIhY7ZdYGFoHfvwKhn4MT75qdSKRbKMCKrdcvgy+vrn/uHw50xF9fX3x9fVl+fLlJCYmplm/bds2wF74nDx50vEcYP/+/SxevJhPP/2UXbt23fRY06dP57nnnmPNmjVERkZy8uRJwsPDqVevHtu3b2f16tX88ccfdOnSJdP5RSQPSU6Ct3tBmdtgxo/QtKvViUSylU7hiUORIkWYP38+ffr04d1336VBgwaEh4fz2GOPUadOHUqVKgVA8eLFKVOmjNO2165d48MPP3S0uZGRI0eyYMECYmNjqV27NgCzZ8+mQYMGTJo0ydFu3rx5VKhQgb1793LHHXdk4ysVkRxzfA8U9YZSoTB+A5QoD+7uVqcSyXYqoHJLsWJw6ZI1x3VB586dad++Pd988w2bN29m9erVTJ06lf/7v/8jKioqw+0qVqyYqeJpxowZJCQksH37dipX/uvqmx07drBhwwZ8fX3TbHPgwAEVUCJ5nTHw9f9B9BBo8igMmg/BFa1OJZJjVEDlFpsNfHysTpEpXl5eREZGEhkZyZgxY3j66acZO3bsDQson0y+tubNm/PFF1+wePFiRowY4ViemppKhw4dePXVtGMkQkJCXH4NIpKL4s/A7D6wdTlE/gOiXrM6kUiOUwElN1WjRg3H1AUeHh6kpKRkeV933XUXgwYNom3btri7uzN8+HAAGjRowKeffkpYWBhFiuhjKZJvJCfByLsh4QK8sBzuetDqRCK5QoPIxeHs2bO0bNmSjz76iJ9++olDhw6xZMkSpk6dyoMP2v9RDAsLY926dZw6dYrz589n6ThNmjThyy+/5OWXX+b1118HYMCAAZw7d45u3bqxdetWDh48yFdffUWvXr1uqWATkRxy7ar9UcQDnpoJr/+s4kkKFf1XXxx8fX1p3Lgxr7/+OgcOHCApKYkKFSrQp08fXnzRfpPPGTNmMHToUObMmUO5cuU4fPhwlo7VtGlTvvjiC9q1a4e7uzuDBw/mu+++44UXXqBt27YkJiZSsWJF7rvvPtw0Z4xI3nL0V5j5ONSMgN5vQMMHrE4kkutsxrgwUZA4xMfHExAQQFxcHP7+/k7rrl69yqFDh6hUqRJeXl4WJZTCTp9DyXbGwJez4MPnofRtMORfEFbX6lQiLrnR97cr1AMlIiI3l3QNpj4EP6yCdoPgiVfB09vqVCKWUQElIiI351EUKtaB+wbAne2sTiNiORVQIiKSvsTLsOA5qHwntO4NT0y2OpFInqHRuSIiktbBnTD8TtgQbXUSkTxJPVA5SOPzxUr6/EmWpKbCytdg4YtQoSZM+wHKV7c6lUieox6oHODh4QHAZRdu5CuS3a5//q5/HkUyxaTaZxRv9yxM3qLiSSQD6oHKAe7u7hQvXpzTp08DUKxYMWw2m8WppLAwxnD58mVOnz5N8eLFcdeNXCUztiyFoHJwR2MYt94+aFxEMqQCKoeUKVMGwFFEieS24sWLOz6HIhm6csl+A+B1c+GBIfYCSsWTyE2pgMohNpuNkJAQgoODSUpKsjqOFDIeHh7qeZKb27cVZnaHCyeh/1xo+ZTViUTyDRVQOczd3V1fZCKS9yRdg+mPQvHS8NIqKHu71YlE8hUVUCIihcnpI+DhCYFlYMxXULqy/YbAIuISXYUnIlJYfBMDw+rCv0ban5erquJJJIvUAyUiUtAlxMH/DYRNH0GzbvDU61YnEsn3VECJiBRkSddgRGM4fwKe/Qju7W51IpECQQWUiEhBlJwExtinJHhsPFS5C0pXsjqVSIGhMVAiIgXNqQMwqjl8PMb+vGlXFU8i2UwFlIhIQWEMrJ8Pw+rBxTPQ+CGrE4kUWDqFJyJSECRdgzeegM1L7BNi9noDvP2sTiVSYKmAEhEpCDyKQkAwDFsM9zxqdRqRAk8FlIhIfpV0DWJGQeUG0Owx6DPL6kQihYbGQImI5Ee//wdG3g1fzIT4M1anESl01AMlIpKfGANfvQfzh0LJUJi8xd4DJSK5SgWUiEh+kpIMX8+BiJ4QNQM8i1mdSKRQUgElIpIf7FxjvwFwWF2Y8I0KJxGLaQyUiEhedu0qzBsCE+6DtXPsy1Q8iVhOPVAiInnVkZ9h5uNwch88NRPaDbI6kYj8lwooEZG8KOkaTGwHPsXh1W1QsbbViUTkf6iAEhHJS86fgiIe4FcCXvwcylaFol5WpxKRv9EYKBGRvGLbChhaGz58wf48rK6KJ5E8SgWUiIjVEi/De8/AlAfhjibQfbLViUTkJnQKT0TESknXYERjOHUA/jEb2vQFm83qVCJyEyqgRESskJpqn1Xcoyi0HwLV7oHy1a1OJSKZpFN4IiK57ezvML41fDrR/rx1bxVPIvmMCigRkdz0/RIYWgdO7IXqza1OIyJZpFN4IiK5IekavN8P1kdDk0eg73vgF2R1KhHJIhVQIiK5oYgHpKbAgHnQIkoDxUXyORVQIiI5JSUFlk2GinWgUUcYtMDqRCKSTTQGSkQkJ5w+DGPCYdFY+3gnESlQ1AMlIpLdNv0L5vQH3yB4ZRNUa2p1IhHJZiqgRESyU9I1+/QEDTvC07PAJ8DqRCKSAyw9hbdp0yY6dOhA2bJlsdlsLF++/Ibtly5dSmRkJKVKlcLf358mTZqwZs0apzZz5syhefPmBAYGEhgYSOvWrdm6datTm8mTJ9OoUSP8/PwIDg6mU6dO7NmzJ7tfnogUJr99A7//xz4x5qTv4dkPVTyJFGCWFlAJCQnUrVuXWbNmZar9pk2biIyMZNWqVezYsYMWLVrQoUMHdu7c6WgTGxtLt27d2LBhA5s3byY0NJQ2bdpw/PhxR5uNGzcyYMAAtmzZwtq1a0lOTqZNmzYkJCRk+2sUkQIuOQliRsPYCPhipn2ZT3ELA4lIbrAZY4zVIQBsNhvLli2jU6dOLm1Xs2ZNunbtypgxY9Jdn5KSQmBgILNmzaJHjx7ptvnzzz8JDg5m48aN3HvvvZk6bnx8PAEBAcTFxeHv7+9SZhEpIE7sgzefgAM7oOt4eGgEuLtbnUpEbiC7vr/z9Rio1NRULl68SFBQxpPRXb58maSkpBu2iYuLA7hhm8TERBITEx3P4+Pjs5BYRAqMpEQY2wKKesHE7+COxlYnEpFclK8LqBkzZpCQkECXLl0ybDNixAjKlStH69at011vjGHo0KE0a9aMWrVqZbifyZMnM378+FvOLCL53MWz4O4BxfzhuSUQWhu8fa1OJSK5LN/OAxUTE8O4ceNYtGgRwcHB6baZOnUqMTExLF26FC8vr3TbDBw4kJ9++omYmJgbHm/kyJHExcU5HseOHbvl1yAi+cxP6+z3sfvwefvzqk1UPIkUUvmyB2rRokX07t2bJUuWZNizNH36dCZNmsTXX39NnTp10m0zaNAgVqxYwaZNmyhfvvwNj+np6Ymnp+ctZxeRfCgpERaOghXToXZLeGSU1YlExGL5roCKiYmhV69exMTE0L59+3TbTJs2jQkTJrBmzRoaNmyYZr0xhkGDBrFs2TJiY2OpVKlSTscWkfwqKRFevAeO/gw9p8MD/wS3fNt5LyLZxNIC6tKlS+zfv9/x/NChQ+zatYugoCBCQ0MZOXIkx48f54MPPgDsxVOPHj144403uPvuuzl16hQA3t7eBATY51uZOnUqo0ePZuHChYSFhTna+Pr64utr72ofMGAACxcu5LPPPsPPz8/RJiAgAG9v71x7/SKShxljf3h4QngPqHEvVK5vdSoRySMsncYgNjaWFi1apFnes2dP5s+fT1RUFIcPHyY2NhaAiIgINm7cmGF7gLCwMI4cOZKmzdixYxk3bhxgnzIhPdHR0URFRWUqu6YxECnA4k7D272gVgvoOMzqNCKSjbLr+zvPzAOV36iAEimgfvgSZkXZe58GzIOGD1idSESykeaBEhHJTknX4IPnYNVbUP8+GBANgWWsTiUieZQKKBERgCIecPZ36P0W3D8AMjjVLyICKqBEpDBLTYVVb0KFmlA3EoZ/qsJJRDJF1+KKSOF0/iRMuB+i/wn7/m1fpuJJRDJJPVAiUvhs/Qze6W2/JcvoNVCvjdWJRCSfUQElIoVLUiIsGAbVmkH//wP/klYnEpF8SAWUiBQOB3aATyCUqQwTv4OAYJ2yE5Es0xgoESnYUlJg2asw8m5Y/qp9WfHSKp5E5JaoB0pECq4zx+DNHvDbRuj0AnQdb3UiESkgVECJSMF0/SbAAOPWQ60IS+OISMGiAkpECpbL8eDmDl4+MHA+VG4AvoFWpxKRAkZjoESk4NizGZ6rDx+NsD+v00rFk4jkCBVQIpL/pSTD4pdhVHP71XUPDLE6kYgUcDqFJyL5W1IijGsFezfDI6PhkVHgrn/aRCRn6V8ZEcmzjl+4wvmEa/Ynfx6FbZ/BuZMQFAKNOhJYsQrlAotB/fvhyVehWlNrA4tIoWEzxhirQ+RH8fHxBAQEEBcXh7+/v9VxRAqc4xeu0HJ6LInJqRm28SSF9SMiKVfcOxeTiUh+ll3f3xoDJSJ50vmEazcsngAScef8kQO5lEhE5C8qoEQkf9u63OoEIlIIqYASkfzt3EmrE4hIIaQCSkTyt6AQqxOISCGkAkpE8h5jYOeXmWt7V6ccjSIikh4VUCKSt5w/BZMegIWjMte+ZIWczSMikg4VUCKSt3gWg4tnIeo1q5OIiGRIBZSIWO/IzzA+Es4cg2L+MHkzgXdF4lnkxv9EeRZxI9CnaC6FFBH5i2YiFxHrXLsKn0yA5a9CyO1w6bz9lJzNRrni3qx/LuKvmcjTEehTVJNoioglVECJiDUO7ICZj8PpQ/b71z00Ajw8nZqUK+6tAklE8iQVUCJiDU8fCCoHzy+DCjWsTiMi4hKNgRKR3PPvZTCmhf3UXflqMH69iicRyZdUQIlIzjt3AqZ2hqkPg7cfXL1kdSIRkVuiU3gikrO+/Rje62cf3zRsMTR5BGw2q1OJiNwSFVAikjOMsRdKnsXg7s7QYxr4BVmdSkQkW6iAEpHslXQNPpsGh3fZe5wadbQ/REQKEI2BEpHss28rPN8QFo2F0pUhNcXqRCIiOUI9UCKSPT4aaZ8Qs3IDeHUbVK5vdSIRkRyjAkpEbk1qKri5gX9J+zin9s+Cu/5pEZGCTf/KiUjWxP0J0UOgVBh0nwgdh1mdSEQk12gMlIi4xhiI/RCerQ47V0P56lYnEhHJdeqBEpHMu3YVpjwIP34FzbpBr5kQEGx1KhGRXKcCSkRuLiXFPs6pqJf91ivtB8Od7a1OJSJimVsqoM6cOcPhw4ex2WyEhYVRokSJ7MolInnFoV0w+2l4cDg07QpPvW51IhERy2VpDNSvv/7KvffeS+nSpWncuDF33XUXwcHBtGzZkj179mR3RhGxQuIV+9QEzzeEpEQIrmR1IhGRPMPlHqhTp04RHh5OqVKleO2116hWrRrGGH777TfmzJlD8+bN+eWXXwgO1rgIkXzr1EF4pS2cOQpdx8GDz4NHUatTiYjkGTZjjHFlgxdeeIGvv/6a7777Di8vL6d1V65coVmzZrRp04bJkydna9C8Jj4+noCAAOLi4vD397c6jojrTuyD9fPg9GEIDoOWvew/i3jYb8cypz90fA7KV7M4qIhI9smu72+XC6gGDRowYsQIunTpku76jz/+mKlTp/LDDz9kOVR+oAJK8rX10fDO0/ab/V6/6a9JBZ9AGL8ewupanVBEJEdk1/e3y6fwDh48SIMGDTJc37BhQw4ePJjlQCKSw07ssxdPJhWu//fp+s9L5+DKRauSiYjkGy4PIr948eINKzY/Pz8uXbp0S6FEJAetn2fvcUqPmzvs+CJ384iI5ENZmsbg4sWLacY/XRcfH4+LZwVFJDedPmw/bZcuY18vIiI35HIBZYzhjjvuuOF6W0b/uxURa125BH8ctJ++S5fNPpBcRERuyOUCasOGDTmRQ0Ry2tbPYO4giDsN2Phr4NP/MAZa9c7tZCIi+Y7LBVR4eHhO5BCRnPThC7B8KtS/H15+G37dCO/0/u9YKAP892q8/nMhpIrVaUVE8jyXC6jU1FRSU1MpUuSvTf/44w/effddEhIS6NixI82aNcvWkCKSBSnJEP8nBIZAk0egSiO4u7O9aCpdCao3g3Vz/5oHqlVvFU8iIpnk8jxQTz31FB4eHrz//vuAfUB5zZo1uXr1KiEhIfz222989tlntGvXLkcC5xWaB0rytL3/hvf6gocXTN6c8VV3IiKFTHZ9f7s8jcF3333HI4884nj+wQcfkJyczL59+/jxxx8ZOnQo06ZNy3IgEbkFCRfg/f7wYhP7lARPz1LxJCKSA1w+hXf8+HFuv/12x/N169bRuXNnAgICAOjZsyfR0dHZl1BEMic1FV5sCmePwVMz4b4B4O5udSoRkQLJ5QLKy8uLK1euOJ5v2bLFqcfJy8tLE2mK5KZTB8CnOPiVgF5vQPnqUKKc1alERAo0l0/h1a1blw8//BCAb775hj/++IOWLVs61h84cICyZctmX0IRSV9SInwyAYbUhKX/vXl33dYqnkREcoHLPVCjR4+mXbt2LF68mJMnTxIVFUVISIhj/bJly2jatGm2hhSRv/klFt5/Bk7thw7D4NHRVicSESlUXC6gWrRowfbt2/n6668pU6YMjz76qNP6evXqcdddd2VbQBH5m9NHYHxruL0xTPsBKta2OpGISKHj8jQGYqdpDCRXpabCv5fCXZ3AvQj853u4425wc/ksvIhIoZZd398u90B98MEH6S4PCAigatWqVKtWLcthRCQdx36D9/rB7m/gpVXQ4H6odo/VqURECjWXC6hnn3023eWXLl0iNTWVdu3asXDhQvz8/G45nEihlnjFPkh8xTQIrgTj1kHtljffTkREcpzL/f/nz59P95GYmMiWLVs4evQo48ePz4msIoXLts9gxXTo/BK89pOKJxGRPCTbx0B9/fXXDBgwgD179mTnbvMcjYGSHHHuBGxdDvf1t9/c988j9vvUiYhItrDsVi43U6VKFX7//fdMtd20aRMdOnSgbNmy2Gw2li9ffsP2S5cuJTIyklKlSuHv70+TJk1Ys2aNU5s5c+bQvHlzAgMDCQwMpHXr1mzdujXNvt555x0qVaqEl5cXd955J998802mX6NItktJgVWz4NnqsHg8xJ+x34JFxZOISJ6U7QXUgQMHKF++fKbaJiQkULduXWbNmpWp9ps2bSIyMpJVq1axY8cOWrRoQYcOHdi5c6ejTWxsLN26dWPDhg1s3ryZ0NBQ2rRpw/Hjxx1tFi1axJAhQ3jppZfYuXMnzZs35/777+fo0aOuvViR7HDwBxh5N8wdBE0fgzf/A/4lrU4lIiI3kG2n8Iwx7Ny5k169etG6dWumT5/uWhCbjWXLltGpUyeXtqtZsyZdu3ZlzJgx6a5PSUkhMDCQWbNm0aNHDwAaN25MgwYNmD17tqNd9erV6dSpE5MnT87UcXUKT7LN/GHw41ro+66urhMRyWGWTWMQGBiILZ27u1+6dImUlBTuu+8+xo0bl+VArkhNTeXixYsEBQVl2Oby5cskJSU52ly7do0dO3YwYsQIp3Zt2rTh+++/z3A/iYmJJCYmOp7Hx8ffYnoptIyxj3O6eBZaPw3dJsATU6CIh9XJREQkk1wuoGbOnJnucn9/f6pVq0b16tVvNVOmzZgxg4SEBLp06ZJhmxEjRlCuXDlat24NwJkzZ0hJSaF06dJO7UqXLs2pU6cy3M/kyZN1daHcutNH4P8Gwo7P7afrWvUGT2+rU4mIiItcLqBCQkJo0aIFHh7W/m85JiaGcePG8dlnnxEcHJxum6lTpxITE0NsbCxeXl5O6/7ei2aMSbdn7bqRI0cydOhQx/P4+HgqVKhwC69ACpWUFFj5GiweBz6B8Px/ZxW/wWdORETyLpcLqH79+nHu3Dnatm3Lgw8+SLt27ShevHgORMvYokWL6N27N0uWLHH0LP3d9OnTmTRpEl9//TV16tRxLC9ZsiTu7u5peptOnz6dplfqf3l6euLp6Zk9L0AKHzc3+HkdRPaFx8aDtyaaFRHJz1y+Cu/gwYNs2rSJ2rVrM3PmTMqUKUOrVq148803OXz4cA5EdBYTE0NUVBQLFy6kffv26baZNm0ar7zyCqtXr6Zhw4ZO64oWLcqdd97J2rVrnZavXbuWe+7RAF7JohP74KOR8Fo3+88T++DSeXi3L+z6yt7T9OIX8NRrKp5ERAoAl3ugAOrUqUOdOnUYNWoUJ06cYMWKFaxYsYIXXniBO+64gwcffJCOHTumKV7+7tKlS+zfv9/x/NChQ+zatYugoCBCQ0MZOXIkx48fd9x/LyYmhh49evDGG29w9913O3qRvL29CQgIAOyn7UaPHs3ChQsJCwtztPH19cXX1xeAoUOH8uSTT9KwYUOaNGnC+++/z9GjR+nXr19W3g4p7NZHwztP24skY+w/l78KXvbPGzXD7T/d3a3LKCIi2ctko0uXLpklS5aYJ5980pQoUcJMnDjxhu03bNhggDSPnj17GmOM6dmzpwkPD3e0Dw8Pv2F7Y4ypWLFium3Gjh3rdOy3337bVKxY0RQtWtQ0aNDAbNy40aXXGhcXZwATFxfn0nZSwBzfa0xnN2MeJv3H7m+tTigiIv8ju76/s/1WLgDHjx8nJCSEs2fPUqpUqezefZ6geaAEsJ+u+2wapKakXefmDg8OhycyN7eYiIjkvDx5K5dTp04xaNAgqlSpgpubW4EtnkQc/jgEJjWDlQZOH87NNCIikktcLqAuXLhA9+7dKVWqFGXLluXNN98kNTWVMWPGULlyZbZs2cK8efNyIqtI3mEM/PAl/Py1/c/p0r3sREQKKpcHkb/44ots2rSJnj17snr1av75z3+yevVqrl69ypdffkl4eHhO5BTJWz6dCDGjoUoj+9V26fVCGWOfKFNERAocl3ugvvjiC6Kjo5k+fTorVqzAGMMdd9zB+vXrVTxJwXbhD9i31f7nZt3g+WUw5d/Qfy7Y3Oxjntz++9PmZl8eUsXazCIikiNcHkTu4eHBkSNHKFu2LADFihVj69at1KpVK0cC5lUaRF6IJF6xzyK+bAqUqwqvbks7g/jJ/bBurn3MU3CYvedJxZOISJ5j2c2EU1NTnW7j4u7ujo+PT5YDiORZqanwzUL410iI+wPuGwiPjEr/9ishVXS1nYhIIeJyAWWMISoqynFbk6tXr9KvX780RdTSpUuzJ6GIVVKSYcnLcHtjeGKKepRERMTB5QKqZ8+eTs+feOKJbAsjYrmT++09To+9DOWr20/X+QRYnUpERPIYlwuo6OjonMghYq1L52HJK7B6FgSUhvOn7AWUiicREUlHlu6FJ1Kg7PoKXu8Gydegyzh44J/g6W11KhERycNcLqBatGiBLZ1BtAEBAVStWpUBAwZQoUKFbAknkmOMgXPHoUR5e09T067w6BgILGN1MhERyQdcLqDq1auX7vILFy6watUqZs2axbfffpthOxHLHfwB5g+FE3vh7QNQsgL84x2rU4mISD6S7TcTHjBgAIcOHWLVqlXZuds8R/NA5UNnf4eFL8HGD6FcdYiaAfXvszqViIjkIsvmgbqZvn370rZt2+zercitm/4onDoAfd6B1k+Du4YAiohI1mT7N4i3tzdXr17N7t2KuC4lBWIXQKX6ULk+DIiGoLJQTD2GIiJya1y+F97NfPXVV9xxxx3ZvVsR1/z4NQxvAO/0hl2r7cvKV1PxJCIi2cLlHqgVK1akuzwuLo5t27Yxd+5c5s+ff6u5RLLmz6Mwpz/s+AKq3gOTt8Adja1OJSIiBYzLBVSnTp3SXe7n50e1atWYP38+jz766K3mEnFNSrJ9TFNRL/v0BMMWQ5NH0r9vnYiIyC3K0s2ERfKMa1dh1Zvw1XswdTsEBMO0H1Q4iYhIjnJ5DFS7du2Ii4tzPJ84cSIXLlxwPD979iw1atTIlnAiGTIGvlsEz1aHf70IDdr9tU7Fk4iI5DCXC6jVq1eTmJjoeP7qq69y7tw5x/Pk5GT27NmTPelEMvJ/A+G1xyC0Nrz+Czz9FvgGWp1KREQKiVuexiCb5+EUsTuxD9bPg9OHITgMWvaCIh5w9RKE1oJWveHuzlC7pdVJRUSkENJMgpL3rI+Gd562n4ozxv5z2avg7g7174eRK6ByA6tTiohIIeZyAWWz2dLcTDi9mwuLZMmJffbiyaTC9c7N6z9TUqDbBKuSiYiIOLhcQBljiIqKwtPTE4CrV6/Sr18/fHx8AJzGR4m4bP28//Y8pbPOzQ2+jYGwOrkeS0RE5H+5XED17NnT6fkTTzyRpk2PHj2ynkgKt1P7IcOpMox9TJSIiIjFXC6goqOjcyKHCPy6EX76mvS7nwBs9gHlIiIiFsv2e+GJuOxyPLz3DIyJgDK3gS2Dj6Ux9qvvRERELKYCSqx3+hB8vwiengVTtkL/ufYiys3dPu7Jzd3+vP9cCKlidVoRERFsRhM5ZUl8fDwBAQHExcXh7+9vdZz8J/4MrHwNuo63z+905RJ4+/61/uR+WDf3r3mgWvVW8SQiIrcsu76/NQ+U5K7rt2CZOwhSU6BpVwir61w8gb1YemKyNRlFRERuQgWU5J6zx2FOf9i2Apo8Yj9lV7y01alERERcpgJKcs/ub2DfVhj+Kdz9sNVpREREskyDyCVnnToIS6fY/9y0K8zaq+JJRETyPRVQkjNSUmDl6/DPWrD2Pbh41j7DuLef1clERERumU7hSfY7+iu80xv2b4X7B8HjE9MOEhcREcnHVEBJ9vvmX3A5DiZ8A9WaWp1GREQk22keqCzSPFB/s38bHP0FWj4F167alxX1sjaTiIjI32TX97fGQMmtSbwMC4bDyLvh6zn2sU9FvVQ8iYhIgaZTeJJ1v26Ed56Gs8fg8UnQcRi4u1udSkREJMepgJKs+2w6BJaBFz+HclWtTiMiIpJrVECJa3Z8AUWKQt1IePYj+7QEbjoTLCIihYu++SRz4s/AG0/ApAfg24/ty3wCVDyJiEihpB4ouTGnm/+mwqAPIPwJq1OJiIhYSgWU3FjyNfh4DNRsAU+/pZv/ioiIoAJK0mMMrJsL1ZvbB4dP3gJ+QVanEhERyTM0gEWcnToI41vD7D6w43P7MhVPIiIiTtQDJXYpKbDqTVj4kv003Zi1ULe11alERETyJBVQYnfhFCweB5H/gG4TdPNfERGRG1ABVZglXbP3OkX+A0qUg7cPgH9Jq1OJiIjkeSqgCosT+2D9PDh9GILDoEpDWDQOjv8HylaFRh1UPImIiGSSCqjCYH20/Z51Npv9CjuM/WepivDqNqhUz+qEIiIi+YoKqILuxD578WRSwfxt3Zlj4KWxTiIiIq7SNAYF3fp59p6n9Nhs9vmeRERExCUqoAq604ftvU/pMvb1IiIi4hIVUIWB+fu5u+ts9gHlIiIi4hIVUAXZns2w7bOM1xsDrXrnXh4REZECQgVUQbY+Gm5rCH3fBZsbuLmD239/2tyg/1wIqWJ1ShERkXxHV+EVRCkp4O4O/5gN167YZxWv3co+YPz6PFCteqt4EhERySIVUAXNn0dhwv3Q7z2o3uyvW7KEVIEnJlubTUREpIBQAVWQXPgDxreGlGQIrmR1GhERkQJLBVRBcek8vNwGrl6CCd/a720nIiIiOUIFVEHxVk84dxxe3ghlKludRkREpECz9Cq8TZs20aFDB8qWLYvNZmP58uU3bL906VIiIyMpVaoU/v7+NGnShDVr1ji1+fXXX+ncuTNhYWHYbDZmzpyZZj/JycmMGjWKSpUq4e3tTeXKlXn55ZdJTc1owsl84MlXYdRqCK1pdRIREZECz9ICKiEhgbp16zJr1qxMtd+0aRORkZGsWrWKHTt20KJFCzp06MDOnTsdbS5fvkzlypWZMmUKZcqUSXc/r776Ku+++y6zZs1i9+7dTJ06lWnTpvHWW29ly+vKNclJsOQVuJoA5atDlYZWJxIRESkULD2Fd//993P//fdnuv3fe5MmTZrEZ599xsqVK6lfvz4AjRo1olGjRgCMGDEi3f1s3ryZBx98kPbt2wMQFhZGTEwM27dvz8KrsEhqKrz9FHy/GGpGQI3mVicSEREpNPL1RJqpqalcvHiRoKAgl7Zr1qwZ69atY+/evQD8+OOPfPvtt7Rr1y7DbRITE4mPj3d6WMYYmDMAvo2BZ/+l4klERCSX5etB5DNmzCAhIYEuXbq4tN0LL7xAXFwc1apVw93dnZSUFCZOnEi3bt0y3Gby5MmMHz/+ViPfOmPgoxHw1bv2mcTvedTqRCIiIoVOvu2BiomJYdy4cSxatIjg4GCXtl20aBEfffQRCxcu5IcffmDBggVMnz6dBQsWZLjNyJEjiYuLczyOHTt2qy8h64oFwFOvQ6te1mUQEREpxPJlD9SiRYvo3bs3S5YsoXXr1i5vP3z4cEaMGMFjjz0GQO3atTly5AiTJ0+mZ8+e6W7j6emJp6fnLeW+ZSf2QdnbofOL1uYQEREp5PJdD1RMTAxRUVEsXLjQMQjcVZcvX8bNzfmlu7u75+1pDGI/gGerwe5vrU4iIiJS6FnaA3Xp0iX279/veH7o0CF27dpFUFAQoaGhjBw5kuPHj/PBBx8A9uKpR48evPHGG9x9992cOnUKAG9vbwICAgC4du0av/32m+PPx48fZ9euXfj6+lKliv3muR06dGDixImEhoZSs2ZNdu7cyWuvvUavXnn0lNi/l9mvuGvZC6o1tTqNiIhIoWczxhirDh4bG0uLFi3SLO/Zsyfz588nKiqKw4cPExsbC0BERAQbN27MsD3A4cOHqVQp7X3gwsPDHfu5ePEio0ePZtmyZZw+fZqyZcvSrVs3xowZQ9GiRTOVPT4+noCAAOLi4vD398/cC86KH9fCpAeg8UP2K+7c3XPuWCIiIgVcdn1/W1pA5We5UkAZAy81BZ9AeH4ZeGSuuBMREZH0Zdf3d74cRF4oGAM2G7z4BXh4qXgSERHJQ/LdIPJC4ff/wEvN4PQR8A0ET2+rE4mIiMj/UAGV15w+DC9HwuU48Pa1Oo2IiIikQwVUXnL+JIxvDUWKwti14FfC6kQiIiKSDo2ByitSUmBie7h2FSZ8A4EhVicSERGRDKiAyivc3eGxl6HMbVA67TQMIiIiknfoFJ7VEq/AmnftV901fADKV7c6kYiIiNyECigrJSfBjC4wfyic3Gd1GhEREckkncKzSkoKvNkDflwDI1ZC2TusTiQiIiKZpALKCsbA+8/A5sUwdDHUb2t1IhEREXGBTuFZISUZEs5D/3nQpLPVaURERMRF6oHKbedPQWAZGLbYfqsWERERyXfUA5WbPn8DBt1hv0WLiicREZF8SwVUblkfDdFDILIvlAq1Oo2IiIjcAhVQuWHzJzD7aYj8B/SYqt4nERGRfE4FVE5LvAxzB0OTLtDnHRVPIiIiBYAGkec0z2L2e9uVDLXfrkVERETyPfVA5ZSDP8D0LvYeqDK3QREPqxOJiIhINlEBlRN+3w2vtIUzRyA1xeo0IiIiks1UQGW3Pw7B+NZQPARe+hK8/axOJCIiItlMBVR2SoizF09Fi8GYr8AvyOpEIiIikgM0iDw7FfOH+wdC44fts42LiIhIgaQeqOxwOR52fGGfoqDDPyG4otWJREREJAepB+pWLXwJDv4b/tgP7xwEn+JWJxIREZEcpgLqVq2aBR5A5xdVPImIiBQSOoWXXZZOgZP7rU4hIiIiuUAFVHax2WDdXKtTiIiISC5QAZVtDJw+bHUIERERyQUqoLKNDYLDrA4hIiIiuUAFVHYxBlr1tjqFiIiI5AJdhXer3NzABvSfCyFVrE4jIiIiuUAF1K1q/yw80F/Fk4iISCGiAupWdR0H/v5WpxAREZFcpDFQIiIiIi5SASUiIiLiIhVQIiIiIi5SASUiIiLiIhVQIiIiIi5SASUiIiLiIhVQIiIiIi5SASUiIiLiIhVQIiIiIi5SASUiIiLiIhVQIiIiIi5SASUiIiLiIhVQIiIiIi5SASUiIiLiIhVQIiIiIi5SASUiIiLiIhVQIiIiIi5SASUiIiLiIhVQIiIiIi5SASUiIiLiIhVQIiIiIi5SASUiIiLiIhVQIiIiIi5SASUiIiLiIhVQIiIiIi5SASUiIiLiIhVQIiIiIi5SASUiIiLiIhVQIiIiIi6ytIDatGkTHTp0oGzZsthsNpYvX37D9kuXLiUyMpJSpUrh7+9PkyZNWLNmjVObX3/9lc6dOxMWFobNZmPmzJnp7uv48eM88cQTlChRgmLFilGvXj127NiRTa9MRERECjJLC6iEhATq1q3LrFmzMtV+06ZNREZGsmrVKnbs2EGLFi3o0KEDO3fudLS5fPkylStXZsqUKZQpUybd/Zw/f56mTZvi4eHBl19+yW+//caMGTMoXrx4drwsERERKeBsxhhjdQgAm83GsmXL6NSpk0vb1axZk65duzJmzJg068LCwhgyZAhDhgxxWj5ixAi+++47vvnmmyznjY+PJyAggLi4OPz9/bO8HxEREck92fX9na/HQKWmpnLx4kWCgoJc2m7FihU0bNiQRx99lODgYOrXr8+cOXNuuE1iYiLx8fFODxERESmc8nUBNWPGDBISEujSpYtL2x08eJDZs2dz++23s2bNGvr168fgwYP54IMPMtxm8uTJBAQEOB4VKlS41fgiIiKST+XbAiomJoZx48axaNEigoODXdo2NTWVBg0aMGnSJOrXr0/fvn3p06cPs2fPznCbkSNHEhcX53gcO3bsVl+CiIiI5FP5soBatGgRvXv3ZvHixbRu3drl7UNCQqhRo4bTsurVq3P06NEMt/H09MTf39/pISIiIoVTviugYmJiiIqKYuHChbRv3z5L+2jatCl79uxxWrZ3714qVqyYHRFFRESkgCti5cEvXbrE/v37Hc8PHTrErl27CAoKIjQ0lJEjR3L8+HHH2KSYmBh69OjBG2+8wd13382pU6cA8Pb2JiAgAIBr167x22+/Of58/Phxdu3aha+vL1WqVAHgn//8J/fccw+TJk2iS5cubN26lffff5/3338/N1++iIiI5FOWTmMQGxtLixYt0izv2bMn8+fPJyoqisOHDxMbGwtAREQEGzduzLA9wOHDh6lUqVKaNuHh4Y79AHz++eeMHDmSffv2UalSJYYOHUqfPn0ynV3TGIiIiOQ/2fX9nWfmgcpvVECJiIjkP5oHSkRERMQiKqBEREREXKQCSkRERMRFKqBEREREXKQCSkRERMRFKqBEREREXKQCSkRERMRFKqBEREREXKQCSkRERMRFlt4Lr0BISAB3d6tTiIiISGYkJGTLblRA3aqyZa1OICIiIrlMp/BEREREXKQeqFt14gToZsIiIiL5Q3x8tpw9UgF1q3x87A8RERHJ+1JSsmU3OoUnIiIi4iIVUCIiIiIuUgElIiIi4iIVUCIiIiIuUgElIiIi4iIVUCIiIiIuUgElIiIi4iIVUCIiIiIuUgElIiIi4iIVUCIiIiIuUgElIiIi4iIVUCIiIiIuUgElIiIi4iIVUCIiIiIuUgElIiIi4qIiVgfIr4wxAMTHx1ucRERERDLr+vf29e/xrFIBlUVnz54FoEKFChYnEREREVedPXuWgICALG+vAiqLgoKCADh69Ogt/QJyU3x8PBUqVODYsWP4+/tbHeemlDfn5bfM+S2v5Dx9JsRVcXFxhIaGOr7Hs0oFVBa5udmHjwUEBOS7v7T+/v75KrPy5rz8ljm/5ZWcp8+EuOr693iWt8+mHCIiIiKFhgooERERERepgMoiT09Pxo4di6enp9VRMi2/ZVbenJffMue3vJLz9JkQV2XXZ8ZmbvU6PhEREZFCRj1QIiIiIi5SASUiIiLiIhVQIiIiIi5SASUiIiLiIhVQIiIiIi5SASUiIiLiIhVQIiIiUmBdunQpR/areaAKqJdffjlT7caMGZPDSQomvb85T++x/J0+E5IVlSpVYsGCBdx7773Zul8VUJmU3/7iurm5UbZsWYKDg8noV2yz2fjhhx9yOVn69P7mPL3Hkt/pMyFZ8fzzzzNz5kwGDRrEpEmTsm3WehVQmZTf/uK2a9eODRs20LZtW3r16kX79u1xd3e3OlaG9P7mPL3Hkt/pMyFZtWXLFnr16oXNZuPDDz+kQYMGt7xPFVCZlB//4p48eZL58+czf/584uPj6dGjB7169aJq1apWR0tD72/O03ssBYE+E5JViYmJjBo1ilmzZhEZGUmRIkWc1i9dutSl/WkQeSatWrWKgwcP0rhxY4YPH0758uV54YUX2LNnj9XRMhQSEsLIkSPZs2cPixYt4vTp0zRq1IimTZty5coVq+M50fub8/QeS0Ggz4RkVWJiIqdPn8ZmsxEQEJDm4TIjWbJx40YTFRVl/Pz8zD333GMuX75sdaQbunz5slmwYIG56667jLe3t4mLi7M60g3p/c15eo8lv9NnQjJrzZo1pnz58uauu+4yu3fvzpZ9qgcqixo1akSLFi2oXr06O3fuJCkpyepI6dq8eTN9+vShTJkyvPXWW/Ts2ZMTJ07g7+9vdbQb0vub8/QeS36lz4S4om/fvnTs2JE+ffrw/fffU61atezZcbaUYYXI999/b55++mnj7+9vGjZsaN5++21z/vx5q2Ol8eqrr5pq1aqZUqVKmSFDhpiffvrJ6kiZovc35+k9lvxKnwnJipo1a5odO3Zk+341iDyTpk6dSnR0NGfPnqV79+706tWL2rVrWx0rQ25uboSGhvLAAw9QtGjRDNu99tpruZgqY3p/c57eY8nv9JmQrLh27doNPy/Hjh1j7NixzJs3z6X9qoDKpPz2FzciIgKbzXbDNjabjfXr1+dSohvT+5vz9B5LfqfPhOSEH3/8kQYNGpCSkuLSdiqgMikzf3EBNmzYkAtpCp6C8g+jMSZTnxMrFJT3WETEFStWrLjh+oMHDzJs2DAVUCJWKlq0KD/++CPVq1e3OopIgXTy5Elmz57Nt99+y8mTJ3F3d6dSpUp06tSJqKioPD+3meQ+Nzc3bDZbhhMIg/0/j64WUEVu3kQyI6vnUHPSlStX2LFjB0FBQdSoUcNp3dWrV1m8eDE9evSwKF1au3fvZsuWLdxzzz1UrVqV//znP7zxxhskJibyxBNP0LJlS6sjOgwdOjTd5SkpKUyZMoUSJUoAeed0WHrOnz/PggUL2LdvH2XLlqVnz56UL1/e6lgOO3fupHjx4lSqVAmAjz76iNmzZ3P06FEqVqzIwIEDeeyxxyxOKblp+/bttG7dmkqVKuHt7c3evXvp3r07165d47nnnmPu3LmsWbMGPz8/q6NKHhISEsLbb79Np06d0l2/a9cu7rzzTtd3nO3D0gupXbt2GTc3N6tjOOzZs8dUrFjR2Gw24+bmZsLDw82JEycc60+dOpWn8n755ZemaNGiJigoyHh5eZkvv/zSlCpVyrRu3dq0atXKFClSxKxbt87qmA42m83Uq1fPREREOD1sNptp1KiRiYiIMC1atLA6ppOQkBBz5swZY4wxBw8eNGXKlDFlypQxkZGRpnz58iYgICDb5kfJDvXr1zfr1683xhgzZ84c4+3tbQYPHmxmz55thgwZYnx9fc3cuXMtTim5qWnTpmbcuHGO5x9++KFp3LixMcaYc+fOmXr16pnBgwdbFU/yqA4dOpjRo0dnuH7Xrl3GZrO5vF+dwsuknDqHmlMeeughkpOTiY6O5sKFCwwdOpRffvmF2NhYQkND+eOPPyhbtmyeyXvPPffQsmVLJkyYwMcff0z//v155plnmDhxIgAvvfQS27Zt46uvvrI4qd3kyZOZM2cO//d//+fUM+bh4cGPP/6YpscvL3Bzc+PUqVMEBwfTrVs3Tp06xRdffEGxYsVITEzkkUcewcvLiyVLllgdFQAfHx92795NaGgoDRo0oF+/fvzjH/9wrF+4cCETJ07k119/tTCl5KZixYrxyy+/ULlyZQBSU1Px8vLi2LFjlC5dmrVr1xIVFcXx48ctTip5yTfffENCQgL33XdfuusTEhLYvn074eHhru046zVd4XK9J8dms2X4yEs9OsHBwWnmSOnfv78JDQ01Bw4cyHM9UP7+/mbfvn3GGGNSUlJMkSJFnObt+Pnnn03p0qWtipeurVu3mjvuuMMMGzbMXLt2zRhjTJEiRcyvv/5qcbL02Ww288cffxhjjKlUqVKaHr0tW7aY8uXLWxEtXSVKlDDbt283xtg/z7t27XJav3//fuPt7W1FNLFIxYoVzbfffut4fuLECWOz2Ryz6B86dMh4eXlZFU8KGc1EnkkhISF8+umnpKampvvIK3ewv+7KlStpbpT49ttv07FjR8LDw9m7d69FyW7Ozc0NLy8vihcv7ljm5+dHXFycdaHS0ahRI3bs2MGff/5Jw4YN+fnnn/PsFXjXXc+XmJhI6dKlndaVLl2aP//804pY6br//vuZPXs2AOHh4XzyySdO6xcvXkyVKlWsiCYW6dSpE/369WP16tVs2LCB7t27Ex4ejre3NwB79uyhXLlyFqeUwkKDyDPpzjvv5IcffshwENrNRvjntmrVqrF9+/Y0V4O99dZbGGPo2LGjRcnSFxYWxv79+x1fiJs3byY0NNSx/tixY4SEhFgVL0O+vr4sWLCAjz/+mMjIyDxzSjQjrVq1okiRIsTHx7N3715q1qzpWHf06FFKlixpYTpnr776Kk2bNiU8PJyGDRsyY8YMYmNjqV69Onv27GHLli0sW7bM6piSiyZMmMDJkyfp0KEDKSkpNGnShI8++six3mazMXnyZAsTSmGiAiqThg8fTkJCQobrq1SpkqfmgHrooYeIiYnhySefTLNu1qxZpKam8u6771qQLH3PPPOMU/FRq1Ytp/VffvllnroK7+8ee+wxmjVrxo4dO6hYsaLVcdI1duxYp+fFihVzer5y5UqaN2+em5FuqGzZsuzcuZMpU6awcuVKjDFs3bqVY8eO0bRpU7777jsaNmxodUzJRb6+vixatIirV6+SnJyMr6+v0/o2bdpYlEwKIw0iFxEREXGRxkCJiIiIuEgFlIiIiIiLVECJiIiIuEgFlIiIiIiLVECJiIiIuEgFlIiIiIiLVECJiIiIuOj/Aby7l7D4Ra8HAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -1288,23 +1565,74 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 24,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:21:59.717233500Z",
+     "start_time": "2024-07-01T14:21:58.758020100Z"
+    },
     "pycharm": {
      "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:15.065446Z",
-     "start_time": "2024-03-18T18:02:12.855098Z"
     }
    },
    "outputs": [
     {
      "data": {
-      "text/plain": "                   InstrumentName      ClientInternal  \\\n0  EUR/USD 6M FX Forward 20210720  FWD-EURUSD20210720   \n\n   Market Value (Portfolio Currency)  Forward Rate (Interpolated)  \\\n0                         5,319.0608                       1.2220   \n\n   FX Spot Rate  Holding/default/Units  PnL (1-day)  \n0        1.2171                 1.0000     570.1016  ",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>InstrumentName</th>\n      <th>ClientInternal</th>\n      <th>Market Value (Portfolio Currency)</th>\n      <th>Forward Rate (Interpolated)</th>\n      <th>FX Spot Rate</th>\n      <th>Holding/default/Units</th>\n      <th>PnL (1-day)</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>EUR/USD 6M FX Forward 20210720</td>\n      <td>FWD-EURUSD20210720</td>\n      <td>5,319.0608</td>\n      <td>1.2220</td>\n      <td>1.2171</td>\n      <td>1.0000</td>\n      <td>570.1016</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>InstrumentName</th>\n",
+       "      <th>ClientInternal</th>\n",
+       "      <th>Market Value (Portfolio Currency)</th>\n",
+       "      <th>Forward Rate (Interpolated)</th>\n",
+       "      <th>FX Spot Rate</th>\n",
+       "      <th>Holding/default/Units</th>\n",
+       "      <th>PnL (1-day)</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>EUR/USD 6M FX Forward 20210720</td>\n",
+       "      <td>FWD-EURUSD20210720</td>\n",
+       "      <td>5,319.0608</td>\n",
+       "      <td>1.2220</td>\n",
+       "      <td>1.2171</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>570.1016</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                   InstrumentName      ClientInternal  \\\n",
+       "0  EUR/USD 6M FX Forward 20210720  FWD-EURUSD20210720   \n",
+       "\n",
+       "   Market Value (Portfolio Currency)  Forward Rate (Interpolated)  \\\n",
+       "0                         5,319.0608                       1.2220   \n",
+       "\n",
+       "   FX Spot Rate  Holding/default/Units  PnL (1-day)  \n",
+       "0        1.2171                 1.0000     570.1016  "
+      ]
      },
-     "execution_count": 26,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1346,23 +1674,77 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 25,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:22:00.328073100Z",
+     "start_time": "2024-07-01T14:21:59.691235100Z"
+    },
     "pycharm": {
      "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:16.728291Z",
-     "start_time": "2024-03-18T18:02:15.066318Z"
     }
    },
    "outputs": [
     {
      "data": {
-      "text/plain": "  Leg Currency                  InstrumentName  \\\n0          EUR  EUR/USD 6M FX Forward 20210720   \n1          USD  EUR/USD 6M FX Forward 20210720   \n\n   Market Value (Portfolio Currency)  Forward Rate (Interpolated) FX Spot Rate  \n0                     1,000,000.0000                       1.2220         None  \n1                      -994,680.9392                       1.2220         None  ",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>Leg Currency</th>\n      <th>InstrumentName</th>\n      <th>Market Value (Portfolio Currency)</th>\n      <th>Forward Rate (Interpolated)</th>\n      <th>FX Spot Rate</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>EUR</td>\n      <td>EUR/USD 6M FX Forward 20210720</td>\n      <td>1,000,000.0000</td>\n      <td>1.2220</td>\n      <td>None</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>USD</td>\n      <td>EUR/USD 6M FX Forward 20210720</td>\n      <td>-994,680.9392</td>\n      <td>1.2220</td>\n      <td>None</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Leg Currency</th>\n",
+       "      <th>InstrumentName</th>\n",
+       "      <th>Market Value (Portfolio Currency)</th>\n",
+       "      <th>Forward Rate (Interpolated)</th>\n",
+       "      <th>FX Spot Rate</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>EUR</td>\n",
+       "      <td>EUR/USD 6M FX Forward 20210720</td>\n",
+       "      <td>1,000,000.0000</td>\n",
+       "      <td>1.2220</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>USD</td>\n",
+       "      <td>EUR/USD 6M FX Forward 20210720</td>\n",
+       "      <td>-994,680.9392</td>\n",
+       "      <td>1.2220</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  Leg Currency                  InstrumentName  \\\n",
+       "0          EUR  EUR/USD 6M FX Forward 20210720   \n",
+       "1          USD  EUR/USD 6M FX Forward 20210720   \n",
+       "\n",
+       "   Market Value (Portfolio Currency)  Forward Rate (Interpolated) FX Spot Rate  \n",
+       "0                     1,000,000.0000                       1.2220         None  \n",
+       "1                      -994,680.9392                       1.2220         None  "
+      ]
      },
-     "execution_count": 27,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1406,23 +1788,74 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 26,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:22:01.221431500Z",
+     "start_time": "2024-07-01T14:22:00.313066700Z"
+    },
     "pycharm": {
      "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:18.855923Z",
-     "start_time": "2024-03-18T18:02:16.728946Z"
     }
    },
    "outputs": [
     {
      "data": {
-      "text/plain": "                   InstrumentName      ClientInternal  \\\n0  EUR/USD 6M FX Forward 20210720  FWD-EURUSD20210720   \n\n   Market Value (Portfolio Currency)  Forward Rate (Interpolated)  \\\n0                         1,068.3583                       1.2168   \n\n   FX Spot Rate  Holding/default/Units  PnL (1-day)  \n0        1.2119                 1.0000   2,221.4566  ",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>InstrumentName</th>\n      <th>ClientInternal</th>\n      <th>Market Value (Portfolio Currency)</th>\n      <th>Forward Rate (Interpolated)</th>\n      <th>FX Spot Rate</th>\n      <th>Holding/default/Units</th>\n      <th>PnL (1-day)</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>EUR/USD 6M FX Forward 20210720</td>\n      <td>FWD-EURUSD20210720</td>\n      <td>1,068.3583</td>\n      <td>1.2168</td>\n      <td>1.2119</td>\n      <td>1.0000</td>\n      <td>2,221.4566</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>InstrumentName</th>\n",
+       "      <th>ClientInternal</th>\n",
+       "      <th>Market Value (Portfolio Currency)</th>\n",
+       "      <th>Forward Rate (Interpolated)</th>\n",
+       "      <th>FX Spot Rate</th>\n",
+       "      <th>Holding/default/Units</th>\n",
+       "      <th>PnL (1-day)</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>EUR/USD 6M FX Forward 20210720</td>\n",
+       "      <td>FWD-EURUSD20210720</td>\n",
+       "      <td>1,068.3583</td>\n",
+       "      <td>1.2168</td>\n",
+       "      <td>1.2119</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>2,221.4566</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                   InstrumentName      ClientInternal  \\\n",
+       "0  EUR/USD 6M FX Forward 20210720  FWD-EURUSD20210720   \n",
+       "\n",
+       "   Market Value (Portfolio Currency)  Forward Rate (Interpolated)  \\\n",
+       "0                         1,068.3583                       1.2168   \n",
+       "\n",
+       "   FX Spot Rate  Holding/default/Units  PnL (1-day)  \n",
+       "0        1.2119                 1.0000   2,221.4566  "
+      ]
      },
-     "execution_count": 28,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1442,14 +1875,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 27,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:22:01.988168600Z",
+     "start_time": "2024-07-01T14:22:01.212337300Z"
+    },
     "pycharm": {
      "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:19.156042Z",
-     "start_time": "2024-03-18T18:02:18.856760Z"
     }
    },
    "outputs": [
@@ -1457,7 +1890,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Transaction successfully updated at time: 2024-03-18 18:02:19.116261+00:00\n"
+      "Transaction successfully updated at time: 2024-07-01 15:11:03.924946+00:00\n"
      ]
     }
    ],
@@ -1508,14 +1941,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 28,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:22:02.291628900Z",
+     "start_time": "2024-07-01T14:22:01.897877Z"
+    },
     "pycharm": {
      "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:19.286780Z",
-     "start_time": "2024-03-18T18:02:19.156667Z"
     }
    },
    "outputs": [
@@ -1523,7 +1956,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "LUID_0000FMOX\n"
+      "LUID_00003D9O\n"
      ]
     }
    ],
@@ -1569,14 +2002,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 29,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:22:02.761790300Z",
+     "start_time": "2024-07-01T14:22:02.283644100Z"
+    },
     "pycharm": {
      "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:19.768114Z",
-     "start_time": "2024-03-18T18:02:19.290736Z"
     }
    },
    "outputs": [
@@ -1584,7 +2017,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Transaction successfully updated at time: 2024-03-18 18:02:19.697192+00:00\n"
+      "Transaction successfully updated at time: 2024-07-01 15:11:03.924946+00:00\n"
      ]
     }
    ],
@@ -1618,64 +2051,138 @@
     }
    },
    "source": [
-    "# 7.2 Upsertable Cash Flows\n",
+    "# 7.2 Queryable Cash Flows\n",
     "\n",
-    "For the instrument's life cycle events, LUSID has a native cash flows API end point that allows a user to query upcoming portfolio flows. The example below shows an example that retrieves the cash flows occurring at maturity for the FX forward, as shown below for both the EUR and USD legs.\n",
+    "You can enable LUSID to automatically emit lifecycle events for certain instruments, including FxForward instruments.  For more information, see [Understanding instrument lifecycle events emitted by LUSID](https://support.lusid.com/knowledgebase/article/KA-02277/). \n",
     "\n",
-    "Notice that the results of the _UpsertableCashFlows_ call will be composed of headers that match an _UpsertTransactions_ payload, which means it can be used to execute life cycle events as part of a scripted process."
+    "The example below uses the _InstrumentEventsApi_ to query cash flows for the portfolio, returning rows for both the USD and EUR legs of the FxForward instrument held in the portfolio."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 30,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:22:04.145306Z",
+     "start_time": "2024-07-01T14:22:02.766790200Z"
+    },
     "pycharm": {
      "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:21.968074Z",
-     "start_time": "2024-03-18T18:02:19.768811Z"
     }
    },
    "outputs": [
     {
      "data": {
-      "text/plain": "                                      transaction_id       type  \\\n0  TXN003-LUID_0000FMOX-20210819-Principal-EUR-Re...  Principal   \n1    TXN003-LUID_0000FMOX-20210819-Principal-USD-Pay  Principal   \n\n  instrument_identifiers.Instrument/default/LusidInstrumentId  \\\n0                                      LUID_0000FMOX            \n1                                      LUID_0000FMOX            \n\n  instrument_scope instrument_uid          transaction_date  \\\n0          default  LUID_0000FMOX 2021-08-19 00:00:00+00:00   \n1          default  LUID_0000FMOX 2021-08-19 00:00:00+00:00   \n\n            settlement_date           units  transaction_price.price  \\\n0 2021-08-19 00:00:00+00:00  1,000,000.0000                   1.0000   \n1 2021-08-19 00:00:00+00:00 -1,216,800.0000                   1.0000   \n\n  transaction_price.type  total_consideration.amount  \\\n0                  Price              1,000,000.0000   \n1                  Price             -1,216,800.0000   \n\n  total_consideration.currency  exchange_rate transaction_currency  \\\n0                          EUR         1.0000                  EUR   \n1                          USD         1.0000                  USD   \n\n  properties.Transaction/default/ParentLuid.key  \\\n0                Transaction/default/ParentLuid   \n1                Transaction/default/ParentLuid   \n\n  properties.Transaction/default/ParentLuid.value.label_value  \\\n0                                      LUID_0000FMOX            \n1                                      LUID_0000FMOX            \n\n  properties.Transaction/default/InstrumentEventId.key  \\\n0              Transaction/default/InstrumentEventId     \n1              Transaction/default/InstrumentEventId     \n\n  properties.Transaction/default/InstrumentEventId.value.label_value   source  \\\n0    LUID_0000FMOX-20210819-Principal-EUR-Receive-v1                  default   \n1        LUID_0000FMOX-20210819-Principal-USD-Pay-v1                  default   \n\n             entry_date_time transaction_status  \n0  0001-01-01 00:00:00+00:00             Active  \n1  0001-01-01 00:00:00+00:00             Active  ",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>transaction_id</th>\n      <th>type</th>\n      <th>instrument_identifiers.Instrument/default/LusidInstrumentId</th>\n      <th>instrument_scope</th>\n      <th>instrument_uid</th>\n      <th>transaction_date</th>\n      <th>settlement_date</th>\n      <th>units</th>\n      <th>transaction_price.price</th>\n      <th>transaction_price.type</th>\n      <th>total_consideration.amount</th>\n      <th>total_consideration.currency</th>\n      <th>exchange_rate</th>\n      <th>transaction_currency</th>\n      <th>properties.Transaction/default/ParentLuid.key</th>\n      <th>properties.Transaction/default/ParentLuid.value.label_value</th>\n      <th>properties.Transaction/default/InstrumentEventId.key</th>\n      <th>properties.Transaction/default/InstrumentEventId.value.label_value</th>\n      <th>source</th>\n      <th>entry_date_time</th>\n      <th>transaction_status</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>TXN003-LUID_0000FMOX-20210819-Principal-EUR-Re...</td>\n      <td>Principal</td>\n      <td>LUID_0000FMOX</td>\n      <td>default</td>\n      <td>LUID_0000FMOX</td>\n      <td>2021-08-19 00:00:00+00:00</td>\n      <td>2021-08-19 00:00:00+00:00</td>\n      <td>1,000,000.0000</td>\n      <td>1.0000</td>\n      <td>Price</td>\n      <td>1,000,000.0000</td>\n      <td>EUR</td>\n      <td>1.0000</td>\n      <td>EUR</td>\n      <td>Transaction/default/ParentLuid</td>\n      <td>LUID_0000FMOX</td>\n      <td>Transaction/default/InstrumentEventId</td>\n      <td>LUID_0000FMOX-20210819-Principal-EUR-Receive-v1</td>\n      <td>default</td>\n      <td>0001-01-01 00:00:00+00:00</td>\n      <td>Active</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>TXN003-LUID_0000FMOX-20210819-Principal-USD-Pay</td>\n      <td>Principal</td>\n      <td>LUID_0000FMOX</td>\n      <td>default</td>\n      <td>LUID_0000FMOX</td>\n      <td>2021-08-19 00:00:00+00:00</td>\n      <td>2021-08-19 00:00:00+00:00</td>\n      <td>-1,216,800.0000</td>\n      <td>1.0000</td>\n      <td>Price</td>\n      <td>-1,216,800.0000</td>\n      <td>USD</td>\n      <td>1.0000</td>\n      <td>USD</td>\n      <td>Transaction/default/ParentLuid</td>\n      <td>LUID_0000FMOX</td>\n      <td>Transaction/default/InstrumentEventId</td>\n      <td>LUID_0000FMOX-20210819-Principal-USD-Pay-v1</td>\n      <td>default</td>\n      <td>0001-01-01 00:00:00+00:00</td>\n      <td>Active</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>source_transaction_id</th>\n",
+       "      <th>diagnostics.CashFlowType</th>\n",
+       "      <th>diagnostics.PayReceive</th>\n",
+       "      <th>source_instrument_id</th>\n",
+       "      <th>source_instrument_scope</th>\n",
+       "      <th>currency</th>\n",
+       "      <th>amount</th>\n",
+       "      <th>payment_date</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>TXN003</td>\n",
+       "      <td>Principal</td>\n",
+       "      <td>Receive</td>\n",
+       "      <td>LUID_00003D9O</td>\n",
+       "      <td>default</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>1,000,000.0000</td>\n",
+       "      <td>2021-08-19 00:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>TXN003</td>\n",
+       "      <td>Principal</td>\n",
+       "      <td>Pay</td>\n",
+       "      <td>LUID_00003D9O</td>\n",
+       "      <td>default</td>\n",
+       "      <td>USD</td>\n",
+       "      <td>1,216,800.0000</td>\n",
+       "      <td>2021-08-19 00:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  source_transaction_id diagnostics.CashFlowType diagnostics.PayReceive  \\\n",
+       "0                TXN003                Principal                Receive   \n",
+       "1                TXN003                Principal                    Pay   \n",
+       "\n",
+       "  source_instrument_id source_instrument_scope currency         amount  \\\n",
+       "0        LUID_00003D9O                 default      EUR 1,000,000.0000   \n",
+       "1        LUID_00003D9O                 default      USD 1,216,800.0000   \n",
+       "\n",
+       "               payment_date  \n",
+       "0 2021-08-19 00:00:00+00:00  \n",
+       "1 2021-08-19 00:00:00+00:00  "
+      ]
      },
-     "execution_count": 32,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "upsertable_cash_flows = transaction_portfolios_api.get_upsertable_portfolio_cash_flows(\n",
-    "    scope=scope,\n",
-    "    code=portfolio_code,\n",
-    "    effective_at=\"2021-02-21T12:00:00Z\",\n",
-    "    window_start=trade_date,\n",
-    "    window_end=maturity_date,\n",
-    "    recipe_id_scope=scope,\n",
-    "    recipe_id_code=net_recipe_code\n",
+    "cash_flows_response = instrument_events_api.query_cash_flows(\n",
+    "    query_cash_flows_request = lm.QueryCashFlowsRequest(\n",
+    "        window_start = trade_date,\n",
+    "        window_end = maturity_date,\n",
+    "        portfolio_entity_ids = [\n",
+    "            lm.PortfolioEntityId(\n",
+    "                scope = scope,\n",
+    "                code = portfolio_code\n",
+    "            )\n",
+    "        ],\n",
+    "        recipe_id = lm.ResourceId(\n",
+    "            scope = scope,\n",
+    "            code = net_recipe_code\n",
+    "        ),\n",
+    "        effective_at = \"2021-02-21T12:00:00Z\"\n",
+    "    )\n",
     ")\n",
     "\n",
-    "# we create a dataframe out of the cash flows table and drop some columns to improve readability\n",
-    "cash_flow_table = lusid_response_to_data_frame(upsertable_cash_flows)\n",
+    "# we create a dataframe out of the cash flows table and only keep certain columns to improve readability\n",
+    "cash_flow_table = lusid_response_to_data_frame(cash_flows_response)\n",
     "if(not cash_flow_table.empty):\n",
-    "    cash_flow_table[\n",
+    "    cash_flow_table = cash_flow_table[\n",
     "        [\n",
-    "            \"transaction_id\", \n",
-    "            \"type\", \n",
-    "            \"instrument_identifiers.Instrument/default/LusidInstrumentId\", \n",
-    "            \"instrument_scope\", \n",
-    "            \"transaction_date\", \n",
-    "            \"settlement_date\", \n",
-    "            \"total_consideration.amount\", \n",
-    "            \"total_consideration.currency\", \n",
-    "            \"source\", \n",
-    "            \"transaction_status\"\n",
+    "            \"source_transaction_id\",\n",
+    "            \"diagnostics.CashFlowType\",\n",
+    "            \"diagnostics.PayReceive\",\n",
+    "            \"source_instrument_id\",\n",
+    "            \"source_instrument_scope\",\n",
+    "            \"currency\",\n",
+    "            \"amount\",\n",
+    "            \"payment_date\"\n",
     "        ]\n",
     "    ]\n",
+    "\n",
     "cash_flow_table"
    ]
   },
@@ -1689,24 +2196,24 @@
    "source": [
     "# 7.3 At Maturity\n",
     "\n",
-    "The previous cash flows output can also be ingested as transaction in order for the portfolio holdings to reflect the settlement of 2 instrument cash flows. These are not booked automatically, but the process can be scripted for where needed, and run as a scheduled job in LUSID. This process that can be run periodically would consist of the following steps:\n",
-    "1. Retrieve upsertable cash flows.\n",
-    "2. Remove the zero cash flows\n",
-    "3. Book cash flows as transactions in order to adjust holdings.\n",
+    "At maturity of the FxForward instrument, we can use LUSID's instrument lifecycle events to automatically generate three transactions: two of transaction type `FxForwardPrincipal` (one for each leg of the FxForward) and one of transaction type `Maturity`.  For LUSID to generate these transactions, we must first define each of the transaction types.  \n",
     "\n",
-    "Below we upsert the previously seen cash flows below to show this taking place."
+    "The configuration details for these transaction types are based on instrument event transaction templates, which you can view by calling _ListTransactionTemplates_ with the _InstrumentEventTypesApi_.\n",
+    "\n",
+    "For the `FxForwardPrincipal` transaction type, we use the side we created at the start of this notebook."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 31,
    "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
     "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:22.453085Z",
-     "start_time": "2024-03-18T18:02:21.968726Z"
+     "end_time": "2024-07-01T14:22:04.380023100Z",
+     "start_time": "2024-07-01T14:22:04.133448400Z"
+    },
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
     }
    },
    "outputs": [
@@ -1714,27 +2221,92 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Transaction successfully updated at time: 2024-03-18 18:02:22.362077+00:00\n"
+      "Transaction type for FxForwardPrincipal successfully upserted\n"
      ]
     }
    ],
    "source": [
-    "# Set the instrument identifiers\n",
-    "non_zero_upsertable_cash_flows = []\n",
-    "\n",
-    "for x in upsertable_cash_flows.values:\n",
-    "    if(x.units != 0):\n",
-    "        x.instrument_identifiers = {\"Instrument/default/Currency\": x.transaction_currency}\n",
-    "        non_zero_upsertable_cash_flows.append(x)\n",
-    "\n",
-    "        # Upsert the transactions\n",
-    "response = transaction_portfolios_api.upsert_transactions(\n",
-    "    scope=scope,\n",
-    "    code=portfolio_code,\n",
-    "    transaction_request=non_zero_upsertable_cash_flows\n",
-    ")\n",
-    "\n",
-    "print(f\"Transaction successfully updated at time: {response.version.as_at_date}\")"
+    "try:\n",
+    "    set_txn_response = transaction_configuration_api.set_transaction_type(\n",
+    "        scope = scope,\n",
+    "        source = \"default\",\n",
+    "        type = \"FxForwardPrincipal\",\n",
+    "        transaction_type_request = lm.TransactionTypeRequest(\n",
+    "            aliases = [\n",
+    "                lm.TransactionTypeAlias(\n",
+    "                    type = \"FxForwardPrincipal\",\n",
+    "                    description = \"Reduces cash units to represent an FX Spot or Forward expiry / maturity\",\n",
+    "                    transaction_class = \"Fx\",\n",
+    "                    transaction_roles = \"Shorter\",\n",
+    "                    is_default = False\n",
+    "                )\n",
+    "            ],\n",
+    "            movements = [\n",
+    "                lm.TransactionTypeMovement(\n",
+    "                    movement_types = \"StockMovement\",\n",
+    "                    side = \"FxForwardPrincipal\",\n",
+    "                    direction = 1,\n",
+    "                    name = \"FxForwardPrincipal\"\n",
+    "                )\n",
+    "            ]\n",
+    "        )\n",
+    "    )\n",
+    "    print(\"Transaction type for FxForwardPrincipal successfully upserted\")\n",
+    "except lusid.ApiException as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:22:04.586003300Z",
+     "start_time": "2024-07-01T14:22:04.367937100Z"
+    },
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Transaction type for Maturity successfully upserted\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    set_txn_response = transaction_configuration_api.set_transaction_type(\n",
+    "        scope = scope,\n",
+    "        source = \"default\",\n",
+    "        type = \"Maturity\",\n",
+    "        transaction_type_request = lm.TransactionTypeRequest(\n",
+    "            aliases = [\n",
+    "                lm.TransactionTypeAlias(\n",
+    "                    type = \"Maturity\",\n",
+    "                    description = \"Maturity Event\",\n",
+    "                    transaction_class = \"Basic\",\n",
+    "                    transaction_roles = \"AllRoles\",\n",
+    "                    is_default = False\n",
+    "                )\n",
+    "            ],\n",
+    "            movements = [\n",
+    "                lm.TransactionTypeMovement(\n",
+    "                    name = \"MaturityEvent\",\n",
+    "                    movement_types = \"StockMovement\",\n",
+    "                    side = \"Side1\",\n",
+    "                    direction = -1,\n",
+    "                )\n",
+    "            ]\n",
+    "        )\n",
+    "    )\n",
+    "    print(\"Transaction type for Maturity successfully upserted\")\n",
+    "except lusid.ApiException as e:\n",
+    "    print(e)"
    ]
   },
   {
@@ -1745,26 +2317,264 @@
     }
    },
    "source": [
-    "With the cash transactions loaded into LUSID, we can now view our holdings as of the maturity date."
+    "With the required instrument event transaction types upserted to LUSID, we can see the resulting transactions by calling `BuildTransactions`.  The three transactions generated by LUSID instrument events have an auto-generated values for `transaction_id` and a `source_instrument_event_id` based on the instrument type and instrument's maturity date."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:22:05.608126700Z",
+     "start_time": "2024-07-01T14:22:04.573841100Z"
+    },
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>transaction_id</th>\n",
+       "      <th>source_instrument_event_id</th>\n",
+       "      <th>type</th>\n",
+       "      <th>instrument_uid</th>\n",
+       "      <th>transaction_date</th>\n",
+       "      <th>settlement_date</th>\n",
+       "      <th>total_consideration.amount</th>\n",
+       "      <th>total_consideration.currency</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>TXN001</td>\n",
+       "      <td>None</td>\n",
+       "      <td>StockIn</td>\n",
+       "      <td>LUID_00003D9L</td>\n",
+       "      <td>2021-01-20 00:00:00+00:00</td>\n",
+       "      <td>2021-01-22 00:00:00+00:00</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>USD</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>TXN002</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Sell</td>\n",
+       "      <td>LUID_00003D9L</td>\n",
+       "      <td>2021-02-19 12:00:00+00:00</td>\n",
+       "      <td>2021-02-21 12:00:00+00:00</td>\n",
+       "      <td>1,068.3583</td>\n",
+       "      <td>USD</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>TXN003</td>\n",
+       "      <td>None</td>\n",
+       "      <td>StockIn</td>\n",
+       "      <td>LUID_00003D9O</td>\n",
+       "      <td>2021-02-19 12:00:00+00:00</td>\n",
+       "      <td>2021-02-21 12:00:00+00:00</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>USD</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>LUID_00003D9O_FxForwardSettlementEvent_2021081...</td>\n",
+       "      <td>LUID_00003D9O_FxForwardSettlementEvent_20210819</td>\n",
+       "      <td>FxForwardPrincipal</td>\n",
+       "      <td>LUID_00003D9O</td>\n",
+       "      <td>2021-08-19 00:00:00+00:00</td>\n",
+       "      <td>2021-08-19 00:00:00+00:00</td>\n",
+       "      <td>1,000,000.0000</td>\n",
+       "      <td>EUR</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>LUID_00003D9O_FxForwardSettlementEvent_2021081...</td>\n",
+       "      <td>LUID_00003D9O_FxForwardSettlementEvent_20210819</td>\n",
+       "      <td>FxForwardPrincipal</td>\n",
+       "      <td>LUID_00003D9O</td>\n",
+       "      <td>2021-08-19 00:00:00+00:00</td>\n",
+       "      <td>2021-08-19 00:00:00+00:00</td>\n",
+       "      <td>-1,216,800.0000</td>\n",
+       "      <td>USD</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>LUID_00003D9O_MaturityEvent_20210819-68522294</td>\n",
+       "      <td>LUID_00003D9O_MaturityEvent_20210819</td>\n",
+       "      <td>Maturity</td>\n",
+       "      <td>LUID_00003D9O</td>\n",
+       "      <td>2021-08-19 00:00:00+00:00</td>\n",
+       "      <td>2021-08-19 00:00:00+00:00</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>USD</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                      transaction_id  \\\n",
+       "0                                             TXN001   \n",
+       "1                                             TXN002   \n",
+       "2                                             TXN003   \n",
+       "3  LUID_00003D9O_FxForwardSettlementEvent_2021081...   \n",
+       "4  LUID_00003D9O_FxForwardSettlementEvent_2021081...   \n",
+       "5      LUID_00003D9O_MaturityEvent_20210819-68522294   \n",
+       "\n",
+       "                        source_instrument_event_id                type  \\\n",
+       "0                                             None             StockIn   \n",
+       "1                                             None                Sell   \n",
+       "2                                             None             StockIn   \n",
+       "3  LUID_00003D9O_FxForwardSettlementEvent_20210819  FxForwardPrincipal   \n",
+       "4  LUID_00003D9O_FxForwardSettlementEvent_20210819  FxForwardPrincipal   \n",
+       "5             LUID_00003D9O_MaturityEvent_20210819            Maturity   \n",
+       "\n",
+       "  instrument_uid          transaction_date           settlement_date  \\\n",
+       "0  LUID_00003D9L 2021-01-20 00:00:00+00:00 2021-01-22 00:00:00+00:00   \n",
+       "1  LUID_00003D9L 2021-02-19 12:00:00+00:00 2021-02-21 12:00:00+00:00   \n",
+       "2  LUID_00003D9O 2021-02-19 12:00:00+00:00 2021-02-21 12:00:00+00:00   \n",
+       "3  LUID_00003D9O 2021-08-19 00:00:00+00:00 2021-08-19 00:00:00+00:00   \n",
+       "4  LUID_00003D9O 2021-08-19 00:00:00+00:00 2021-08-19 00:00:00+00:00   \n",
+       "5  LUID_00003D9O 2021-08-19 00:00:00+00:00 2021-08-19 00:00:00+00:00   \n",
+       "\n",
+       "   total_consideration.amount total_consideration.currency  \n",
+       "0                      1.0000                          USD  \n",
+       "1                  1,068.3583                          USD  \n",
+       "2                      1.0000                          USD  \n",
+       "3              1,000,000.0000                          EUR  \n",
+       "4             -1,216,800.0000                          USD  \n",
+       "5                      0.0000                          USD  "
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = lusid_response_to_data_frame(transaction_portfolios_api.build_transactions(\n",
+    "    scope = scope,\n",
+    "    code = portfolio_code,\n",
+    "    transaction_query_parameters = lm.TransactionQueryParameters(\n",
+    "        start_date = trade_date.strftime(\"%Y-%m-%d\"),\n",
+    "        end_date = maturity_date.strftime(\"%Y-%m-%d\")\n",
+    "    )\n",
+    "))\n",
+    "\n",
+    "# we create a dataframe out of the cash flows table and only keep certain columns to improve readability\n",
+    "df = df[\n",
+    "    [\n",
+    "        \"transaction_id\",\n",
+    "        \"source_instrument_event_id\",\n",
+    "        \"type\",\n",
+    "        \"instrument_uid\",\n",
+    "        \"transaction_date\",\n",
+    "        \"settlement_date\",\n",
+    "        \"total_consideration.amount\",\n",
+    "        \"total_consideration.currency\",\n",
+    "    ]\n",
+    "]\n",
+    "\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "We can also observe our holdings within the portfolio that include only the cash balances and the market value of each position."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 34,
    "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T14:22:06.786744600Z",
+     "start_time": "2024-07-01T14:22:05.558127500Z"
+    },
     "pycharm": {
      "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:23.669385Z",
-     "start_time": "2024-03-18T18:02:22.461594Z"
     }
    },
    "outputs": [
     {
      "data": {
-      "text/plain": "                   InstrumentName      ClientInternal  \\\n0  EUR/USD 6M FX Forward 20210819  FWD-EURUSD20210819   \n1                             USD                None   \n2                             EUR                None   \n\n   Market Value (Portfolio Currency)  Forward Rate (Interpolated)  \\\n0                       -37,163.5927                       1.1732   \n1                    -1,041,311.8987                          NaN   \n2                     1,000,000.0000                          NaN   \n\n   FX Spot Rate  Holding/default/Units  PnL (1-day)  \n0        1.1675                 1.0000  -3,172.8331  \n1           NaN        -1,215,731.6417       0.0000  \n2           NaN         1,000,000.0000       0.0000  ",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>InstrumentName</th>\n      <th>ClientInternal</th>\n      <th>Market Value (Portfolio Currency)</th>\n      <th>Forward Rate (Interpolated)</th>\n      <th>FX Spot Rate</th>\n      <th>Holding/default/Units</th>\n      <th>PnL (1-day)</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>EUR/USD 6M FX Forward 20210819</td>\n      <td>FWD-EURUSD20210819</td>\n      <td>-37,163.5927</td>\n      <td>1.1732</td>\n      <td>1.1675</td>\n      <td>1.0000</td>\n      <td>-3,172.8331</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>USD</td>\n      <td>None</td>\n      <td>-1,041,311.8987</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>-1,215,731.6417</td>\n      <td>0.0000</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>EUR</td>\n      <td>None</td>\n      <td>1,000,000.0000</td>\n      <td>NaN</td>\n      <td>NaN</td>\n      <td>1,000,000.0000</td>\n      <td>0.0000</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>InstrumentName</th>\n",
+       "      <th>Market Value (Portfolio Currency)</th>\n",
+       "      <th>Holding/default/Units</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>USD</td>\n",
+       "      <td>-1,041,311.8987</td>\n",
+       "      <td>-1,215,731.6417</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>EUR</td>\n",
+       "      <td>1,000,000.0000</td>\n",
+       "      <td>1,000,000.0000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  InstrumentName  Market Value (Portfolio Currency)  Holding/default/Units\n",
+       "0            USD                    -1,041,311.8987        -1,215,731.6417\n",
+       "1            EUR                     1,000,000.0000         1,000,000.0000"
+      ]
      },
      "execution_count": 34,
      "metadata": {},
@@ -1773,105 +2583,16 @@
    ],
    "source": [
     "df = get_daily_valuation(maturity_date, portfolio_code, net_recipe_code, metrics)\n",
-    "df"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
-   "source": [
-    "As we can see, we now have our cash balances within our portfolio holdings. However, we still hold a position in the FX forward position with a negative market value.\n",
     "\n",
-    "In order to remove the instrument from our holdings, we will need to add a transaction to reflect this. The default `StockOut` transaction can be used here as shown below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 35,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:23.996188Z",
-     "start_time": "2024-03-18T18:02:23.670042Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Transaction successfully updated at time: 2024-03-18 18:02:23.942714+00:00\n"
-     ]
-    }
-   ],
-   "source": [
-    "#Set trade variables\n",
-    "settle_days = 2\n",
-    "units = 1\n",
+    "# we create a dataframe out of the cash flows table and only keep certain columns to improve readability\n",
+    "df = df[\n",
+    "    [\n",
+    "        \"InstrumentName\",\n",
+    "        \"Market Value (Portfolio Currency)\",\n",
+    "        \"Holding/default/Units\"\n",
+    "    ]\n",
+    "]\n",
     "\n",
-    "# Book a StockOut transaction against the forward\n",
-    "fwd_txn = lm.TransactionRequest(\n",
-    "    transaction_id=\"TXN004\",\n",
-    "    type=\"StockOut\",\n",
-    "    instrument_identifiers={\"Instrument/default/ClientInternal\": forward_identifier2},\n",
-    "    transaction_date=(maturity_date + timedelta(days=1)).isoformat(),\n",
-    "    settlement_date=(maturity_date + timedelta(days=settle_days)).isoformat(),\n",
-    "    units=units,\n",
-    "    transaction_price=lm.TransactionPrice(price=1,type=\"Price\"),\n",
-    "    total_consideration=lm.CurrencyAndAmount(amount=1,currency=\"USD\"),\n",
-    "    exchange_rate=1,\n",
-    "    transaction_currency=\"USD\"\n",
-    ")\n",
-    "\n",
-    "response = transaction_portfolios_api.upsert_transactions(scope=scope,\n",
-    "                                                    code=portfolio_code,\n",
-    "                                                    transaction_request=[fwd_txn])\n",
-    "\n",
-    "print(f\"Transaction successfully updated at time: {response.version.as_at_date}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
-   "source": [
-    "We can now observe our holdings within the portfolio that include only the cash balances and the market value of each position."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 36,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2024-03-18T18:02:24.925837Z",
-     "start_time": "2024-03-18T18:02:23.996938Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": "  InstrumentName ClientInternal  Market Value (Portfolio Currency)  \\\n0            USD           None                    -1,039,264.5253   \n1            EUR           None                     1,000,000.0000   \n\n  Forward Rate (Interpolated) FX Spot Rate  Holding/default/Units  PnL (1-day)  \n0                        None         None        -1,215,731.6417       0.0000  \n1                        None         None         1,000,000.0000       0.0000  ",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>InstrumentName</th>\n      <th>ClientInternal</th>\n      <th>Market Value (Portfolio Currency)</th>\n      <th>Forward Rate (Interpolated)</th>\n      <th>FX Spot Rate</th>\n      <th>Holding/default/Units</th>\n      <th>PnL (1-day)</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>USD</td>\n      <td>None</td>\n      <td>-1,039,264.5253</td>\n      <td>None</td>\n      <td>None</td>\n      <td>-1,215,731.6417</td>\n      <td>0.0000</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>EUR</td>\n      <td>None</td>\n      <td>1,000,000.0000</td>\n      <td>None</td>\n      <td>None</td>\n      <td>1,000,000.0000</td>\n      <td>0.0000</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
-     },
-     "execution_count": 36,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df = get_daily_valuation(maturity_date + timedelta(days=settle_days), portfolio_code, net_recipe_code, metrics)\n",
     "df"
    ]
   }

--- a/examples/use-cases/instruments/FX Forward.ipynb
+++ b/examples/use-cases/instruments/FX Forward.ipynb
@@ -5,8 +5,8 @@
    "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:21:51.470407400Z",
-     "start_time": "2024-07-01T14:21:50.878173800Z"
+     "end_time": "2024-07-01T15:06:25.474029Z",
+     "start_time": "2024-07-01T15:06:25.407170800Z"
     },
     "collapsed": false,
     "jupyter": {
@@ -79,8 +79,8 @@
    "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:21:52.422667900Z",
-     "start_time": "2024-07-01T14:21:51.461409400Z"
+     "end_time": "2024-07-01T15:04:07.621282100Z",
+     "start_time": "2024-07-01T15:04:07.192309800Z"
     },
     "collapsed": false,
     "jupyter": {
@@ -157,8 +157,8 @@
    "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:21:52.424665600Z",
-     "start_time": "2024-07-01T14:21:52.419658800Z"
+     "end_time": "2024-07-01T15:04:07.622277700Z",
+     "start_time": "2024-07-01T15:04:07.569891200Z"
     },
     "collapsed": false,
     "jupyter": {
@@ -184,8 +184,8 @@
    "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:21:52.686403100Z",
-     "start_time": "2024-07-01T14:21:52.677406Z"
+     "end_time": "2024-07-01T15:04:07.623276100Z",
+     "start_time": "2024-07-01T15:04:07.570900200Z"
     },
     "collapsed": false,
     "jupyter": {
@@ -203,8 +203,8 @@
    "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:21:52.686403100Z",
-     "start_time": "2024-07-01T14:21:52.677406Z"
+     "end_time": "2024-07-01T15:04:07.650355500Z",
+     "start_time": "2024-07-01T15:04:07.590631100Z"
     },
     "collapsed": false,
     "jupyter": {
@@ -265,8 +265,8 @@
    "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:21:52.825567400Z",
-     "start_time": "2024-07-01T14:21:52.677406Z"
+     "end_time": "2024-07-01T15:04:07.900425400Z",
+     "start_time": "2024-07-01T15:04:07.590631100Z"
     },
     "collapsed": false,
     "jupyter": {
@@ -299,8 +299,7 @@
     "            units = \"Txn:TotalConsideration\",\n",
     "            currency = \"Txn:TradeCurrency\",\n",
     "            rate = \"Txn:TradeToPortfolioRate\",\n",
-    "            amount = \"Txn:TotalConsideration\",\n",
-    "            notional_amount = \"Transaction/default/NotionalAmount\"\n",
+    "            amount = \"Txn:TotalConsideration\"\n",
     "        ))\n",
     "]\n",
     "\n",
@@ -403,8 +402,8 @@
    "execution_count": 7,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:21:53.036540Z",
-     "start_time": "2024-07-01T14:21:52.824251700Z"
+     "end_time": "2024-07-01T15:04:08.029506900Z",
+     "start_time": "2024-07-01T15:04:07.883909700Z"
     },
     "collapsed": false,
     "jupyter": {
@@ -416,7 +415,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{\"name\":\"PortfolioWithIdAlreadyExists\",\"errorDetails\":[],\"code\":112,\"type\":\"https://docs.lusid.com/#section/Error-Codes/112\",\"title\":\"Could not create a portfolio with id 'FxForwardWithPipsCurve' because it already exists in scope 'fx-forward-notebook-example'.\",\"status\":400,\"detail\":\"Error creating portfolio with id 'FxForwardWithPipsCurve' in scope 'fx-forward-notebook-example' effective at 2010-01-01T00:00:00.0000000+00:00 because it already exists.\",\"instance\":\"https://fbn-kitk.lusid.com/app/insights/logs/0HN4PNII9LPIS:0000002C\",\"extensions\":{}}\n"
+      "{\"name\":\"PortfolioWithIdAlreadyExists\",\"errorDetails\":[],\"code\":112,\"type\":\"https://docs.lusid.com/#section/Error-Codes/112\",\"title\":\"Could not create a portfolio with id 'FxForwardWithPipsCurve' because it already exists in scope 'fx-forward-notebook-example'.\",\"status\":400,\"detail\":\"Error creating portfolio with id 'FxForwardWithPipsCurve' in scope 'fx-forward-notebook-example' effective at 2010-01-01T00:00:00.0000000+00:00 because it already exists.\",\"instance\":\"https://fbn-kitk.lusid.com/app/insights/logs/0HN4PS50N9HGG:0000003B\",\"extensions\":{}}\n"
      ]
     }
    ],
@@ -454,8 +453,8 @@
    "execution_count": 8,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:21:53.037541700Z",
-     "start_time": "2024-07-01T14:21:53.036540Z"
+     "end_time": "2024-07-01T15:04:08.055610100Z",
+     "start_time": "2024-07-01T15:04:08.016693800Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -506,8 +505,8 @@
     }
    },
    "source": [
-    "For this example we will be creating a 6M EUR/USD forward, with the following characteristics:\n",
-    "- Forward Exchange Rate (Strike): 1.21552025\n",
+    "For this example we will be creating a 6M USD/EUR forward, with the following characteristics:\n",
+    "- Forward Exchange Rate (Strike): 0.8226929992\n",
     "- Buy/Receive: EUR\n",
     "- Sell/Pay: USD\n",
     "- Start Date: 20 Jan 2021\n",
@@ -519,8 +518,8 @@
    "execution_count": 9,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:21:53.040540100Z",
-     "start_time": "2024-07-01T14:21:53.036540Z"
+     "end_time": "2024-07-01T15:04:08.057621600Z",
+     "start_time": "2024-07-01T15:04:08.016693800Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -529,16 +528,27 @@
    "outputs": [],
    "source": [
     "# Set the instrument variables\n",
-    "forward_name = \"EUR/USD 6M FX Forward 20210720\"\n",
-    "forward_identifier = \"FWD-EURUSD20210720\"\n",
     "identifier_type = \"ClientInternal\"\n",
-    "description = \"EUR/USD FX Forward 20210720\"\n",
     "start_date = datetime(2021, 1, 20, tzinfo=pytz.utc)\n",
     "maturity_date = datetime(2021, 7, 22, tzinfo=pytz.utc)\n",
-    "dom_ccy = \"EUR\"\n",
-    "fgn_ccy = \"USD\"\n",
-    "dom_amount = 1000000\n",
-    "fgn_amount = -1215520.25"
+    "####################################################################################################\n",
+    "#   ORIGINAL\n",
+    "# dom_ccy = \"EUR\"\n",
+    "# fgn_ccy = \"USD\"\n",
+    "# dom_amount = 1000000\n",
+    "# fgn_amount = -1215520.25\n",
+    "# forward_name = \"EUR/USD 6M FX Forward 20210720\"\n",
+    "# forward_identifier = \"FWD-EURUSD20210720\"\n",
+    "# description = \"EUR/USD FX Forward 20210720\"\n",
+    "####################################################################################################\n",
+    "#   NEW swap dom/fgn\n",
+    "dom_ccy = \"USD\"\n",
+    "fgn_ccy = \"EUR\"\n",
+    "dom_amount = -1215520.25\n",
+    "fgn_amount = 1000000\n",
+    "forward_name = \"USD/EUR 6M FX Forward 20210720\"\n",
+    "forward_identifier = \"FWD-USDEUR20210720\"\n",
+    "description = \"USD/EUR FX Forward 20210720\""
    ]
   },
   {
@@ -546,8 +556,8 @@
    "execution_count": 10,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:21:53.416924Z",
-     "start_time": "2024-07-01T14:21:53.036540Z"
+     "end_time": "2024-07-01T15:04:08.323157Z",
+     "start_time": "2024-07-01T15:04:08.016693800Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -558,7 +568,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "LUID_00003D9L\n"
+      "LUID_00003D9Q\n"
      ]
     }
    ],
@@ -593,8 +603,8 @@
    "execution_count": 11,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:21:54.233888600Z",
-     "start_time": "2024-07-01T14:21:53.421926800Z"
+     "end_time": "2024-07-01T15:04:08.798561300Z",
+     "start_time": "2024-07-01T15:04:08.283343500Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -605,7 +615,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Transaction successfully updated at time: 2024-07-01 15:11:03.924946+00:00\n"
+      "Transaction successfully updated at time: 2024-07-01 15:27:53.252276+00:00\n"
      ]
     }
    ],
@@ -624,9 +634,11 @@
     "    settlement_date=(trade_date + timedelta(days=settle_days)).isoformat(),\n",
     "    units=units,\n",
     "    transaction_price=lm.TransactionPrice(price=1,type=\"Price\"),\n",
-    "    total_consideration=lm.CurrencyAndAmount(amount=1,currency=\"USD\"),\n",
+    "    # total_consideration=lm.CurrencyAndAmount(amount=1,currency=\"USD\"), # swap dom/fgn\n",
+    "    total_consideration=lm.CurrencyAndAmount(amount=1,currency=\"EUR\"),\n",
     "    exchange_rate=1,\n",
-    "    transaction_currency=\"USD\"\n",
+    "    # transaction_currency=\"USD\" # swap dom/fgn\n",
+    "    transaction_currency=\"EUR\"\n",
     ")\n",
     "\n",
     "response = transaction_portfolios_api.upsert_transactions(scope=scope,\n",
@@ -663,8 +675,8 @@
    "execution_count": 12,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:21:54.292643600Z",
-     "start_time": "2024-07-01T14:21:54.234889100Z"
+     "end_time": "2024-07-01T15:04:08.857978400Z",
+     "start_time": "2024-07-01T15:04:08.812454200Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -759,8 +771,8 @@
    "execution_count": 13,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:21:54.907770Z",
-     "start_time": "2024-07-01T14:21:54.285264700Z"
+     "end_time": "2024-07-01T15:04:09.480306200Z",
+     "start_time": "2024-07-01T15:04:08.889034Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -815,7 +827,9 @@
    "source": [
     "# 4.2 FX Forward Curve\n",
     "\n",
-    "Next we will read in our FX forward curve data, and create a `ComplexMarketData` object that can be loaded into LUSID's market data store to be used for valuation. Notice, in this example our curve is composed of points rather than outrights, which are commonly referred to as pips as well. These will be added to the spot rate of the day a valuation is run, and need to be scaled so that they are in the correct order of magnitude."
+    "Next we will read in our FX forward curve data, and create a `ComplexMarketData` object that can be loaded into LUSID's market data store to be used for valuation. Notice, in this example our curve is \n",
+    "- composed of points rather than outrights, which are commonly referred to as pips as well. These will be added to the spot rate of the day a valuation is run, and need to be scaled so that they are in the correct order of magnitude.\n",
+    "- EUR/USD, which LUSID converts to USD/EUR for use with our USD/EUR FxForward instrument."
    ]
   },
   {
@@ -823,8 +837,8 @@
    "execution_count": 14,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:21:54.939659200Z",
-     "start_time": "2024-07-01T14:21:54.917775100Z"
+     "end_time": "2024-07-01T15:04:09.482304400Z",
+     "start_time": "2024-07-01T15:04:09.477306200Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -941,8 +955,8 @@
    "execution_count": 15,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:21:55.177592900Z",
-     "start_time": "2024-07-01T14:21:54.927492700Z"
+     "end_time": "2024-07-01T15:04:09.793855300Z",
+     "start_time": "2024-07-01T15:04:09.478305100Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -1011,8 +1025,8 @@
    "execution_count": 16,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:21:55.770149500Z",
-     "start_time": "2024-07-01T14:21:55.182581600Z"
+     "end_time": "2024-07-01T15:04:10.419155Z",
+     "start_time": "2024-07-01T15:04:09.798855100Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -1081,8 +1095,8 @@
    "execution_count": 17,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:21:55.771150700Z",
-     "start_time": "2024-07-01T14:21:55.751811600Z"
+     "end_time": "2024-07-01T15:04:10.420273900Z",
+     "start_time": "2024-07-01T15:04:10.405152800Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -1163,8 +1177,8 @@
    "execution_count": 18,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:21:56.334672800Z",
-     "start_time": "2024-07-01T14:21:55.755810200Z"
+     "end_time": "2024-07-01T15:04:10.742929Z",
+     "start_time": "2024-07-01T15:04:10.406158Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -1175,8 +1189,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Configuration recipe loaded into LUSID at time 2024-07-01 15:27:23.967658+00:00.\n",
-      "Configuration recipe loaded into LUSID at time 2024-07-01 15:27:24.200462+00:00.\n"
+      "Configuration recipe loaded into LUSID at time 2024-07-01 15:27:54.994629+00:00.\n",
+      "Configuration recipe loaded into LUSID at time 2024-07-01 15:27:55.424890+00:00.\n"
      ]
     }
    ],
@@ -1212,8 +1226,8 @@
    "execution_count": 19,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:21:56.336657500Z",
-     "start_time": "2024-07-01T14:21:56.293371100Z"
+     "end_time": "2024-07-01T15:04:10.777167700Z",
+     "start_time": "2024-07-01T15:04:10.745931100Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -1281,8 +1295,8 @@
    "execution_count": 20,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:21:57.132099300Z",
-     "start_time": "2024-07-01T14:21:56.299873900Z"
+     "end_time": "2024-07-01T15:04:11.865259600Z",
+     "start_time": "2024-07-01T15:04:10.752929300Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -1322,11 +1336,11 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>EUR/USD 6M FX Forward 20210720</td>\n",
-       "      <td>FWD-EURUSD20210720</td>\n",
+       "      <td>USD/EUR 6M FX Forward 20210720</td>\n",
+       "      <td>FWD-USDEUR20210720</td>\n",
        "      <td>0.0000</td>\n",
-       "      <td>1.2155</td>\n",
-       "      <td>1.2106</td>\n",
+       "      <td>0.8227</td>\n",
+       "      <td>0.8260</td>\n",
        "      <td>1.0000</td>\n",
        "      <td>None</td>\n",
        "    </tr>\n",
@@ -1336,13 +1350,13 @@
       ],
       "text/plain": [
        "                   InstrumentName      ClientInternal  \\\n",
-       "0  EUR/USD 6M FX Forward 20210720  FWD-EURUSD20210720   \n",
+       "0  USD/EUR 6M FX Forward 20210720  FWD-USDEUR20210720   \n",
        "\n",
        "   Market Value (Portfolio Currency)  Forward Rate (Interpolated)  \\\n",
-       "0                             0.0000                       1.2155   \n",
+       "0                             0.0000                       0.8227   \n",
        "\n",
        "   FX Spot Rate  Holding/default/Units PnL (1-day)  \n",
-       "0        1.2106                 1.0000        None  "
+       "0        0.8260                 1.0000        None  "
       ]
      },
      "execution_count": 20,
@@ -1372,8 +1386,8 @@
    "execution_count": 21,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:21:57.851877600Z",
-     "start_time": "2024-07-01T14:21:57.123100Z"
+     "end_time": "2024-07-01T15:04:12.484243700Z",
+     "start_time": "2024-07-01T15:04:11.905941200Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -1422,8 +1436,8 @@
    "execution_count": 22,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:22:24.059197300Z",
-     "start_time": "2024-07-01T14:22:23.101323300Z"
+     "end_time": "2024-07-01T15:04:13.312432100Z",
+     "start_time": "2024-07-01T15:04:12.448729100Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -1463,13 +1477,13 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>EUR/USD 6M FX Forward 20210720</td>\n",
-       "      <td>FWD-EURUSD20210720</td>\n",
-       "      <td>4,748.9592</td>\n",
-       "      <td>1.2213</td>\n",
-       "      <td>1.2164</td>\n",
+       "      <td>USD/EUR 6M FX Forward 20210720</td>\n",
+       "      <td>FWD-USDEUR20210720</td>\n",
+       "      <td>4,768.1684</td>\n",
+       "      <td>0.8188</td>\n",
+       "      <td>0.8221</td>\n",
        "      <td>1.0000</td>\n",
-       "      <td>4,748.9592</td>\n",
+       "      <td>4,768.1684</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1477,13 +1491,13 @@
       ],
       "text/plain": [
        "                   InstrumentName      ClientInternal  \\\n",
-       "0  EUR/USD 6M FX Forward 20210720  FWD-EURUSD20210720   \n",
+       "0  USD/EUR 6M FX Forward 20210720  FWD-USDEUR20210720   \n",
        "\n",
        "   Market Value (Portfolio Currency)  Forward Rate (Interpolated)  \\\n",
-       "0                         4,748.9592                       1.2213   \n",
+       "0                         4,768.1684                       0.8188   \n",
        "\n",
        "   FX Spot Rate  Holding/default/Units  PnL (1-day)  \n",
-       "0        1.2164                 1.0000   4,748.9592  "
+       "0        0.8221                 1.0000   4,768.1684  "
       ]
      },
      "execution_count": 22,
@@ -1520,8 +1534,8 @@
    "execution_count": 23,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:21:58.759021100Z",
-     "start_time": "2024-07-01T14:21:58.363020500Z"
+     "end_time": "2024-07-01T15:04:13.592414Z",
+     "start_time": "2024-07-01T15:04:13.310981Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -1568,8 +1582,8 @@
    "execution_count": 24,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:21:59.717233500Z",
-     "start_time": "2024-07-01T14:21:58.758020100Z"
+     "end_time": "2024-07-01T15:04:14.792292200Z",
+     "start_time": "2024-07-01T15:04:13.591046400Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -1609,13 +1623,13 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>EUR/USD 6M FX Forward 20210720</td>\n",
-       "      <td>FWD-EURUSD20210720</td>\n",
-       "      <td>5,319.0608</td>\n",
-       "      <td>1.2220</td>\n",
-       "      <td>1.2171</td>\n",
+       "      <td>USD/EUR 6M FX Forward 20210720</td>\n",
+       "      <td>FWD-USDEUR20210720</td>\n",
+       "      <td>5,340.5636</td>\n",
+       "      <td>0.8183</td>\n",
+       "      <td>0.8216</td>\n",
        "      <td>1.0000</td>\n",
-       "      <td>570.1016</td>\n",
+       "      <td>575.1376</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1623,13 +1637,13 @@
       ],
       "text/plain": [
        "                   InstrumentName      ClientInternal  \\\n",
-       "0  EUR/USD 6M FX Forward 20210720  FWD-EURUSD20210720   \n",
+       "0  USD/EUR 6M FX Forward 20210720  FWD-USDEUR20210720   \n",
        "\n",
        "   Market Value (Portfolio Currency)  Forward Rate (Interpolated)  \\\n",
-       "0                         5,319.0608                       1.2220   \n",
+       "0                         5,340.5636                       0.8183   \n",
        "\n",
        "   FX Spot Rate  Holding/default/Units  PnL (1-day)  \n",
-       "0        1.2171                 1.0000     570.1016  "
+       "0        0.8216                 1.0000     575.1376  "
       ]
      },
      "execution_count": 24,
@@ -1677,8 +1691,8 @@
    "execution_count": 25,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:22:00.328073100Z",
-     "start_time": "2024-07-01T14:21:59.691235100Z"
+     "end_time": "2024-07-01T15:04:15.465883400Z",
+     "start_time": "2024-07-01T15:04:14.782994500Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -1716,18 +1730,18 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>EUR</td>\n",
-       "      <td>EUR/USD 6M FX Forward 20210720</td>\n",
-       "      <td>1,000,000.0000</td>\n",
-       "      <td>1.2220</td>\n",
+       "      <td>USD</td>\n",
+       "      <td>USD/EUR 6M FX Forward 20210720</td>\n",
+       "      <td>-998,702.0376</td>\n",
+       "      <td>0.8183</td>\n",
        "      <td>None</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>USD</td>\n",
-       "      <td>EUR/USD 6M FX Forward 20210720</td>\n",
-       "      <td>-994,680.9392</td>\n",
-       "      <td>1.2220</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>USD/EUR 6M FX Forward 20210720</td>\n",
+       "      <td>1,004,042.6013</td>\n",
+       "      <td>0.8183</td>\n",
        "      <td>None</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -1736,12 +1750,12 @@
       ],
       "text/plain": [
        "  Leg Currency                  InstrumentName  \\\n",
-       "0          EUR  EUR/USD 6M FX Forward 20210720   \n",
-       "1          USD  EUR/USD 6M FX Forward 20210720   \n",
+       "0          USD  USD/EUR 6M FX Forward 20210720   \n",
+       "1          EUR  USD/EUR 6M FX Forward 20210720   \n",
        "\n",
        "   Market Value (Portfolio Currency)  Forward Rate (Interpolated) FX Spot Rate  \n",
-       "0                     1,000,000.0000                       1.2220         None  \n",
-       "1                      -994,680.9392                       1.2220         None  "
+       "0                      -998,702.0376                       0.8183         None  \n",
+       "1                     1,004,042.6013                       0.8183         None  "
       ]
      },
      "execution_count": 25,
@@ -1757,7 +1771,7 @@
     "    lm.AggregateSpec(\"Valuation/PV/Ccy\", \"Value\"),\n",
     "    lm.AggregateSpec(\"Valuation/PvInPortfolioCcy\", \"Value\"),\n",
     "    lm.AggregateSpec(\"Valuation/Diagnostics/FxForwardRate\", \"Value\"),\n",
-    "    lm.AggregateSpec(\"Quotes/FxRate/DomFgn\", \"Value\"),\n",
+    "    lm.AggregateSpec(\"Quotes/FxRate/DomFgn\", \"Value\")\n",
     "        ]\n",
     "\n",
     "df = get_daily_valuation(trade_date + timedelta(days=3), portfolio_code, sep_recipe_code, new_metrics, [\"Instrument/default/Name\",  \"Valuation/PvInPortfolioCcy\"])\n",
@@ -1791,8 +1805,8 @@
    "execution_count": 26,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:22:01.221431500Z",
-     "start_time": "2024-07-01T14:22:00.313066700Z"
+     "end_time": "2024-07-01T15:04:16.407157800Z",
+     "start_time": "2024-07-01T15:04:15.444818300Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -1832,13 +1846,13 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>EUR/USD 6M FX Forward 20210720</td>\n",
-       "      <td>FWD-EURUSD20210720</td>\n",
-       "      <td>1,068.3583</td>\n",
-       "      <td>1.2168</td>\n",
-       "      <td>1.2119</td>\n",
+       "      <td>USD/EUR 6M FX Forward 20210720</td>\n",
+       "      <td>FWD-USDEUR20210720</td>\n",
+       "      <td>1,072.6958</td>\n",
+       "      <td>0.8218</td>\n",
+       "      <td>0.8252</td>\n",
        "      <td>1.0000</td>\n",
-       "      <td>2,221.4566</td>\n",
+       "      <td>2,227.9066</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1846,13 +1860,13 @@
       ],
       "text/plain": [
        "                   InstrumentName      ClientInternal  \\\n",
-       "0  EUR/USD 6M FX Forward 20210720  FWD-EURUSD20210720   \n",
+       "0  USD/EUR 6M FX Forward 20210720  FWD-USDEUR20210720   \n",
        "\n",
        "   Market Value (Portfolio Currency)  Forward Rate (Interpolated)  \\\n",
-       "0                         1,068.3583                       1.2168   \n",
+       "0                         1,072.6958                       0.8218   \n",
        "\n",
        "   FX Spot Rate  Holding/default/Units  PnL (1-day)  \n",
-       "0        1.2119                 1.0000   2,221.4566  "
+       "0        0.8252                 1.0000   2,227.9066  "
       ]
      },
      "execution_count": 26,
@@ -1878,8 +1892,8 @@
    "execution_count": 27,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:22:01.988168600Z",
-     "start_time": "2024-07-01T14:22:01.212337300Z"
+     "end_time": "2024-07-01T15:04:17.120019600Z",
+     "start_time": "2024-07-01T15:04:16.413150500Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -1890,7 +1904,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Transaction successfully updated at time: 2024-07-01 15:11:03.924946+00:00\n"
+      "Transaction successfully updated at time: 2024-07-01 15:28:01.526115+00:00\n"
      ]
     }
    ],
@@ -1910,9 +1924,11 @@
     "    settlement_date=(unwind_date + timedelta(days=settle_days)).isoformat(),\n",
     "    units=units,\n",
     "    transaction_price=lm.TransactionPrice(price=1,type=\"Price\"),\n",
-    "    total_consideration=lm.CurrencyAndAmount(amount=market_val,currency=\"USD\"),\n",
+    "    # total_consideration=lm.CurrencyAndAmount(amount=market_val,currency=\"USD\"), # swap dom/fgn\n",
+    "    total_consideration=lm.CurrencyAndAmount(amount=market_val,currency=\"EUR\"),\n",
     "    exchange_rate=1,\n",
-    "    transaction_currency=\"USD\"\n",
+    "    # transaction_currency=\"USD\" # swap dom/fgn\n",
+    "    transaction_currency=\"EUR\"\n",
     ")\n",
     "\n",
     "response = transaction_portfolios_api.upsert_transactions(scope=scope,\n",
@@ -1944,8 +1960,8 @@
    "execution_count": 28,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:22:02.291628900Z",
-     "start_time": "2024-07-01T14:22:01.897877Z"
+     "end_time": "2024-07-01T15:04:17.259115100Z",
+     "start_time": "2024-07-01T15:04:17.119020900Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -1956,22 +1972,33 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "LUID_00003D9O\n"
+      "LUID_00003D9R\n"
      ]
     }
    ],
    "source": [
     "# Set the instrument variables\n",
-    "forward_name2 = \"EUR/USD 6M FX Forward 20210819\"\n",
-    "forward_identifier2 = \"FWD-EURUSD20210819\"\n",
     "identifier_type = \"ClientInternal\"\n",
-    "description = \"EUR/USD FX Forward 20210819\"\n",
     "start_date = datetime(2021, 2, 19, tzinfo=pytz.utc)\n",
     "maturity_date = datetime(2021, 8, 19, tzinfo=pytz.utc)\n",
-    "dom_ccy = \"EUR\"\n",
-    "fgn_ccy = \"USD\"\n",
-    "dom_amount = 1000000\n",
-    "fgn_amount = -1216800\n",
+    "####################################################################################################\n",
+    "#   ORIGINAL\n",
+    "# dom_ccy = \"EUR\"\n",
+    "# fgn_ccy = \"USD\"\n",
+    "# dom_amount = 1000000\n",
+    "# fgn_amount = -1216800\n",
+    "# forward_name2 = \"EUR/USD 6M FX Forward 20210819\"\n",
+    "# forward_identifier2 = \"FWD-EURUSD20210819\"\n",
+    "# description = \"EUR/USD FX Forward 20210819\"\n",
+    "####################################################################################################\n",
+    "#   NEW # swap dom/fgn\n",
+    "dom_ccy = \"USD\"\n",
+    "fgn_ccy = \"EUR\"\n",
+    "dom_amount = -1216800.25\n",
+    "fgn_amount = 1000000\n",
+    "forward_name2 = \"USD/EUR 6M FX Forward 20210819\"\n",
+    "forward_identifier2 = \"FWD-USDEUR20210819\"\n",
+    "description = \"USD/EUR FX Forward 20210819\"\n",
     "\n",
     "# Create the forward\n",
     "forward_definition = create_fx_forward(\n",
@@ -2005,8 +2032,8 @@
    "execution_count": 29,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:22:02.761790300Z",
-     "start_time": "2024-07-01T14:22:02.283644100Z"
+     "end_time": "2024-07-01T15:04:17.728193700Z",
+     "start_time": "2024-07-01T15:04:17.249077300Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -2017,7 +2044,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Transaction successfully updated at time: 2024-07-01 15:11:03.924946+00:00\n"
+      "Transaction successfully updated at time: 2024-07-01 15:28:02.458831+00:00\n"
      ]
     }
    ],
@@ -2031,9 +2058,11 @@
     "    settlement_date=(unwind_date + timedelta(days=settle_days)).isoformat(),\n",
     "    units=units,\n",
     "    transaction_price=lm.TransactionPrice(price=1,type=\"Price\"),\n",
-    "    total_consideration=lm.CurrencyAndAmount(amount=1,currency=\"USD\"),\n",
+    "    # total_consideration=lm.CurrencyAndAmount(amount=1,currency=\"USD\"), # swap dom/fgn\n",
+    "    total_consideration=lm.CurrencyAndAmount(amount=1,currency=\"EUR\"),\n",
     "    exchange_rate=1,\n",
-    "    transaction_currency=\"USD\"\n",
+    "    # transaction_currency=\"USD\" # swap dom/fgn\n",
+    "    transaction_currency=\"EUR\"\n",
     ")\n",
     "\n",
     "response = transaction_portfolios_api.upsert_transactions(scope=scope,\n",
@@ -2063,8 +2092,8 @@
    "execution_count": 30,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:22:04.145306Z",
-     "start_time": "2024-07-01T14:22:02.766790200Z"
+     "end_time": "2024-07-01T15:04:20.341813100Z",
+     "start_time": "2024-07-01T15:04:17.726189Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -2107,22 +2136,22 @@
        "      <th>0</th>\n",
        "      <td>TXN003</td>\n",
        "      <td>Principal</td>\n",
-       "      <td>Receive</td>\n",
-       "      <td>LUID_00003D9O</td>\n",
+       "      <td>Pay</td>\n",
+       "      <td>LUID_00003D9R</td>\n",
        "      <td>default</td>\n",
-       "      <td>EUR</td>\n",
-       "      <td>1,000,000.0000</td>\n",
+       "      <td>USD</td>\n",
+       "      <td>1,216,800.2500</td>\n",
        "      <td>2021-08-19 00:00:00+00:00</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>TXN003</td>\n",
        "      <td>Principal</td>\n",
-       "      <td>Pay</td>\n",
-       "      <td>LUID_00003D9O</td>\n",
+       "      <td>Receive</td>\n",
+       "      <td>LUID_00003D9R</td>\n",
        "      <td>default</td>\n",
-       "      <td>USD</td>\n",
-       "      <td>1,216,800.0000</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>1,000,000.0000</td>\n",
        "      <td>2021-08-19 00:00:00+00:00</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -2131,12 +2160,12 @@
       ],
       "text/plain": [
        "  source_transaction_id diagnostics.CashFlowType diagnostics.PayReceive  \\\n",
-       "0                TXN003                Principal                Receive   \n",
-       "1                TXN003                Principal                    Pay   \n",
+       "0                TXN003                Principal                    Pay   \n",
+       "1                TXN003                Principal                Receive   \n",
        "\n",
        "  source_instrument_id source_instrument_scope currency         amount  \\\n",
-       "0        LUID_00003D9O                 default      EUR 1,000,000.0000   \n",
-       "1        LUID_00003D9O                 default      USD 1,216,800.0000   \n",
+       "0        LUID_00003D9R                 default      USD 1,216,800.2500   \n",
+       "1        LUID_00003D9R                 default      EUR 1,000,000.0000   \n",
        "\n",
        "               payment_date  \n",
        "0 2021-08-19 00:00:00+00:00  \n",
@@ -2208,8 +2237,8 @@
    "execution_count": 31,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:22:04.380023100Z",
-     "start_time": "2024-07-01T14:22:04.133448400Z"
+     "end_time": "2024-07-01T15:04:20.595343300Z",
+     "start_time": "2024-07-01T15:04:20.334811Z"
     },
     "collapsed": false,
     "jupyter": {
@@ -2261,8 +2290,8 @@
    "execution_count": 32,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:22:04.586003300Z",
-     "start_time": "2024-07-01T14:22:04.367937100Z"
+     "end_time": "2024-07-01T15:04:20.724145600Z",
+     "start_time": "2024-07-01T15:04:20.494498500Z"
     },
     "collapsed": false,
     "jupyter": {
@@ -2325,8 +2354,8 @@
    "execution_count": 33,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:22:05.608126700Z",
-     "start_time": "2024-07-01T14:22:04.573841100Z"
+     "end_time": "2024-07-01T15:04:21.361888200Z",
+     "start_time": "2024-07-01T15:04:20.664312800Z"
     },
     "collapsed": false,
     "jupyter": {
@@ -2356,118 +2385,606 @@
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
        "      <th>transaction_id</th>\n",
-       "      <th>source_instrument_event_id</th>\n",
        "      <th>type</th>\n",
+       "      <th>description</th>\n",
+       "      <th>instrument_identifiers.Instrument/default/ClientInternal</th>\n",
+       "      <th>instrument_scope</th>\n",
        "      <th>instrument_uid</th>\n",
        "      <th>transaction_date</th>\n",
        "      <th>settlement_date</th>\n",
+       "      <th>units</th>\n",
+       "      <th>transaction_amount</th>\n",
+       "      <th>transaction_price.price</th>\n",
+       "      <th>transaction_price.type</th>\n",
        "      <th>total_consideration.amount</th>\n",
        "      <th>total_consideration.currency</th>\n",
+       "      <th>exchange_rate</th>\n",
+       "      <th>transaction_to_portfolio_rate</th>\n",
+       "      <th>transaction_currency</th>\n",
+       "      <th>properties.Transaction/default/SourcePortfolioId.key</th>\n",
+       "      <th>properties.Transaction/default/SourcePortfolioId.value.label_value</th>\n",
+       "      <th>properties.Transaction/default/SourcePortfolioScope.key</th>\n",
+       "      <th>properties.Transaction/default/SourcePortfolioScope.value.label_value</th>\n",
+       "      <th>properties.Transaction/default/ResultantHolding.key</th>\n",
+       "      <th>properties.Transaction/default/ResultantHolding.value.metric_value.value</th>\n",
+       "      <th>source</th>\n",
+       "      <th>transaction_status</th>\n",
+       "      <th>entry_date_time</th>\n",
+       "      <th>realised_gain_loss</th>\n",
+       "      <th>holding_ids.0</th>\n",
+       "      <th>source_type</th>\n",
+       "      <th>source_instrument_event_id</th>\n",
+       "      <th>realised_gain_loss.0.instrument_scope</th>\n",
+       "      <th>realised_gain_loss.0.instrument_uid</th>\n",
+       "      <th>realised_gain_loss.0.units</th>\n",
+       "      <th>realised_gain_loss.0.cost_trade_ccy.amount</th>\n",
+       "      <th>realised_gain_loss.0.cost_trade_ccy.currency</th>\n",
+       "      <th>realised_gain_loss.0.cost_portfolio_ccy.amount</th>\n",
+       "      <th>realised_gain_loss.0.cost_portfolio_ccy.currency</th>\n",
+       "      <th>realised_gain_loss.0.realised_trade_ccy.amount</th>\n",
+       "      <th>realised_gain_loss.0.realised_trade_ccy.currency</th>\n",
+       "      <th>realised_gain_loss.0.realised_total.amount</th>\n",
+       "      <th>realised_gain_loss.0.realised_total.currency</th>\n",
+       "      <th>realised_gain_loss.0.realised_market.amount</th>\n",
+       "      <th>realised_gain_loss.0.realised_market.currency</th>\n",
+       "      <th>realised_gain_loss.0.realised_currency.amount</th>\n",
+       "      <th>realised_gain_loss.0.realised_currency.currency</th>\n",
+       "      <th>holding_ids.1</th>\n",
+       "      <th>instrument_identifiers.Instrument/default/LusidInstrumentId</th>\n",
+       "      <th>properties</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>TXN001</td>\n",
-       "      <td>None</td>\n",
        "      <td>StockIn</td>\n",
-       "      <td>LUID_00003D9L</td>\n",
+       "      <td>Transfer In</td>\n",
+       "      <td>FWD-USDEUR20210720</td>\n",
+       "      <td>default</td>\n",
+       "      <td>LUID_00003D9Q</td>\n",
        "      <td>2021-01-20 00:00:00+00:00</td>\n",
        "      <td>2021-01-22 00:00:00+00:00</td>\n",
        "      <td>1.0000</td>\n",
-       "      <td>USD</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>Price</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>Transaction/default/SourcePortfolioId</td>\n",
+       "      <td>FxForwardWithPipsCurve</td>\n",
+       "      <td>Transaction/default/SourcePortfolioScope</td>\n",
+       "      <td>fx-forward-notebook-example</td>\n",
+       "      <td>Transaction/default/ResultantHolding</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td></td>\n",
+       "      <td>Active</td>\n",
+       "      <td>2024-07-01 15:27:53.252276+00:00</td>\n",
+       "      <td>[]</td>\n",
+       "      <td>68522289</td>\n",
+       "      <td>InputTransaction</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>TXN002</td>\n",
-       "      <td>None</td>\n",
        "      <td>Sell</td>\n",
-       "      <td>LUID_00003D9L</td>\n",
+       "      <td>Sale</td>\n",
+       "      <td>FWD-USDEUR20210720</td>\n",
+       "      <td>default</td>\n",
+       "      <td>LUID_00003D9Q</td>\n",
        "      <td>2021-02-19 12:00:00+00:00</td>\n",
        "      <td>2021-02-21 12:00:00+00:00</td>\n",
-       "      <td>1,068.3583</td>\n",
-       "      <td>USD</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>1,072.7000</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>Price</td>\n",
+       "      <td>1,072.6958</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>Transaction/default/SourcePortfolioId</td>\n",
+       "      <td>FxForwardWithPipsCurve</td>\n",
+       "      <td>Transaction/default/SourcePortfolioScope</td>\n",
+       "      <td>fx-forward-notebook-example</td>\n",
+       "      <td>Transaction/default/ResultantHolding</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td></td>\n",
+       "      <td>Active</td>\n",
+       "      <td>2024-07-01 15:28:01.526115+00:00</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>68522289</td>\n",
+       "      <td>InputTransaction</td>\n",
+       "      <td>None</td>\n",
+       "      <td>default</td>\n",
+       "      <td>LUID_00003D9Q</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>1,071.7000</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>1,071.7000</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>1,071.7000</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>68,522,291.0000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>TXN003</td>\n",
-       "      <td>None</td>\n",
        "      <td>StockIn</td>\n",
-       "      <td>LUID_00003D9O</td>\n",
+       "      <td>Transfer In</td>\n",
+       "      <td>FWD-USDEUR20210819</td>\n",
+       "      <td>default</td>\n",
+       "      <td>LUID_00003D9R</td>\n",
        "      <td>2021-02-19 12:00:00+00:00</td>\n",
        "      <td>2021-02-21 12:00:00+00:00</td>\n",
        "      <td>1.0000</td>\n",
-       "      <td>USD</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>Price</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>Transaction/default/SourcePortfolioId</td>\n",
+       "      <td>FxForwardWithPipsCurve</td>\n",
+       "      <td>Transaction/default/SourcePortfolioScope</td>\n",
+       "      <td>fx-forward-notebook-example</td>\n",
+       "      <td>Transaction/default/ResultantHolding</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td></td>\n",
+       "      <td>Active</td>\n",
+       "      <td>2024-07-01 15:28:02.458831+00:00</td>\n",
+       "      <td>[]</td>\n",
+       "      <td>68522290</td>\n",
+       "      <td>InputTransaction</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>LUID_00003D9O_FxForwardSettlementEvent_2021081...</td>\n",
-       "      <td>LUID_00003D9O_FxForwardSettlementEvent_20210819</td>\n",
+       "      <td>LUID_00003D9R_FxForwardSettlementEvent_2021081...</td>\n",
        "      <td>FxForwardPrincipal</td>\n",
-       "      <td>LUID_00003D9O</td>\n",
+       "      <td>Reduces cash units to represent an FX Spot or ...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>default</td>\n",
+       "      <td>LUID_00003D9R</td>\n",
        "      <td>2021-08-19 00:00:00+00:00</td>\n",
        "      <td>2021-08-19 00:00:00+00:00</td>\n",
-       "      <td>1,000,000.0000</td>\n",
-       "      <td>EUR</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>1,216,800.2500</td>\n",
+       "      <td>-1,216,800.2500</td>\n",
+       "      <td>CashFlowPerUnit</td>\n",
+       "      <td>-1,216,800.2500</td>\n",
+       "      <td>USD</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>USD</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>default</td>\n",
+       "      <td>Active</td>\n",
+       "      <td>2024-07-01 15:28:04.248071+00:00</td>\n",
+       "      <td>[]</td>\n",
+       "      <td>68522292</td>\n",
+       "      <td>InstrumentEvent</td>\n",
+       "      <td>LUID_00003D9R_FxForwardSettlementEvent_20210819</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>LUID_00003D9R</td>\n",
+       "      <td>{}</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>LUID_00003D9O_FxForwardSettlementEvent_2021081...</td>\n",
-       "      <td>LUID_00003D9O_FxForwardSettlementEvent_20210819</td>\n",
+       "      <td>LUID_00003D9R_FxForwardSettlementEvent_2021081...</td>\n",
        "      <td>FxForwardPrincipal</td>\n",
-       "      <td>LUID_00003D9O</td>\n",
+       "      <td>Reduces cash units to represent an FX Spot or ...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>default</td>\n",
+       "      <td>LUID_00003D9R</td>\n",
        "      <td>2021-08-19 00:00:00+00:00</td>\n",
        "      <td>2021-08-19 00:00:00+00:00</td>\n",
-       "      <td>-1,216,800.0000</td>\n",
-       "      <td>USD</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>1,000,000.0000</td>\n",
+       "      <td>1,000,000.0000</td>\n",
+       "      <td>CashFlowPerUnit</td>\n",
+       "      <td>1,000,000.0000</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>default</td>\n",
+       "      <td>Active</td>\n",
+       "      <td>2024-07-01 15:28:04.248071+00:00</td>\n",
+       "      <td>[]</td>\n",
+       "      <td>68522291</td>\n",
+       "      <td>InstrumentEvent</td>\n",
+       "      <td>LUID_00003D9R_FxForwardSettlementEvent_20210819</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>LUID_00003D9R</td>\n",
+       "      <td>{}</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td>LUID_00003D9O_MaturityEvent_20210819-68522294</td>\n",
-       "      <td>LUID_00003D9O_MaturityEvent_20210819</td>\n",
+       "      <td>LUID_00003D9R_MaturityEvent_20210819-68522290</td>\n",
        "      <td>Maturity</td>\n",
-       "      <td>LUID_00003D9O</td>\n",
+       "      <td>Maturity Event</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>default</td>\n",
+       "      <td>LUID_00003D9R</td>\n",
        "      <td>2021-08-19 00:00:00+00:00</td>\n",
        "      <td>2021-08-19 00:00:00+00:00</td>\n",
+       "      <td>1.0000</td>\n",
        "      <td>0.0000</td>\n",
-       "      <td>USD</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>Price</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Transaction/default/ResultantHolding</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>default</td>\n",
+       "      <td>Active</td>\n",
+       "      <td>2024-07-01 15:28:04.248071+00:00</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>68522290</td>\n",
+       "      <td>InstrumentEvent</td>\n",
+       "      <td>LUID_00003D9R_MaturityEvent_20210819</td>\n",
+       "      <td>default</td>\n",
+       "      <td>LUID_00003D9R</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>-1.0000</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>-1.0000</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>-1.0000</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>LUID_00003D9R</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                                      transaction_id  \\\n",
-       "0                                             TXN001   \n",
-       "1                                             TXN002   \n",
-       "2                                             TXN003   \n",
-       "3  LUID_00003D9O_FxForwardSettlementEvent_2021081...   \n",
-       "4  LUID_00003D9O_FxForwardSettlementEvent_2021081...   \n",
-       "5      LUID_00003D9O_MaturityEvent_20210819-68522294   \n",
+       "                                      transaction_id                type  \\\n",
+       "0                                             TXN001             StockIn   \n",
+       "1                                             TXN002                Sell   \n",
+       "2                                             TXN003             StockIn   \n",
+       "3  LUID_00003D9R_FxForwardSettlementEvent_2021081...  FxForwardPrincipal   \n",
+       "4  LUID_00003D9R_FxForwardSettlementEvent_2021081...  FxForwardPrincipal   \n",
+       "5      LUID_00003D9R_MaturityEvent_20210819-68522290            Maturity   \n",
        "\n",
-       "                        source_instrument_event_id                type  \\\n",
-       "0                                             None             StockIn   \n",
-       "1                                             None                Sell   \n",
-       "2                                             None             StockIn   \n",
-       "3  LUID_00003D9O_FxForwardSettlementEvent_20210819  FxForwardPrincipal   \n",
-       "4  LUID_00003D9O_FxForwardSettlementEvent_20210819  FxForwardPrincipal   \n",
-       "5             LUID_00003D9O_MaturityEvent_20210819            Maturity   \n",
+       "                                         description  \\\n",
+       "0                                        Transfer In   \n",
+       "1                                               Sale   \n",
+       "2                                        Transfer In   \n",
+       "3  Reduces cash units to represent an FX Spot or ...   \n",
+       "4  Reduces cash units to represent an FX Spot or ...   \n",
+       "5                                     Maturity Event   \n",
        "\n",
-       "  instrument_uid          transaction_date           settlement_date  \\\n",
-       "0  LUID_00003D9L 2021-01-20 00:00:00+00:00 2021-01-22 00:00:00+00:00   \n",
-       "1  LUID_00003D9L 2021-02-19 12:00:00+00:00 2021-02-21 12:00:00+00:00   \n",
-       "2  LUID_00003D9O 2021-02-19 12:00:00+00:00 2021-02-21 12:00:00+00:00   \n",
-       "3  LUID_00003D9O 2021-08-19 00:00:00+00:00 2021-08-19 00:00:00+00:00   \n",
-       "4  LUID_00003D9O 2021-08-19 00:00:00+00:00 2021-08-19 00:00:00+00:00   \n",
-       "5  LUID_00003D9O 2021-08-19 00:00:00+00:00 2021-08-19 00:00:00+00:00   \n",
+       "  instrument_identifiers.Instrument/default/ClientInternal instrument_scope  \\\n",
+       "0                                 FWD-USDEUR20210720                default   \n",
+       "1                                 FWD-USDEUR20210720                default   \n",
+       "2                                 FWD-USDEUR20210819                default   \n",
+       "3                                                NaN                default   \n",
+       "4                                                NaN                default   \n",
+       "5                                                NaN                default   \n",
        "\n",
-       "   total_consideration.amount total_consideration.currency  \n",
-       "0                      1.0000                          USD  \n",
-       "1                  1,068.3583                          USD  \n",
-       "2                      1.0000                          USD  \n",
-       "3              1,000,000.0000                          EUR  \n",
-       "4             -1,216,800.0000                          USD  \n",
-       "5                      0.0000                          USD  "
+       "  instrument_uid          transaction_date           settlement_date  units  \\\n",
+       "0  LUID_00003D9Q 2021-01-20 00:00:00+00:00 2021-01-22 00:00:00+00:00 1.0000   \n",
+       "1  LUID_00003D9Q 2021-02-19 12:00:00+00:00 2021-02-21 12:00:00+00:00 1.0000   \n",
+       "2  LUID_00003D9R 2021-02-19 12:00:00+00:00 2021-02-21 12:00:00+00:00 1.0000   \n",
+       "3  LUID_00003D9R 2021-08-19 00:00:00+00:00 2021-08-19 00:00:00+00:00 1.0000   \n",
+       "4  LUID_00003D9R 2021-08-19 00:00:00+00:00 2021-08-19 00:00:00+00:00 1.0000   \n",
+       "5  LUID_00003D9R 2021-08-19 00:00:00+00:00 2021-08-19 00:00:00+00:00 1.0000   \n",
+       "\n",
+       "   transaction_amount  transaction_price.price transaction_price.type  \\\n",
+       "0              1.0000                   1.0000                  Price   \n",
+       "1          1,072.7000                   1.0000                  Price   \n",
+       "2              1.0000                   1.0000                  Price   \n",
+       "3      1,216,800.2500          -1,216,800.2500        CashFlowPerUnit   \n",
+       "4      1,000,000.0000           1,000,000.0000        CashFlowPerUnit   \n",
+       "5              0.0000                   0.0000                  Price   \n",
+       "\n",
+       "   total_consideration.amount total_consideration.currency  exchange_rate  \\\n",
+       "0                      1.0000                          EUR         1.0000   \n",
+       "1                  1,072.6958                          EUR         1.0000   \n",
+       "2                      1.0000                          EUR         1.0000   \n",
+       "3             -1,216,800.2500                          USD         1.0000   \n",
+       "4              1,000,000.0000                          EUR         1.0000   \n",
+       "5                      0.0000                          EUR         1.0000   \n",
+       "\n",
+       "   transaction_to_portfolio_rate transaction_currency  \\\n",
+       "0                         0.0000                  EUR   \n",
+       "1                         0.0000                  EUR   \n",
+       "2                         0.0000                  EUR   \n",
+       "3                         0.0000                  USD   \n",
+       "4                         0.0000                  EUR   \n",
+       "5                         0.0000                  EUR   \n",
+       "\n",
+       "  properties.Transaction/default/SourcePortfolioId.key  \\\n",
+       "0              Transaction/default/SourcePortfolioId     \n",
+       "1              Transaction/default/SourcePortfolioId     \n",
+       "2              Transaction/default/SourcePortfolioId     \n",
+       "3                                                NaN     \n",
+       "4                                                NaN     \n",
+       "5                                                NaN     \n",
+       "\n",
+       "  properties.Transaction/default/SourcePortfolioId.value.label_value  \\\n",
+       "0                             FxForwardWithPipsCurve                   \n",
+       "1                             FxForwardWithPipsCurve                   \n",
+       "2                             FxForwardWithPipsCurve                   \n",
+       "3                                                NaN                   \n",
+       "4                                                NaN                   \n",
+       "5                                                NaN                   \n",
+       "\n",
+       "  properties.Transaction/default/SourcePortfolioScope.key  \\\n",
+       "0           Transaction/default/SourcePortfolioScope        \n",
+       "1           Transaction/default/SourcePortfolioScope        \n",
+       "2           Transaction/default/SourcePortfolioScope        \n",
+       "3                                                NaN        \n",
+       "4                                                NaN        \n",
+       "5                                                NaN        \n",
+       "\n",
+       "  properties.Transaction/default/SourcePortfolioScope.value.label_value  \\\n",
+       "0                        fx-forward-notebook-example                      \n",
+       "1                        fx-forward-notebook-example                      \n",
+       "2                        fx-forward-notebook-example                      \n",
+       "3                                                NaN                      \n",
+       "4                                                NaN                      \n",
+       "5                                                NaN                      \n",
+       "\n",
+       "  properties.Transaction/default/ResultantHolding.key  \\\n",
+       "0               Transaction/default/ResultantHolding    \n",
+       "1               Transaction/default/ResultantHolding    \n",
+       "2               Transaction/default/ResultantHolding    \n",
+       "3                                                NaN    \n",
+       "4                                                NaN    \n",
+       "5               Transaction/default/ResultantHolding    \n",
+       "\n",
+       "   properties.Transaction/default/ResultantHolding.value.metric_value.value  \\\n",
+       "0                                             1.0000                          \n",
+       "1                                             0.0000                          \n",
+       "2                                             1.0000                          \n",
+       "3                                                NaN                          \n",
+       "4                                                NaN                          \n",
+       "5                                             0.0000                          \n",
+       "\n",
+       "    source transaction_status                  entry_date_time  \\\n",
+       "0                      Active 2024-07-01 15:27:53.252276+00:00   \n",
+       "1                      Active 2024-07-01 15:28:01.526115+00:00   \n",
+       "2                      Active 2024-07-01 15:28:02.458831+00:00   \n",
+       "3  default             Active 2024-07-01 15:28:04.248071+00:00   \n",
+       "4  default             Active 2024-07-01 15:28:04.248071+00:00   \n",
+       "5  default             Active 2024-07-01 15:28:04.248071+00:00   \n",
+       "\n",
+       "  realised_gain_loss  holding_ids.0       source_type  \\\n",
+       "0                 []       68522289  InputTransaction   \n",
+       "1                NaN       68522289  InputTransaction   \n",
+       "2                 []       68522290  InputTransaction   \n",
+       "3                 []       68522292   InstrumentEvent   \n",
+       "4                 []       68522291   InstrumentEvent   \n",
+       "5                NaN       68522290   InstrumentEvent   \n",
+       "\n",
+       "                        source_instrument_event_id  \\\n",
+       "0                                             None   \n",
+       "1                                             None   \n",
+       "2                                             None   \n",
+       "3  LUID_00003D9R_FxForwardSettlementEvent_20210819   \n",
+       "4  LUID_00003D9R_FxForwardSettlementEvent_20210819   \n",
+       "5             LUID_00003D9R_MaturityEvent_20210819   \n",
+       "\n",
+       "  realised_gain_loss.0.instrument_scope realised_gain_loss.0.instrument_uid  \\\n",
+       "0                                   NaN                                 NaN   \n",
+       "1                               default                       LUID_00003D9Q   \n",
+       "2                                   NaN                                 NaN   \n",
+       "3                                   NaN                                 NaN   \n",
+       "4                                   NaN                                 NaN   \n",
+       "5                               default                       LUID_00003D9R   \n",
+       "\n",
+       "   realised_gain_loss.0.units  realised_gain_loss.0.cost_trade_ccy.amount  \\\n",
+       "0                         NaN                                         NaN   \n",
+       "1                      1.0000                                      1.0000   \n",
+       "2                         NaN                                         NaN   \n",
+       "3                         NaN                                         NaN   \n",
+       "4                         NaN                                         NaN   \n",
+       "5                      1.0000                                      1.0000   \n",
+       "\n",
+       "  realised_gain_loss.0.cost_trade_ccy.currency  \\\n",
+       "0                                          NaN   \n",
+       "1                                          EUR   \n",
+       "2                                          NaN   \n",
+       "3                                          NaN   \n",
+       "4                                          NaN   \n",
+       "5                                          EUR   \n",
+       "\n",
+       "   realised_gain_loss.0.cost_portfolio_ccy.amount  \\\n",
+       "0                                             NaN   \n",
+       "1                                          1.0000   \n",
+       "2                                             NaN   \n",
+       "3                                             NaN   \n",
+       "4                                             NaN   \n",
+       "5                                          1.0000   \n",
+       "\n",
+       "  realised_gain_loss.0.cost_portfolio_ccy.currency  \\\n",
+       "0                                              NaN   \n",
+       "1                                              EUR   \n",
+       "2                                              NaN   \n",
+       "3                                              NaN   \n",
+       "4                                              NaN   \n",
+       "5                                              EUR   \n",
+       "\n",
+       "   realised_gain_loss.0.realised_trade_ccy.amount  \\\n",
+       "0                                             NaN   \n",
+       "1                                      1,071.7000   \n",
+       "2                                             NaN   \n",
+       "3                                             NaN   \n",
+       "4                                             NaN   \n",
+       "5                                         -1.0000   \n",
+       "\n",
+       "  realised_gain_loss.0.realised_trade_ccy.currency  \\\n",
+       "0                                              NaN   \n",
+       "1                                              EUR   \n",
+       "2                                              NaN   \n",
+       "3                                              NaN   \n",
+       "4                                              NaN   \n",
+       "5                                              EUR   \n",
+       "\n",
+       "   realised_gain_loss.0.realised_total.amount  \\\n",
+       "0                                         NaN   \n",
+       "1                                  1,071.7000   \n",
+       "2                                         NaN   \n",
+       "3                                         NaN   \n",
+       "4                                         NaN   \n",
+       "5                                     -1.0000   \n",
+       "\n",
+       "  realised_gain_loss.0.realised_total.currency  \\\n",
+       "0                                          NaN   \n",
+       "1                                          EUR   \n",
+       "2                                          NaN   \n",
+       "3                                          NaN   \n",
+       "4                                          NaN   \n",
+       "5                                          EUR   \n",
+       "\n",
+       "   realised_gain_loss.0.realised_market.amount  \\\n",
+       "0                                          NaN   \n",
+       "1                                   1,071.7000   \n",
+       "2                                          NaN   \n",
+       "3                                          NaN   \n",
+       "4                                          NaN   \n",
+       "5                                      -1.0000   \n",
+       "\n",
+       "  realised_gain_loss.0.realised_market.currency  \\\n",
+       "0                                           NaN   \n",
+       "1                                           EUR   \n",
+       "2                                           NaN   \n",
+       "3                                           NaN   \n",
+       "4                                           NaN   \n",
+       "5                                           EUR   \n",
+       "\n",
+       "   realised_gain_loss.0.realised_currency.amount  \\\n",
+       "0                                            NaN   \n",
+       "1                                         0.0000   \n",
+       "2                                            NaN   \n",
+       "3                                            NaN   \n",
+       "4                                            NaN   \n",
+       "5                                         0.0000   \n",
+       "\n",
+       "  realised_gain_loss.0.realised_currency.currency   holding_ids.1  \\\n",
+       "0                                             NaN             NaN   \n",
+       "1                                             EUR 68,522,291.0000   \n",
+       "2                                             NaN             NaN   \n",
+       "3                                             NaN             NaN   \n",
+       "4                                             NaN             NaN   \n",
+       "5                                             EUR             NaN   \n",
+       "\n",
+       "  instrument_identifiers.Instrument/default/LusidInstrumentId properties  \n",
+       "0                                                NaN                 NaN  \n",
+       "1                                                NaN                 NaN  \n",
+       "2                                                NaN                 NaN  \n",
+       "3                                      LUID_00003D9R                  {}  \n",
+       "4                                      LUID_00003D9R                  {}  \n",
+       "5                                      LUID_00003D9R                 NaN  "
       ]
      },
      "execution_count": 33,
@@ -2486,18 +3003,18 @@
     "))\n",
     "\n",
     "# we create a dataframe out of the cash flows table and only keep certain columns to improve readability\n",
-    "df = df[\n",
-    "    [\n",
-    "        \"transaction_id\",\n",
-    "        \"source_instrument_event_id\",\n",
-    "        \"type\",\n",
-    "        \"instrument_uid\",\n",
-    "        \"transaction_date\",\n",
-    "        \"settlement_date\",\n",
-    "        \"total_consideration.amount\",\n",
-    "        \"total_consideration.currency\",\n",
-    "    ]\n",
-    "]\n",
+    "# df = df[\n",
+    "#     [\n",
+    "#         \"transaction_id\",\n",
+    "#         \"source_instrument_event_id\",\n",
+    "#         \"type\",\n",
+    "#         \"instrument_uid\",\n",
+    "#         \"transaction_date\",\n",
+    "#         \"settlement_date\",\n",
+    "#         \"total_consideration.amount\",\n",
+    "#         \"total_consideration.currency\",\n",
+    "#     ]\n",
+    "# ]\n",
     "\n",
     "df"
    ]
@@ -2519,8 +3036,8 @@
    "execution_count": 34,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-07-01T14:22:06.786744600Z",
-     "start_time": "2024-07-01T14:22:05.558127500Z"
+     "end_time": "2024-07-01T15:04:22.887492600Z",
+     "start_time": "2024-07-01T15:04:21.345846400Z"
     },
     "pycharm": {
      "name": "#%%\n"
@@ -2556,15 +3073,15 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>USD</td>\n",
-       "      <td>-1,041,311.8987</td>\n",
-       "      <td>-1,215,731.6417</td>\n",
+       "      <td>EUR</td>\n",
+       "      <td>1,001,072.6958</td>\n",
+       "      <td>1,001,072.6958</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>EUR</td>\n",
-       "      <td>1,000,000.0000</td>\n",
-       "      <td>1,000,000.0000</td>\n",
+       "      <td>USD</td>\n",
+       "      <td>-1,042,227.1949</td>\n",
+       "      <td>-1,216,800.2500</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -2572,8 +3089,8 @@
       ],
       "text/plain": [
        "  InstrumentName  Market Value (Portfolio Currency)  Holding/default/Units\n",
-       "0            USD                    -1,041,311.8987        -1,215,731.6417\n",
-       "1            EUR                     1,000,000.0000         1,000,000.0000"
+       "0            EUR                     1,001,072.6958         1,001,072.6958\n",
+       "1            USD                    -1,042,227.1949        -1,216,800.2500"
       ]
      },
      "execution_count": 34,
@@ -2595,6 +3112,22 @@
     "\n",
     "df"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-01T15:04:22.924596200Z",
+     "start_time": "2024-07-01T15:04:22.893089800Z"
+    },
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Changes follow the [style guide](https://github.com/finbourne/sample-notebooks/blob/master/docs/FINBOURNE%20notebook%20style%20guide.ipynb)
- [ ] Tests pass
- [ ] Raised the PR against the `develop` branch
- [ ] Notebook outputs do not contain any priviledged data

# Description of the PR

Making two updates to this notebook:
- **7. Instrument Life Cycle**:  uses LUSID's new instrument events for the FxForward's maturity.  With only this change (0e0d4380a32bd9405c5bd848776d1b926d40d661) all the valuation numbers remain the same, and everything seems to work.
- **Instrument configuration**: In the second commit (6006856ea5bfeedd56b38c2f672989815949c603) the `dom` and `fgn` currencies are swapped so that they match the UI's buy/sell labels.  After this, we see _almost_ correct numbers, however:
  - Some values are slightly off.  Might be rounding, since pips curve data only goes to 4 decimal points.  Swapping dom/fgn means LUSID has to invert the existing curve.
  - Final value for EUR should be exactly 1,000,000 but it's not.  Leads me to believe there are no rounding issues, and there's more updates required to swap dom/fgn.

TODO (reminder for me after numbers are correct): add URL to UI Valuation dashboard like at the end of [Simple Valuation.ipynb](https://github.com/finbourne/sample-notebooks/blob/e62c883d1a6866bcb289da5a3c40dcf420a38348/examples/use-cases/valuation/Simple%20Valuation.ipynb).
