### PR TITLE
ANA-4120: Add FX inference notebook. Clarify linear interpolation for…

### DIFF
--- a/analytics/FX/fx-forward-pricing-models.ipynb
+++ b/analytics/FX/fx-forward-pricing-models.ipynb
@@ -647,7 +647,7 @@
    "source": [
     "### 2.1 Constant Time Value of Money\n",
     "\n",
-    "The Constant Time Value of Money (CTVoM) pricing model values each of the cashflows assuming zero discount interest rates, so no discounting is performed to calculate the present value. For example £1 in one year is worth £1 today. Thus the present value of an FX forward under this model is simply the sum of the two amounts, which are converted to the domestic currency based on the current spot exchange rate `S`.\n",
+    "The Constant Time Value of Money (CTVoM) pricing model values each of the cashflows using a spot rate on the valuation date, assuming zero discount interest rates, so no discounting is performed to calculate the present value. One implication of assuming zero discounting rates is that the implied forward rate for the maturity date is equal to the spot rate on the valuation date. For example £1 in one year is worth £1 today. Thus the present value of an FX forward under this model is simply the sum of the two amounts, which are converted to the domestic currency based on the current spot exchange rate `S`.\n",
     "\n",
     "In this example, the GBP outflow is 100,000 GBP, while the JPY inflow of 19,000,000 JPY is worth `19,000,000 / S` in GBP. If the spot rate is 190 then the PV is zero. If the spot rate is 185, the present value is `102,702.70 - 100,000 = 2,702.70 GBP`."
    ]
@@ -1674,7 +1674,9 @@
     "\n",
     "**1M:** Valuation is on Monday 14/10/24, spot date (+2) is Wednesday 16/10/24. Increment by 1 month and roll forwards over the weekend to Monday 18/11/24. This is 15 calendar days before maturity.\n",
     "\n",
-    "**2M:** Valuation is on Monday 14/10/24, spot date (+2) is Wednesday 16/10/24. Increment by 2 months to Monday 16/12/24. This is 13 calendar days after maturity."
+    "**2M:** Valuation is on Monday 14/10/24, spot date (+2) is Wednesday 16/10/24. Increment by 2 months to Monday 16/12/24. This is 13 calendar days after maturity.\n",
+    "\n",
+    "The period between the 1M and 2M tenors spans 28 days. The forward rate on the valuation date (Mon 14/10/24) implied by linear interpolation on the curve between the 1M and 2M tenors is: `f = f(1M) + (15/28) * (f(2M) - f(1M))`, which can be rearranged as `f = ((28 - 15)/28) * f(1M) + (15/28) * f(2M) = 13 * f(1M) + 15 * f(2M)`."
    ]
   },
   {
@@ -2320,7 +2322,9 @@
     "\n",
     "**1M:** Valuation is on Monday 14/10/24, spot date (+2) is Wednesday 16/10/24. Increment by 1 month and roll forwards over the weekend to Monday 18/11/24. This is 15 calendar days before maturity.\n",
     "\n",
-    "**2M:** Valuation is on Monday 14/10/24, spot date (+2) is Wednesday 16/10/24. Increment by 2 months to Monday 16/12/24. This is 13 calendar days after maturity."
+    "**2M:** Valuation is on Monday 14/10/24, spot date (+2) is Wednesday 16/10/24. Increment by 2 months to Monday 16/12/24. This is 13 calendar days after maturity.\n",
+    "\n",
+    "The period between the 1M and 2M tenors spans 28 days. The forward rate on the valuation date (Mon 14/10/24) implied by linear interpolation on the curve between the 1M and 2M tenors is: `f = f(1M) + (15/28) * (f(2M) - f(1M))`, which can be rearranged as `f = ((28 - 15)/28) * f(1M) + (15/28) * f(2M) = 13 * f(1M) + 15 * f(2M)`."
    ]
   },
   {
@@ -6623,10 +6627,7 @@
     "\n",
     "**2M:** Adding one month to the spot date (Wed 16/10/24) gives the 2M tenor date as Mon 16/12/24. This is 13 days after the 6M maturity.\n",
     "\n",
-    "Therefore, the interpolated GBPJPY forward rate on the valuation date is given by\n",
-    "```\n",
-    "interpolated_fwd_rate = (13 * fwd_rate_1M + 15 * fwd_rate_2M) / (13 + 15)\n",
-    "```"
+    "The period between the 1M and 2M tenors spans 28 days. The forward rate on the valuation date (Mon 14/10/24) implied by linear interpolation on the curve between the 1M and 2M tenors is: `f = f(1M) + (15/28) * (f(2M) - f(1M))`, which can be rearranged as `f = ((28 - 15)/28) * f(1M) + (15/28) * f(2M) = 13 * f(1M) + 15 * f(2M)`."
    ]
   },
   {

--- a/analytics/FX/fx-inference-triangulation.ipynb
+++ b/analytics/FX/fx-inference-triangulation.ipynb
@@ -1,0 +1,1598 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <form action=\"javascript:code_toggle()\"><input type=\"submit\" id=\"toggleButton\" value=\"Toggle Docstring\"></form>\n",
+       "    \n",
+       "         <script>\n",
+       "         function code_toggle() {\n",
+       "             if ($('div.cell.code_cell.rendered.selected div.input').css('display')!='none'){\n",
+       "                 $('div.cell.code_cell.rendered.selected div.input').hide();\n",
+       "             } else {\n",
+       "                 $('div.cell.code_cell.rendered.selected div.input').show();\n",
+       "             }\n",
+       "         }\n",
+       "         </script>\n",
+       "\n",
+       "     "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from lusidtools.jupyter_tools import toggle_code\n",
+    "\n",
+    "\"\"\"FX Inference Triangulation\n",
+    "\n",
+    "Attributes\n",
+    "----------\n",
+    "FX\n",
+    "Foreign Exchange\n",
+    "FX inference\n",
+    "Triangulation\n",
+    "\"\"\"\n",
+    "\n",
+    "toggle_code(\"Toggle Docstring\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# FX Inference Methodology - Triangulation\n",
+    "\n",
+    "In this notebook we demonstrate the FX inference methodology in LUSID. When the market option `attempt_to_infer_missing_fx=True` is used, LUSID will attempt to infer FX quotes from the available market data if no direct quote is found according to a set of rules which are described below and will be demonstrated in this notebook.\n",
+    "\n",
+    "In attempting to infer an FX rate for a currency pair XXXYYY (e.g. XXX=AUD and YYY=JPY for AUDJPY), LUSID performs the following steps, stopping the process and returning an inferred quote as soon as one is found:\n",
+    "\n",
+    "- Check if `XXXYYY` is present. If so, return `XXXYYY`.\n",
+    "- Check if `YYYXXX` is present. If so, return `1 / YYYXXX`.\n",
+    "- Attempt to triangulate through a base currency (USD, GBP, EUR) in order:\n",
+    "    - Triangulate through USD: Given at least one of USDXXX and XXXUSD and at least one of USDYYY and YYYUSD, LUSID will calculate an XXXYYY rate (See [section 2.3](#23-currency-pair-quoting-conventions) for exact ordering).\n",
+    "    - Triangulate through GBP: as above.\n",
+    "    - Triangulate through EUR: as above.\n",
+    "- Otherwise, this is an error state. Insufficient market data.\n",
+    "\n",
+    "The list of base currencies used for triangulation is hardcoded in LUSID as (USD, GBP, EUR) and is not configurable. Triangulation will be attempted first through USD, then GBP, then EUR. \n",
+    "\n",
+    "The `effective_at` date is not taken into consideration when attempting to infer FX rates, provided the quotes lie in the quote interval specified in the market data key rules. That is to say, the first valid quote will be derived according the FX inference rules and priorities described in this notebook, without attempting to rank derived quotes using the effective dates.\n",
+    "\n",
+    "**Example:** Suppose we are running a valuation on Friday 13 September 2024 which requires a EURJPY quote and the market data store contains a EURJPY quote `q1 = 157.0130` effective on Thu 12/09/24 and a JPYEUR quote `q2 = 1/156.75 = 0.00637959` effective on Fri 13/09/24. We could either use the direct EURJPY quote `q1`, which is one day old, or infer a EURJPY quote `1/q2 = 156.75` effective at the valuation date. In LUSID, the direct quote will be used if available without considering derived quotes formed from one or more newer FX rate quotes.\n",
+    "\n",
+    "When triangulating through one of the base currencies (USD, GBP, EUR), the latest quote for each currency pair will be used rather than attempting to match quotes on the same date.\n",
+    "\n",
+    "**Example:** Suppose we are running a valuation on Friday 13 September 2024 that requires a EURJPY quote and the market date store contains the following FX quotes:\n",
+    "\n",
+    "| Currency Pair | Rate   | Effective At |\n",
+    "| ------------- | ----   | ------------ |\n",
+    "| EURUSD        | 1.1011 | 12/09/2024   |\n",
+    "| USDJPY        | 142.59 | 12/09/2024   |\n",
+    "| EURUSD        | 1.1078 | 13/09/2024   |\n",
+    "\n",
+    "Combining the EURUSD and USDJPY quotes effective on Thursday 12 September 2024 gives an inferred quote `EURJPY = 1.1011 * 142.59 = 157.005849`. If instead we combine the latest quote for each currency pair, as LUSID does, we derive a quote `EURJPY = 1.1078 * 142.59 = 157.9612`. It is recommended to upsert all market data effective on the valuation date wherever possible.\n",
+    "\n",
+    "The triangulation methodology only uses a single value for each currency pair, without taking bid/ask prices into account.\n",
+    "\n",
+    "The FX inference methodology is the same whether we are dealing with single FX quotes or curves (for curves, we multiply, divide and scale pointwise), so to focus on the inference rules we will only consider single quotes and ignore complex market data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Table of Contents\n",
+    "\n",
+    "1. [Setup](#1-setup)\n",
+    "    1. [Portfolio Creation](#11-portfolio-creation)\n",
+    "    2. [Create Holdings](#12-create-holdings)\n",
+    "    3. [Pricing Recipes and Market Data](#13-pricing-recipes-and-market-data)\n",
+    "    4. [Valuation](#14-valuation)\n",
+    "2. [Examples](#2-examples)\n",
+    "    1. [Inverse quote](#21-inverse-quote)\n",
+    "    2. [Triangulation through a base currency](#22-triangulation-through-a-base-currency)\n",
+    "    3. [Currency pair quoting conventions](#23-currency-pair-quoting-conventions)\n",
+    "    4. [Multi-step triangulation](#24-multi-step-triangulation)\n",
+    "    5. [Minor currencies](#25-minor-currencies)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>.container { width: 90% !important; }</style>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'LUSID environment initialised'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'LUSID API version: 0.6.13544.0'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Import generic non-LUSID packages\n",
+    "import os\n",
+    "import pandas as pd\n",
+    "from datetime import datetime, timedelta\n",
+    "import pytz\n",
+    "from IPython.core.display import HTML\n",
+    "import json\n",
+    "\n",
+    "# Import key modules from the LUSID package\n",
+    "import lusid\n",
+    "import lusid.models as lm\n",
+    "from lusid.utilities import ApiClientFactory\n",
+    "\n",
+    "# Set DataFrame display formats\n",
+    "pd.set_option(\"display.max_columns\", None)\n",
+    "pd.set_option(\"display.max_rows\", None)\n",
+    "pd.options.display.float_format = \"{:,.4f}\".format\n",
+    "display(HTML(\"<style>.container { width: 90% !important; }</style>\"))\n",
+    "\n",
+    "# Set the secrets path\n",
+    "secrets_path = os.getenv(\"FBN_SECRETS_PATH\")\n",
+    "\n",
+    "# For running the notebook locally\n",
+    "if secrets_path is None:\n",
+    "    secrets_path = os.path.join(os.path.dirname(os.getcwd()), \"secrets.json\")\n",
+    "\n",
+    "# Authenticate user and create API client\n",
+    "api_factory = ApiClientFactory(api_secrets_filename=secrets_path)\n",
+    "build_version = (\n",
+    "    api_factory.build(lusid.api.ApplicationMetadataApi)\n",
+    "    .get_lusid_versions()\n",
+    "    .build_version\n",
+    ")\n",
+    "display(\"LUSID environment initialised\")\n",
+    "display(f\"LUSID API version: {build_version}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set required APIs\n",
+    "portfolio_api = api_factory.build(lusid.api.PortfoliosApi)\n",
+    "transaction_portfolios_api = api_factory.build(lusid.api.TransactionPortfoliosApi)\n",
+    "instruments_api = api_factory.build(lusid.api.InstrumentsApi)\n",
+    "quotes_api = api_factory.build(lusid.api.QuotesApi)\n",
+    "configuration_recipe_api = api_factory.build(lusid.api.ConfigurationRecipeApi)\n",
+    "aggregation_api = api_factory.build(lusid.api.AggregationApi)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.1 Portfolio Creation\n",
+    "\n",
+    "We now create and upsert a portfolio denominated in CHF with creation date Wednesday 01 May 2024."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define common variables\n",
+    "pf_scope = \"fx-inference-triangulation\"\n",
+    "pf_code = \"FxInferenceTriangulation\"\n",
+    "pf_ccy = \"CHF\"\n",
+    "pf_created_at = datetime(2024, 5, 1, tzinfo=pytz.utc)  # Wed 01 May"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Found portfolio FxInferenceTriangulation in scope fx-inference-triangulation'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Get or create portfolio\n",
+    "try:\n",
+    "    portfolio_api.get_portfolio(scope=pf_scope, code=pf_code)\n",
+    "    display(f\"Found portfolio {pf_code} in scope {pf_scope}\")\n",
+    "except lusid.ApiException as e:\n",
+    "    body = json.loads(e.body)\n",
+    "    if body[\"name\"] == \"PortfolioNotFound\":\n",
+    "        transaction_portfolios_api.create_portfolio(\n",
+    "            scope=pf_scope,\n",
+    "            create_transaction_portfolio_request=lm.CreateTransactionPortfolioRequest(\n",
+    "                display_name=pf_code,\n",
+    "                code=pf_code,\n",
+    "                base_currency=pf_ccy,\n",
+    "                created=pf_created_at.isoformat(),\n",
+    "            ),\n",
+    "        )\n",
+    "\n",
+    "        display(f\"Created new portfolio {pf_code} in scope {pf_scope}\")\n",
+    "\n",
+    "    else:\n",
+    "        display(\n",
+    "            f\"Error fetching portfolio - Title: {body['title']}, Details: {body['detail']}, Errors: {body['errors']}\"\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.2 Create Holdings\n",
+    "\n",
+    "We now create and upsert an `Equity` instrument denominated in AUD."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "equity_id = \"AUS12321\"\n",
+    "equity_name = \"AnAustralianCompany\"\n",
+    "equity_ccy = \"AUD\"\n",
+    "\n",
+    "equity = lm.Equity(\n",
+    "    identifiers={\"ClientInternal\": equity_id},\n",
+    "    dom_ccy=equity_ccy,\n",
+    "    instrument_type=lm.InstrumentType.EQUITY,\n",
+    ")\n",
+    "\n",
+    "equity_definition = lm.InstrumentDefinition(\n",
+    "    name=equity_name,\n",
+    "    identifiers={\"ClientInternal\": lm.InstrumentIdValue(value=equity_id)},\n",
+    "    definition=equity,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Success! Upserted instrument LUID_000185GZ'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    upsert_response = instruments_api.upsert_instruments(\n",
+    "        request_body={equity_id: equity_definition}\n",
+    "    )\n",
+    "    luid = upsert_response.values[equity_id].lusid_instrument_id\n",
+    "    display(f\"Success! Upserted instrument {luid}\")\n",
+    "except KeyError as e:\n",
+    "    display(\n",
+    "        f\"Failed to upsert instrument {equity_id}. Details: {upsert_response.failed[equity_id].detail}\"\n",
+    "    )\n",
+    "except lusid.ApiException as e:\n",
+    "    body = json.loads(e.body)\n",
+    "    display(\n",
+    "        f\"Title: {body['title']}, Details: {body['detail']}, Errors: {body['errors']}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Having created a transaction portfolio and an `Equity` instrument, we now add a `StockIn` transaction (Monday 03 June 2024) to create a long position of 10,000 units of the equity at 100 AUD each, rather than using  a `Buy/Sell` transaction which would affect the cash holding of the portfolio."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Transaction successfully updated at time 2024-09-13 12:53:11.031480+00:00'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Trade variables\n",
+    "trade_date = datetime(2024, 6, 3, tzinfo=pytz.utc)  # Monday 03 June 2024\n",
+    "settle_days = 2\n",
+    "settlement_date = trade_date + timedelta(days=settle_days)\n",
+    "units = 10_000\n",
+    "unit_price = 100  # AUD\n",
+    "\n",
+    "total_consideration = units * unit_price\n",
+    "\n",
+    "# Create StockIn transaction\n",
+    "stock_in_txn = lm.TransactionRequest(\n",
+    "    transaction_id=\"TXN001\",\n",
+    "    type=\"StockIn\",\n",
+    "    instrument_identifiers={\"Instrument/default/ClientInternal\": equity_id},\n",
+    "    transaction_date=trade_date.isoformat(),\n",
+    "    settlement_date=settlement_date.isoformat(),\n",
+    "    units=units,\n",
+    "    transaction_price=lm.TransactionPrice(price=unit_price, type=\"Price\"),\n",
+    "    transaction_currency=equity_ccy,\n",
+    "    total_consideration=lm.CurrencyAndAmount(\n",
+    "        amount=total_consideration, currency=equity_ccy\n",
+    "    ),\n",
+    "    exchange_rate=1,\n",
+    ")\n",
+    "\n",
+    "# Upsert StockIn transaction\n",
+    "try:\n",
+    "    response = transaction_portfolios_api.upsert_transactions(\n",
+    "        scope=pf_scope, code=pf_code, transaction_request=[stock_in_txn]\n",
+    "    )\n",
+    "    display(f\"Transaction successfully updated at time {response.version.as_at_date}\")\n",
+    "\n",
+    "except lusid.ApiException as e:\n",
+    "    body = json.loads(e.body)\n",
+    "    display(\n",
+    "        f\"Failed to upsert transaction - Title: {body['title']}, Details: {body['detail']}, Errors: {body['errors']}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.3 Pricing Recipes and Market Data\n",
+    "\n",
+    "Now we create some helper functions for upserting pricing recipes and quotes. FX inference is enabled in the market context setting `attempt_to_infer_missing_fx=True` in `MarketOptions`. We will use the `SimpleStatic` pricing model to value the `Equity`, which gives a valuation (in the equity base currency) based on a single price per unit quote for the equity, multiplying by the number of units held. The valuation in the portfolio base currency is given by converting at the spot rate. In our example, the portfolio currency is CHF and the equity is quoted in AUD, so the PV in CHF is given by multiplying the PV in AUD by a AUDCHF spot rate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "market_supplier = \"Lusid\"\n",
+    "\n",
+    "\n",
+    "def create_market_context(scope: str) -> lm.MarketContext:\n",
+    "    return lm.MarketContext(\n",
+    "        market_rules=[\n",
+    "            lm.MarketDataKeyRule(\n",
+    "                key=\"Quote.ClientInternal.*\",\n",
+    "                data_scope=scope,\n",
+    "                supplier=market_supplier,\n",
+    "                quote_type=\"Price\",\n",
+    "                field=\"mid\",\n",
+    "                quote_interval=\"1D\",\n",
+    "            ),\n",
+    "            lm.MarketDataKeyRule(\n",
+    "                key=\"Fx.*.*\",\n",
+    "                data_scope=scope,\n",
+    "                supplier=market_supplier,\n",
+    "                quote_type=\"Rate\",\n",
+    "                field=\"mid\",\n",
+    "                quote_interval=\"5D\",\n",
+    "            ),\n",
+    "        ],\n",
+    "        options=lm.MarketOptions(\n",
+    "            default_supplier=market_supplier,\n",
+    "            default_scope=scope,\n",
+    "            default_instrument_code_type=\"ClientInternal\",\n",
+    "            attempt_to_infer_missing_fx=True,\n",
+    "        ),\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def create_pricing_context() -> lm.PricingContext:\n",
+    "    return lm.PricingContext(\n",
+    "        model_rules=[\n",
+    "            lm.VendorModelRule(\n",
+    "                supplier=market_supplier,\n",
+    "                model_name=\"SimpleStatic\",\n",
+    "                instrument_type=\"Equity\",\n",
+    "            ),\n",
+    "        ],\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def upsert_recipe(scope: str, code: str):\n",
+    "    market_context = create_market_context(scope)\n",
+    "    pricing_context = create_pricing_context()\n",
+    "    description = \"SimpleStatic pricing: \" + scope\n",
+    "\n",
+    "    pricing_recipe = lm.ConfigurationRecipe(\n",
+    "        scope=scope,\n",
+    "        code=code,\n",
+    "        description=description,\n",
+    "        market=market_context,\n",
+    "        pricing=pricing_context,\n",
+    "    )\n",
+    "\n",
+    "    recipe_request = lm.UpsertRecipeRequest(configuration_recipe=pricing_recipe)\n",
+    "    configuration_recipe_api.upsert_configuration_recipe(\n",
+    "        upsert_recipe_request=recipe_request\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we create helper functions for creating and upserting quotes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_fx_quote(\n",
+    "    fx_pair: str, effective_at: datetime, rate: float\n",
+    ") -> lm.UpsertQuoteRequest:\n",
+    "    return lm.UpsertQuoteRequest(\n",
+    "        quote_id=lm.QuoteId(\n",
+    "            quote_series_id=lm.QuoteSeriesId(\n",
+    "                provider=\"Lusid\",\n",
+    "                instrument_id=fx_pair,\n",
+    "                instrument_id_type=\"CurrencyPair\",\n",
+    "                quote_type=\"Rate\",\n",
+    "                field=\"mid\",\n",
+    "            ),\n",
+    "            effective_at=effective_at.isoformat(),\n",
+    "        ),\n",
+    "        metric_value=lm.MetricValue(value=rate, unit=\"rate\"),\n",
+    "        lineage=\"InternalSystem\",\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def upsert_quotes(scope: str, quotes: list[lm.UpsertQuoteRequest]):\n",
+    "    # Create request body object from list of quotes\n",
+    "    request_body = {f\"{i}\": x for i, x in zip(range(len(quotes)), quotes)}\n",
+    "    quote_response = quotes_api.upsert_quotes(scope=scope, request_body=request_body)\n",
+    "\n",
+    "    if quote_response.failed == {}:\n",
+    "        display(\n",
+    "            f\"Quotes successfully loaded into LUSID. {len(quote_response.values)} quotes upserted.\"\n",
+    "        )\n",
+    "    else:\n",
+    "        display(\n",
+    "            f\"Some failures occurred during quote upsert. Failed: {quote_response.failed}\"\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.4 Valuation\n",
+    "\n",
+    "We will value the portfolio on Friday 13 September 2024."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "valuation_date = datetime(2024, 9, 13, tzinfo=pytz.utc)  # Friday 13 September 2024"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now create a helper function to perform the valuation and return the results in a table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_daily_valuation(\n",
+    "    market_data_scope: str,\n",
+    "    date: datetime,\n",
+    "    recipe_code: str,\n",
+    "    report_ccy: str = pf_ccy,\n",
+    ") -> pd.DataFrame:\n",
+    "    metrics = [\n",
+    "        lm.AggregateSpec(key=\"Instrument/CoreData/Name\", op=\"Value\"),\n",
+    "        lm.AggregateSpec(key=\"Valuation/PV\", op=\"Value\"),\n",
+    "        lm.AggregateSpec(key=\"Valuation/PV/Ccy\", op=\"Value\"),\n",
+    "        lm.AggregateSpec(key=\"Valuation/PvInPortfolioCcy\", op=\"Value\"),\n",
+    "    ]\n",
+    "\n",
+    "    valuation_request = lm.ValuationRequest(\n",
+    "        recipe_id=lm.ResourceId(scope=market_data_scope, code=recipe_code),\n",
+    "        metrics=metrics,\n",
+    "        group_by=None,\n",
+    "        portfolio_entity_ids=[lm.PortfolioEntityId(scope=pf_scope, code=pf_code)],\n",
+    "        valuation_schedule=lm.ValuationSchedule(effective_at=date.isoformat()),\n",
+    "        report_currency=report_ccy,\n",
+    "    )\n",
+    "\n",
+    "    valuation_data = aggregation_api.get_valuation(\n",
+    "        valuation_request=valuation_request\n",
+    "    ).data\n",
+    "\n",
+    "    valuation_df = pd.DataFrame(valuation_data)\n",
+    "\n",
+    "    # Reorder columns:\n",
+    "    valuation_df = valuation_df.loc[\n",
+    "        :,\n",
+    "        [\n",
+    "            \"Instrument/CoreData/Name\",\n",
+    "            \"Valuation/PV\",\n",
+    "            \"Valuation/PV/Ccy\",\n",
+    "            \"Valuation/PvInPortfolioCcy\",\n",
+    "        ],\n",
+    "    ]\n",
+    "\n",
+    "    return valuation_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Examples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.1 Inverse quote\n",
+    "\n",
+    "When resolving the AUDCHF quotes, direct AUDCHF quotes will always take precedence over quotes inferred from an inverse rate CHFAUD or triangulated through a third currency, even if a quote could be inferred from more recent market data than the direct quote. In particular, if there is an AUDCHF quote effective the day before the valuation date (Thu 12 September 2024) and a CHFAUD quote effective on the valuation date (Fri 13 September 2024), then the AUDCHF quote will be used, rather than `1 / CHFAUD`.\n",
+    "\n",
+    "We will use the following FX rates:\n",
+    "\n",
+    "| FX Pair | Effective At   | Rate       |\n",
+    "| ------- | ------------   | ---------- |\n",
+    "| AUDCHF  | Thu 12/09/2024 | 0.5720     |\n",
+    "| CHFAUD  | Fri 13/09/2024 | 1 / 0.5671 |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "market_data_scope = \"fx-inference-inverse-quote-only\"\n",
+    "recipe_code = \"fx-inference-inverse-quote-only\"\n",
+    "upsert_recipe(scope=market_data_scope, code=recipe_code)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now upsert a quote of 100 AUD per unit of the equity, which will make the inferred FX rates easily readable from the valuation results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Quotes successfully loaded into LUSID. 1 quotes upserted.'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Upsert a quote for the equity. Assume the equity price has not changed for clarity.\n",
+    "equity_price = 100\n",
+    "\n",
+    "quote_equity = lm.UpsertQuoteRequest(\n",
+    "    quote_id=lm.QuoteId(\n",
+    "        quote_series_id=lm.QuoteSeriesId(\n",
+    "            provider=\"Lusid\",\n",
+    "            instrument_id=equity_id,\n",
+    "            instrument_id_type=\"ClientInternal\",\n",
+    "            quote_type=\"Price\",\n",
+    "            field=\"mid\",\n",
+    "        ),\n",
+    "        effective_at=valuation_date.isoformat(),\n",
+    "    ),\n",
+    "    metric_value=lm.MetricValue(value=equity_price, unit=equity_ccy),\n",
+    "    lineage=\"InternalSystem\",\n",
+    ")\n",
+    "\n",
+    "upsert_quotes(scope=market_data_scope, quotes=[quote_equity])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In order to value the portfolio in the portfolio currency, we need to convert the value of the holding from AUD to CHF by multiplying by the AUDCHF spot rate effective on the valuation date. First, we will only upsert a quote for CHFAUD, effective on the valuation date, so this rate will be inverted to infer an AUDCHF quote."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Quotes successfully loaded into LUSID. 1 quotes upserted.'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "spot_chf_aud = 1 / 0.5671\n",
+    "effective_at = valuation_date\n",
+    "quote_chf_aud = create_fx_quote(\n",
+    "    fx_pair=\"CHF/AUD\", effective_at=effective_at, rate=spot_chf_aud\n",
+    ")\n",
+    "\n",
+    "upsert_quotes(scope=market_data_scope, quotes=[quote_chf_aud])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With a holding of `10,000` units, purchased at `100 AUD` each, which are now still worth `100 AUD` each, the present value of the holding is `1,000,000 AUD`. Given a CHFAUD rate of `1 / 0.5671`, it is inverted to give a derived AUDCHF quote of `0.5671`. The PV of the holding in the portfolio currency CHF is given by multiplying by the AUDCHF spot rate, so is `0.5671 * 1,000,000 = 567,100.00 CHF`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Instrument/CoreData/Name</th>\n",
+       "      <th>Valuation/PV</th>\n",
+       "      <th>Valuation/PV/Ccy</th>\n",
+       "      <th>Valuation/PvInPortfolioCcy</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>AnAustralianCompany</td>\n",
+       "      <td>1,000,000.0000</td>\n",
+       "      <td>AUD</td>\n",
+       "      <td>567,100.0000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  Instrument/CoreData/Name   Valuation/PV Valuation/PV/Ccy  \\\n",
+       "0      AnAustralianCompany 1,000,000.0000              AUD   \n",
+       "\n",
+       "   Valuation/PvInPortfolioCcy  \n",
+       "0                567,100.0000  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "valuation_df = get_daily_valuation(\n",
+    "    market_data_scope=market_data_scope, date=valuation_date, recipe_code=recipe_code\n",
+    ")\n",
+    "\n",
+    "display(valuation_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now upsert the direct quote, effective on the day before the valuation date, along with the equity quote and the CHFAUD quote as above. We will see that the direct (but older) quote is used, rather than using the more recent inverse quote."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "market_data_scope = \"fx-inference-inverse-quote-vs-direct\"\n",
+    "recipe_code = \"fx-inference-inverse-quote-vs-direct\"\n",
+    "upsert_recipe(scope=market_data_scope, code=recipe_code)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Quotes successfully loaded into LUSID. 3 quotes upserted.'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "spot_aud_chf = 0.5720\n",
+    "effective_at = valuation_date + timedelta(days=-1)\n",
+    "quote_aud_chf = create_fx_quote(\n",
+    "    fx_pair=\"AUD/CHF\", effective_at=effective_at, rate=spot_aud_chf\n",
+    ")\n",
+    "\n",
+    "upsert_quotes(\n",
+    "    scope=market_data_scope, quotes=[quote_equity, quote_chf_aud, quote_aud_chf]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With a holding of `10,000` units of the equity, each worth `100 AUD`, the present value of the holding is `1,000,000 AUD`, which is then converted to the portfolio currency CHF by multiplying by an AUDCHF spot rate `S`. The spot rate taken from the direct quote `S=0.5720` gives the PV in portfolio currency as `1,000,000 * 0.5720 = 572,000.00 CHF`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Instrument/CoreData/Name</th>\n",
+       "      <th>Valuation/PV</th>\n",
+       "      <th>Valuation/PV/Ccy</th>\n",
+       "      <th>Valuation/PvInPortfolioCcy</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>AnAustralianCompany</td>\n",
+       "      <td>1,000,000.0000</td>\n",
+       "      <td>AUD</td>\n",
+       "      <td>572,000.0000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  Instrument/CoreData/Name   Valuation/PV Valuation/PV/Ccy  \\\n",
+       "0      AnAustralianCompany 1,000,000.0000              AUD   \n",
+       "\n",
+       "   Valuation/PvInPortfolioCcy  \n",
+       "0                572,000.0000  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "valuation_df = get_daily_valuation(\n",
+    "    market_data_scope=market_data_scope, date=valuation_date, recipe_code=recipe_code\n",
+    ")\n",
+    "\n",
+    "display(valuation_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.2 Triangulation through a base currency\n",
+    "\n",
+    "If there is no direct or inverse quote available, a quote may be inferred by triangulating through one of the base currencies, which are USD, GBP and EUR. For example, given quotes EURCHF and EURAUD, we can infer a quote `AUDCHF = EURCHF / EURAUD`. If there are quotes on multiple days for a given currency pair, the latest quote will always be taken. In this example, we may have EURCHF quotes for yesterday and today, but only a EURAUD quote for yesterday. The EURCHF quote from today will be combined with the EURAUD quote from yesterday.\n",
+    "\n",
+    "\n",
+    "We will use the following FX rates:\n",
+    "\n",
+    "| FX Pair | Effective At   | Rate       |\n",
+    "| ------- | ------------   | ---------- |\n",
+    "| EURCHF  | Thu 12/09/2024 | 0.9388     |\n",
+    "| EURAUD  | Thu 12/09/2024 | 1.6497     |\n",
+    "| EURCHF  | Fri 13/09/2024 | 0.9415     |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "market_data_scope = \"fx-inference-triangulate-through-eur\"\n",
+    "recipe_code = \"fx-inference-triangulate-through-eur\"\n",
+    "upsert_recipe(scope=market_data_scope, code=recipe_code)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Quotes successfully loaded into LUSID. 1 quotes upserted.'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "equity_price = 100\n",
+    "quote_equity = lm.UpsertQuoteRequest(\n",
+    "    quote_id=lm.QuoteId(\n",
+    "        quote_series_id=lm.QuoteSeriesId(\n",
+    "            provider=\"Lusid\",\n",
+    "            instrument_id=equity_id,\n",
+    "            instrument_id_type=\"ClientInternal\",\n",
+    "            quote_type=\"Price\",\n",
+    "            field=\"mid\",\n",
+    "        ),\n",
+    "        effective_at=valuation_date.isoformat(),\n",
+    "    ),\n",
+    "    metric_value=lm.MetricValue(value=equity_price, unit=equity_ccy),\n",
+    "    lineage=\"InternalSystem\",\n",
+    ")\n",
+    "\n",
+    "upsert_quotes(scope=market_data_scope, quotes=[quote_equity])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Quotes successfully loaded into LUSID. 3 quotes upserted.'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "yesterday = valuation_date + timedelta(days=-1)\n",
+    "\n",
+    "# EURCHF Yesterday\n",
+    "spot_eur_chf_yesterday = 0.9388\n",
+    "quote_eur_chf_yesterday = create_fx_quote(\n",
+    "    fx_pair=\"EUR/CHF\", effective_at=yesterday, rate=spot_eur_chf_yesterday\n",
+    ")\n",
+    "\n",
+    "# EURCHF Today\n",
+    "spot_eur_chf_today = 0.9415\n",
+    "quote_eur_chf_today = create_fx_quote(\n",
+    "    fx_pair=\"EUR/CHF\", effective_at=valuation_date, rate=spot_eur_chf_today\n",
+    ")\n",
+    "\n",
+    "# EURAUD Yesterday\n",
+    "spot_eur_aud_yesterday = 1.6497\n",
+    "quote_eur_aud_yesterday = create_fx_quote(\n",
+    "    fx_pair=\"EUR/AUD\", effective_at=yesterday, rate=spot_eur_aud_yesterday\n",
+    ")\n",
+    "\n",
+    "upsert_quotes(\n",
+    "    scope=market_data_scope,\n",
+    "    quotes=[quote_eur_chf_yesterday, quote_eur_chf_today, quote_eur_aud_yesterday],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With a holding of `10,000` units, worth `100 AUD` each, the present value of the holding is `1,000,000 AUD`. Combining the latest EURCHF and EURAUD quotes gives an inferred quote `AUDCHF = EURCHF / EURAUD = 0.9415 / 1.6497 = 0.57070983`, so based on this inferred rate, the PV of the holding in CHF is `0.57070983 * 1,000,000 = 570,709.83 CHF`. If instead the two rates effective the date before valuation were combined, we would end up with a PV of `0.9388 / 1.6497 * 1,000,000 = 569,073.16 CHF`, which is consistent with directly quoted AUDCHF rates for 12/09/23. On the other hand, the inferred AUDCHF rate composed of rates on different dates of `AUDCHF=0.57070983` is different from the AUDCHF quotes both on 12/09/24 (0.5690) and 13/09/24 (0.5716)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Instrument/CoreData/Name</th>\n",
+       "      <th>Valuation/PV</th>\n",
+       "      <th>Valuation/PV/Ccy</th>\n",
+       "      <th>Valuation/PvInPortfolioCcy</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>AnAustralianCompany</td>\n",
+       "      <td>1,000,000.0000</td>\n",
+       "      <td>AUD</td>\n",
+       "      <td>570,709.8260</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  Instrument/CoreData/Name   Valuation/PV Valuation/PV/Ccy  \\\n",
+       "0      AnAustralianCompany 1,000,000.0000              AUD   \n",
+       "\n",
+       "   Valuation/PvInPortfolioCcy  \n",
+       "0                570,709.8260  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "valuation_df = get_daily_valuation(\n",
+    "    market_data_scope=market_data_scope, date=valuation_date, recipe_code=recipe_code\n",
+    ")\n",
+    "\n",
+    "display(valuation_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, we show that rates inferred through one of the base currencies have lower precedence than inverse and direct rates. We have already established that a direct rate takes precedence over an inverse quote, so it remains to show that an inverse quote takes precedence over a quote triangulated through a base currency. Again, the age of the quote is not taken into consideration other than the constraints given by the quote interval."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "market_data_scope = \"fx-inference-inverse-vs-triangulated\"\n",
+    "recipe_code = \"fx-inference-inverse-vs-triangulated\"\n",
+    "upsert_recipe(scope=market_data_scope, code=recipe_code)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First upsert the equity quote and the three FX quotes above for EURCHF and EURAUD."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Quotes successfully loaded into LUSID. 4 quotes upserted.'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "upsert_quotes(\n",
+    "    scope=market_data_scope,\n",
+    "    quotes=[\n",
+    "        quote_equity,\n",
+    "        quote_eur_chf_yesterday,\n",
+    "        quote_eur_chf_today,\n",
+    "        quote_eur_aud_yesterday,\n",
+    "    ],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will now upsert a CHFAUD quote effective on Wed 11/09/24 and demonstrate that this inverse rate is used in the valuation instead of the rate inferred by triangulating through EUR."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Quotes successfully loaded into LUSID. 1 quotes upserted.'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "spot_chf_aud = 1 / 0.5671\n",
+    "effective_at = valuation_date + timedelta(days=-2)\n",
+    "quote_chf_aud = create_fx_quote(\n",
+    "    fx_pair=\"CHF/AUD\", effective_at=effective_at, rate=spot_chf_aud\n",
+    ")\n",
+    "\n",
+    "upsert_quotes(scope=market_data_scope, quotes=[quote_chf_aud])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The effective AUDCHF rate based on the inverse quote for `CHFAUD = 1 / 0.5671` is `AUDCHF = 0.5671`, while the effective rate based on triangulating through EUR using the latest quotes is `AUDCHF = EURCHF / EURAUD = 0.9415 / 1.6497 = 0.57070983`. It is evident from the valuation below that the spot rate `AUDCHF = 0.5671` derived from CHFAUD quote is used rather than triangulating through EUR."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Instrument/CoreData/Name</th>\n",
+       "      <th>Valuation/PV</th>\n",
+       "      <th>Valuation/PV/Ccy</th>\n",
+       "      <th>Valuation/PvInPortfolioCcy</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>AnAustralianCompany</td>\n",
+       "      <td>1,000,000.0000</td>\n",
+       "      <td>AUD</td>\n",
+       "      <td>567,100.0000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  Instrument/CoreData/Name   Valuation/PV Valuation/PV/Ccy  \\\n",
+       "0      AnAustralianCompany 1,000,000.0000              AUD   \n",
+       "\n",
+       "   Valuation/PvInPortfolioCcy  \n",
+       "0                567,100.0000  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "valuation_df = get_daily_valuation(\n",
+    "    market_data_scope=market_data_scope, date=valuation_date, recipe_code=recipe_code\n",
+    ")\n",
+    "\n",
+    "display(valuation_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.3 Currency pair quoting conventions\n",
+    "\n",
+    "In the example above of triangulating through EUR, all currency pairs were quoted with EUR as the first currency in the pair, however it is not necessary for the middle currency in the triangulation to be used as the base currency in the quotes. For example, in resolving the AUDCHF dependency and triangulating through USD, we can upsert quotes for USDCHF and AUDUSD in line with market quoting conventions, rather than being forced to create a USDAUD quote from available market data. The `Manifest` can be inspected to see which FX rates were used in a valuation.\n",
+    "\n",
+    "In fact, any one of the following pairs of quotes is sufficient to infer an AUDCHF spot rate in LUSID:\n",
+    "| Quote Pair     | Expression for AUDCHF |\n",
+    "| -------------- | --------------------- |\n",
+    "| AUDUSD, CHFUSD | AUDUSD / CHFUSD       |\n",
+    "| AUDUSD, USDCHF | AUDUSD * USDCHF       |\n",
+    "| USDAUD, CHFUSD | 1 / (CHFUSD * USDAUD) |\n",
+    "| USDAUD, USDCHF | USDCHF / USDAUD       |\n",
+    "\n",
+    "\n",
+    "Suppose we have given quotes for AUDUSD, CHFUSD and USDCHF, then the table above does not make it clear which two quotes will be used to infer the AUDCHF quote.\n",
+    "\n",
+    "Let `S` denote the set of quotes in the quote store. It is assumed `S` is a subset of `{ AUDUSD, USDAUD, USDCHF, CHFUSD }` since other quotes are irrelevant to this triangulation problem. `S` must contain at least one of `AUDUSD` or `USDAUD` and at least one of `USDCHF` and `CHFUSD`, otherwise an `AUDCHF` quote cannot be inferred. There are 9 subsets satisfying these conditions. There is a (partial) order of preference for which set of quotes is used to form a quote, given by the conditions below:\n",
+    "\n",
+    "1. If `S` contains `AUDUSD` and `CHFUSD`, then `AUDCHF = AUDUSD / CHFUSD`.\n",
+    "2. If `S` contains `AUDUSD` and `USDCHF` but does not contain `CHFUSD`, then `AUDCHF = AUDUSD * USDCHF`\n",
+    "3. If `S` contains `USDAUD` and `CHFUSD` but does not contain `AUDUSD`, then `AUDCHF = 1 / (CHFUSD * USDAUD)`\n",
+    "4. If `S` contains only `USDAUD` and `USDCHF`, then `AUDCHF = USDCHF / USDAUD`\n",
+    "\n",
+    "\n",
+    "We will use the following FX rates:\n",
+    "\n",
+    "| FX Pair | Effective At   | Rate       |\n",
+    "| ------- | ------------   | ---------- |\n",
+    "| USDCHF  | Fri 13/09/2024 | 0.8499     |\n",
+    "| AUDUSD  | Fri 13/09/2024 | 0.6727     |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "market_data_scope = \"fx-inference-triangulate-conventional\"\n",
+    "recipe_code = \"fx-inference-triangulate-conventional\"\n",
+    "upsert_recipe(scope=market_data_scope, code=recipe_code)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Quotes successfully loaded into LUSID. 1 quotes upserted.'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "equity_price = 100\n",
+    "quote_equity = lm.UpsertQuoteRequest(\n",
+    "    quote_id=lm.QuoteId(\n",
+    "        quote_series_id=lm.QuoteSeriesId(\n",
+    "            provider=\"Lusid\",\n",
+    "            instrument_id=equity_id,\n",
+    "            instrument_id_type=\"ClientInternal\",\n",
+    "            quote_type=\"Price\",\n",
+    "            field=\"mid\",\n",
+    "        ),\n",
+    "        effective_at=valuation_date.isoformat(),\n",
+    "    ),\n",
+    "    metric_value=lm.MetricValue(value=equity_price, unit=equity_ccy),\n",
+    "    lineage=\"InternalSystem\",\n",
+    ")\n",
+    "\n",
+    "upsert_quotes(scope=market_data_scope, quotes=[quote_equity])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Quotes successfully loaded into LUSID. 2 quotes upserted.'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "spot_usd_chf = 0.8499\n",
+    "quote_usd_chf = create_fx_quote(\n",
+    "    fx_pair=\"USD/CHF\", effective_at=valuation_date, rate=spot_usd_chf\n",
+    ")\n",
+    "\n",
+    "spot_aud_usd = 0.6727\n",
+    "quote_aud_usd = create_fx_quote(\n",
+    "    fx_pair=\"AUD/USD\", effective_at=valuation_date, rate=spot_aud_usd\n",
+    ")\n",
+    "\n",
+    "upsert_quotes(scope=market_data_scope, quotes=[quote_usd_chf, quote_aud_usd])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Given the above quotes `USDCHF = 0.8499` and `AUDUSD = 0.6727`, we can infer a quote `AUDCHF = AUDUSD * USDCHF = 0.6727 * 0.8499 = 0.57172773`. With a holding in AnAustralianCompany worth 1,000,000 AUD, this gives the valuation below by converting at spot: `1,000,000 * 0.57172773 = 571,727.73 CHF`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Instrument/CoreData/Name</th>\n",
+       "      <th>Valuation/PV</th>\n",
+       "      <th>Valuation/PV/Ccy</th>\n",
+       "      <th>Valuation/PvInPortfolioCcy</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>AnAustralianCompany</td>\n",
+       "      <td>1,000,000.0000</td>\n",
+       "      <td>AUD</td>\n",
+       "      <td>571,727.7300</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  Instrument/CoreData/Name   Valuation/PV Valuation/PV/Ccy  \\\n",
+       "0      AnAustralianCompany 1,000,000.0000              AUD   \n",
+       "\n",
+       "   Valuation/PvInPortfolioCcy  \n",
+       "0                571,727.7300  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "valuation_df = get_daily_valuation(\n",
+    "    market_data_scope=market_data_scope, date=valuation_date, recipe_code=recipe_code\n",
+    ")\n",
+    "\n",
+    "display(valuation_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.4 Multi-step triangulation\n",
+    "\n",
+    "LUSID does not support triangulation in multiple steps - in absence of a direct or inverse rate, if a rate cannot be inferred by triangulating through a single currency (USD, GBP or EUR), a market data resolution failure will be returned. For this reason, it is recommended to upsert all FX rates against one of the base currencies used in triangulation; which are USD, GBP and EUR. For instance, given quotes for EURXXX for each relevant currency XXX, we can infer all cross rates as `XXXYYY = XXXEUR * EURYYY = EURYYY / EURXXX`.\n",
+    "\n",
+    "For example, to price the equity above in the portfolio currency, we require an AUDCHF spot rate. Suppose we are given quotes EURAUD, EURUSD and USDCHF, then in principal we can infer a quote `AUDCHF = EURCHF / EURAUD = (EURUSD * USDCHF) / EURAUD`, but LUSID will not attempt to resolve this quote in two steps. Instead, we need to ensure a full set of quotes is given against one of these base currencies - for instance, if we also upserted a quote `EURCHF = EURUSD * USDCHF`, then LUSID would triangulate through EUR and produce a valuation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.5 Minor currencies\n",
+    "\n",
+    "In LUSID, we maintain a list of the ISO 4217 minor currencies together with the ratio of the major to minor currency - for instance `1 GBP = 100 GBp` and `1 AUD = 100 AUc`. Any minor currency dependencies are transformed to dependencies on the major currency, so we can price an instrument in the minor currency and only need to deal with FX rates involving major currencies (e.g. Not USDGBp)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "market_data_scope = \"fx-inference-minor-ccys\"\n",
+    "recipe_code = \"fx-inference-minor-ccys\"\n",
+    "upsert_recipe(scope=market_data_scope, code=recipe_code)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Quotes successfully loaded into LUSID. 1 quotes upserted.'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Upsert a quote for the equity: 20 AUD = 2000 AUc\n",
+    "aus_cents = \"AUc\"\n",
+    "equity_price = 2000\n",
+    "\n",
+    "quote_equity = lm.UpsertQuoteRequest(\n",
+    "    quote_id=lm.QuoteId(\n",
+    "        quote_series_id=lm.QuoteSeriesId(\n",
+    "            provider=\"Lusid\",\n",
+    "            instrument_id=equity_id,\n",
+    "            instrument_id_type=\"ClientInternal\",\n",
+    "            quote_type=\"Price\",\n",
+    "            field=\"mid\",\n",
+    "        ),\n",
+    "        effective_at=valuation_date.isoformat(),\n",
+    "    ),\n",
+    "    metric_value=lm.MetricValue(value=equity_price, unit=aus_cents),\n",
+    "    lineage=\"InternalSystem\",\n",
+    ")\n",
+    "\n",
+    "upsert_quotes(scope=market_data_scope, quotes=[quote_equity])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this example, the price of the AnAustralianCompany is quoted in AUc, so to calculate the PV of the holding in CHF, we need an AUcCHF spot rate. We will now upsert an AUDCHF quote and allow the AUcCHF quote to be inferred using the minor to major currency scale factor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Quotes successfully loaded into LUSID. 1 quotes upserted.'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "spot_aud_chf = 0.5671\n",
+    "quote_aud_chf = create_fx_quote(\n",
+    "    fx_pair=\"AUD/CHF\", effective_at=valuation_date, rate=spot_aud_chf\n",
+    ")\n",
+    "\n",
+    "upsert_quotes(scope=market_data_scope, quotes=[quote_aud_chf])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Given the spot rate `AUDCHF = 0.5671`, we calculate `AUcCHF = AUDCHF / 100 = 0.005671`. The holding of 10,000 units in AnAustralianCompany, each worth 2000 AUc, is worth 20,000,000 AUc, which is converted to CHF at the spot `AUcCHF` rate: `PvInPortfolioCcy = 20,000,000 * 0.005671 = 113420.0`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Instrument/CoreData/Name</th>\n",
+       "      <th>Valuation/PV</th>\n",
+       "      <th>Valuation/PV/Ccy</th>\n",
+       "      <th>Valuation/PvInPortfolioCcy</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>AnAustralianCompany</td>\n",
+       "      <td>200,000.0000</td>\n",
+       "      <td>AUD</td>\n",
+       "      <td>113,420.0000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  Instrument/CoreData/Name  Valuation/PV Valuation/PV/Ccy  \\\n",
+       "0      AnAustralianCompany  200,000.0000              AUD   \n",
+       "\n",
+       "   Valuation/PvInPortfolioCcy  \n",
+       "0                113,420.0000  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "valuation_df = get_daily_valuation(\n",
+    "    market_data_scope=market_data_scope, date=valuation_date, recipe_code=recipe_code\n",
+    ")\n",
+    "\n",
+    "display(valuation_df)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
…mula.

# Pull Request Checklist

- [x] Changes follow the [style guide](https://github.com/finbourne/sample-notebooks/blob/master/docs/FINBOURNE%20notebook%20style%20guide.ipynb)
- [?] Tests pass
- [x] Raised the PR against the `develop` branch
- [x] Notebook outputs do not contain any priviledged data

# Description of the PR

Public version of the internal FX inference notebook from https://gitlab.com/finbourne/analytics/analytics-notebooks/-/blob/master/Demos/FxInference/fx-inference-triangulation.ipynb?ref_type=heads.

The difference between _this_ and the internal version is:
- Remove sentences (x3) in the FX inference notebook saying that cross FX rates taken from quotes on different days may never exist (this ought to be obvious but might make us look silly)

- Clarify that spot FX rates are used for CTVoM for FX forwards

- Add a sentence explaining that the two expressions for linear interpolation are the same, just rearranged.
