### PR TITLE
ANA-4464: instrument event recipe support

### DIFF
--- a/examples/use-cases/instruments/Forward Rate Agreement.ipynb
+++ b/examples/use-cases/instruments/Forward Rate Agreement.ipynb
@@ -927,6 +927,30 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For environments that have instrument events configured, we also need to set the instrument events recipe on the portfolio.\n",
+    "patch_document = [\n",
+    "    {\n",
+    "        \"value\": {\n",
+    "            \"scope\": market_data_scope,\n",
+    "            \"code\": recipe_code\n",
+    "        },\n",
+    "        \"path\": \"/instrumentEventConfiguration/recipeId\",\n",
+    "        \"op\": \"add\"\n",
+    "    }\n",
+    "]\n",
+    "\n",
+    "patch_response = transaction_portfolios_api.patch_portfolio_details(\n",
+    "    scope=scope,\n",
+    "    code=portfolio_code,\n",
+    "    operation=patch_document)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/examples/use-cases/instruments/Interest Rate Swap.ipynb
+++ b/examples/use-cases/instruments/Interest Rate Swap.ipynb
@@ -2106,6 +2106,30 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For environments that have instrument events configured, we also need to set the instrument events recipe on the portfolio.\n",
+    "patch_document = [\n",
+    "    {\n",
+    "        \"value\": {\n",
+    "            \"scope\": market_data_scope,\n",
+    "            \"code\": ctvm_recipe_code\n",
+    "        },\n",
+    "        \"path\": \"/instrumentEventConfiguration/recipeId\",\n",
+    "        \"op\": \"add\"\n",
+    "    }\n",
+    "]\n",
+    "\n",
+    "patch_response = transaction_portfolios_api.patch_portfolio_details(\n",
+    "    scope=portfolio_scope,\n",
+    "    code=portfolio_code,\n",
+    "    operation=patch_document)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/examples/use-cases/instruments/Mortgage Backed Securities.ipynb
+++ b/examples/use-cases/instruments/Mortgage Backed Securities.ipynb
@@ -681,6 +681,35 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For environments that have instrument events configured, we also need to set the instrument events recipe on the portfolios.\n",
+    "patch_document = [\n",
+    "    {\n",
+    "        \"value\": {\n",
+    "            \"scope\": scope,\n",
+    "            \"code\": recipe_code\n",
+    "        },\n",
+    "        \"path\": \"/instrumentEventConfiguration/recipeId\",\n",
+    "        \"op\": \"add\"\n",
+    "    }\n",
+    "]\n",
+    "\n",
+    "patch_response = transaction_portfolios_api.patch_portfolio_details(\n",
+    "    scope=scope,\n",
+    "    code=portfolio_1_code,\n",
+    "    operation=patch_document)\n",
+    "\n",
+    "patch_response = transaction_portfolios_api.patch_portfolio_details(\n",
+    "    scope=scope,\n",
+    "    code=portfolio_2_code,\n",
+    "    operation=patch_document)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
# Pull Request Checklist

- [x] Changes follow the [style guide](https://github.com/finbourne/sample-notebooks/blob/master/docs/FINBOURNE%20notebook%20style%20guide.ipynb)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch
- [x] Notebook outputs do not contain any priviledged data

# Description of the PR

Modify MBS, IRS, FRA notebooks so that they correctly configure an instrument events recipe. This is required for an upcoming breaking change in which we stop falling back to the valuation recipe.

Tested against local LUSID - notebooks work before/after the breaking change, and with/without instrument events enabled.
